### PR TITLE
Add transport coverage and training notes

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{925D9A38-5241-4520-8D81-A886AAAC42B4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>AdvanceWarsServer</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -75,14 +75,16 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
+    <IncludePath>D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\include;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\include\torch\csrc\api\include;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
+    <LibraryPath>D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
+    <IncludePath>D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\torch\csrc\api\include;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
+    <LibraryPath>D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\bin;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -114,7 +116,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rpcrt4.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\caffe2_nvrtc.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\c10.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\c10_cuda.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\kineto.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\torch.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\torch_cpu.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\torch_cuda.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cublas.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cudart.lib;C:\Program Files\NVIDIA\CUDNN\v9.7\lib\11.8\x64\cudnn.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cufft.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\curand.lib;C:\Program Files\NVIDIA Corporation\NvToolsExt\lib\x64\nvToolsExt64_1.lib;-INCLUDE:?warp_size@cuda@at@@YAHXZ;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -148,14 +150,14 @@
       <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\torch\csrc\api\include;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rpcrt4.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\caffe2_nvrtc.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\c10.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\c10_cuda.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\kineto.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\torch.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\torch_cpu.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\torch_cuda.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cublas.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cudart.lib;C:\Program Files\NVIDIA\CUDNN\v9.7\lib\11.8\x64\cudnn.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cufft.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\curand.lib;C:\Program Files\NVIDIA Corporation\NvToolsExt\lib\x64\nvToolsExt64_1.lib;-INCLUDE:?warp_size@cuda@at@@YAHXZ;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -168,6 +170,7 @@
     <ClCompile Include="src\MapParser.cpp" />
     <ClCompile Include="src\MapTile.cpp" />
     <ClCompile Include="src\Player.cpp" />
+    <ClCompile Include="src\Tensor.cpp" />
     <ClCompile Include="src\TerrainInfo.cpp" />
     <ClCompile Include="src\Unit.cpp" />
     <ClCompile Include="src\UnitInfo.cpp" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="src\win32\Platform.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Tensor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\Map.h">

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -203,7 +203,7 @@ public:
 			to_json(jstate, *this);
 			std::cout << "Chose an invalid action:" << jaction.dump() << "\n" << jstate.dump() << std::endl;
 		}
-		//actedGameState.CheckPlayerResigns();
+		actedGameState.CheckPlayerResigns();
 		return actedGameState;
 	}
 
@@ -223,9 +223,13 @@ public:
 		return m_winningPlayer;
 	}
 
+	int evaluateCurrentPlayer() const {
+		return 0;
+	}
+
 	int getEvaluationForCurrentPlayer() const {
 		if (!m_fGameOver || m_winningPlayer == 2) {
-			return 0;
+			return evaluateCurrentPlayer();
 		}
 
 		int player = m_isFirstPlayerTurn ? 0 : 1;
@@ -285,6 +289,7 @@ private:
 	Result DoMoveLoadAction(int x, int y, const Action& action);
 	Result DoCaptureAction(int x, int y, const Action& action);
 	Result DoUnloadAction(int x, int y, const Action& action);
+	Result DoRepairAction(int x, int y, const Action& action);
 	Result DoCOPowerAction();
 	Result DoSCOPowerAction();
 	Result ResupplyPlayersUnits(const Player* player);

--- a/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
+++ b/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
@@ -59,7 +59,7 @@ public:
 	std::shared_ptr<MCTSNode<StateType, ActionType>> run(std::shared_ptr<MCTSNode<StateType, ActionType>> root, int iterations) {
 		expand(root);
 		for (int i = 0; i < iterations; ++i) {
-			if ((i + 1) % 500 == 0) {
+			if ((i + 1) % 50 == 0) {
 				std::cout << "simmed iterations: " << i << std::endl;
 			}
 

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -7,11 +7,10 @@
 #include "MonteCarloTreeSearch.h"
 #include "SubsystemTest.h"
 #include "Platform.h"
+#include <torch/torch.h>
 
 int main(int argc, char* argv[]) noexcept {
 	try {
-
-
 		if (argc < 2) { // Check if the user provided exactly one argument
 			std::cerr << "Usage: " << argv[0] << " <option>\n";
 			std::cerr << "Options:\n";
@@ -22,8 +21,74 @@ int main(int argc, char* argv[]) noexcept {
 		}
 
 		std::string argument = argv[1];
+		if (argument == "-torchlib") {
 
-		if (argument == "-sim-random-move-game") {
+			std::cout << "CUDA support: " << (torch::cuda::is_available() ? "true" : "false") << std::endl;
+			std::cout << "CUDA devices: " << (torch::cuda::device_count()) << std::endl;
+
+			torch::Tensor tensor = torch::rand({ 2, 3 });
+			std::cout << tensor << std::endl;
+
+			struct Net : torch::nn::Module {
+				Net()
+					: conv1(torch::nn::Conv2dOptions(1, 32, 5)),
+					conv2(torch::nn::Conv2dOptions(32, 64, 5)),
+					fc1(1024, 128),
+					fc2(128, 10) {
+					register_module("conv1", conv1);
+					register_module("conv2", conv2);
+					register_module("fc1", fc1);
+					register_module("fc2", fc2);
+				}
+
+				torch::Tensor forward(torch::Tensor x) {
+					x = torch::relu(conv1->forward(x));
+					x = torch::max_pool2d(x, 2);
+					x = torch::relu(conv2->forward(x));
+					x = torch::max_pool2d(x, 2);
+					x = x.view({ x.size(0), -1 });
+					x = torch::relu(fc1->forward(x));
+					x = fc2->forward(x);
+					return torch::log_softmax(x, 1);
+				}
+
+				torch::nn::Conv2d conv1, conv2;
+				torch::nn::Linear fc1, fc2;
+			};
+			torch::Device device(torch::cuda::is_available() ? torch::kCUDA : torch::kCPU);
+			std::cout << "Using device: " << (device.is_cuda() ? "CUDA" : "CPU") << "\n";
+
+			// Load MNIST dataset
+			auto train_dataset = torch::data::datasets::MNIST("D:/MNIST/MNIST/raw").map(
+				torch::data::transforms::Stack<>());
+			auto train_loader = torch::data::make_data_loader(std::move(train_dataset),
+				torch::data::DataLoaderOptions().batch_size(64));
+
+			// Initialize model, optimizer, and loss function
+			Net model;
+			model.to(device);
+			torch::optim::SGD optimizer(model.parameters(), torch::optim::SGDOptions(0.01).momentum(0.9));
+
+			// Training loop
+			for (size_t epoch = 1; epoch <= 5; ++epoch) {
+				size_t batch_idx = 0;
+				for (auto& batch : *train_loader) {
+					model.train();
+					auto data = batch.data.to(device), targets = batch.target.to(device);
+					optimizer.zero_grad();
+					auto output = model.forward(data);
+					auto loss = torch::nll_loss(output, targets);
+					loss.backward();
+					optimizer.step();
+
+					if (batch_idx++ % 100 == 0) {
+						std::cout << "Train Epoch: " << epoch << " [" << batch_idx * 64
+							<< "/60000] Loss: " << loss.item<float>() << "\n";
+					}
+				}
+			}
+		}
+		else if (argument == "-sim-random-move-game") {
 			// Determine the number of available CPU cores.
 			unsigned int maxConcurrentGames = std::thread::hardware_concurrency();
 			if (maxConcurrentGames == 0) {
@@ -35,7 +100,7 @@ int main(int argc, char* argv[]) noexcept {
 
 			std::atomic<int> simulationMoves = 0;
 			auto runGameSimulation = [&]() {
-				std::fstream filestream("./res/AWBW/MapSources/test.json", std::ios::in);
+				std::fstream filestream("./res/AWBW/MapSources/lefty.json", std::ios::in);
 				if (filestream.fail() || filestream.eof())
 				{
 					return;
@@ -66,6 +131,7 @@ int main(int argc, char* argv[]) noexcept {
 					++totalActions;
 					outFile << "Action: " << jaction.dump() << std::endl;
 					rootState.DoAction(vecActions[action]);
+					rootState.CheckPlayerResigns();
 					//GameState::to_json(jsonState, rootState);
 					//outFile << "GameState: " << std::endl << jsonState.dump() << std::endl;
 					if (totalActions % 1000 == 0) {
@@ -85,7 +151,7 @@ int main(int argc, char* argv[]) noexcept {
 				time_point endTime = std::chrono::steady_clock::now();
 				std::clog << "Game took to simulate: " << std::chrono::duration<double, std::milli>(endTime - startTime).count() << "\n";
 				std::cout << "TotalActions: " << totalActions << std::endl;
-			};
+				};
 
 			// This vector will hold the futures for the running games.
 			std::vector<std::future<void>> futures;
@@ -113,16 +179,16 @@ int main(int argc, char* argv[]) noexcept {
 			}
 
 			// Wait for any remaining games to finish.
-			for (auto &fut : futures) {
+			for (auto& fut : futures) {
 				fut.wait();
-			}			
+			}
 
 			time_point endTimeTotalSim = std::chrono::steady_clock::now();
 			std::clog << "\n\n\n\nTook to simulate: " << std::chrono::duration<double, std::milli>(endTimeTotalSim - startTimeTotalSim).count() << std::endl;
 			std::cout << "TotalActions: " << simulationMoves << std::endl;
 		}
 		else if (argument == "-sim-mcts-game") {
-			std::fstream filestream("./res/AWBW/MapSources/MCTS.json", std::ios::in);
+			std::fstream filestream("./res/AWBW/MapSources/Lefty.json", std::ios::in);
 			if (filestream.fail() || filestream.eof())
 			{
 				return -1;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -85,6 +85,16 @@ Result GameState::BeginTurn() noexcept {
 					ResupplyApcUnits(x, y);
 				}
 
+				if ((pUnit->m_properties.m_type == UnitProperties::Type::Carrier ||
+					pUnit->m_properties.m_type == UnitProperties::Type::Crusier) &&
+					pUnit->m_owner == &GetCurrentPlayer()) {
+					for (int i = 0; i < pUnit->CLoadedUnits(); ++i) {
+						Unit* pLoadedUnit = pUnit->GetLoadedUnit(i);
+						pLoadedUnit->m_properties.m_fuel = GetUnitInfo(pLoadedUnit->m_properties.m_type).m_fuel;
+						pLoadedUnit->m_properties.m_ammo = GetUnitInfo(pLoadedUnit->m_properties.m_type).m_ammo;
+					}
+				}
+
 				if (MapTile::IsProperty(terrain.m_type) && pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[player] && terrain.m_type != Terrain::Type::ComTower && terrain.m_type != Terrain::Type::Lab && pUnit->m_owner == &m_arrPlayers[player]) {
 					Unit* pUnit = pTile->TryGetUnit();
 					pUnit->m_properties.m_fuel = GetUnitInfo(pUnit->m_properties.m_type).m_fuel;
@@ -481,20 +491,12 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 					if (pUnloadDestination->m_spUnit == nullptr && pUnloadDestination->GetTerrain().m_movementCostMap.find(pUnloadUnit->m_properties.m_movementType)->second > 0) {
 						vecActions.emplace_back(Action::Type::Unload, x, y, Action::Direction::North, i);
 					}
-
-					if (pUnit->m_properties.m_type == UnitProperties::Type::BlackBoat && pUnloadDestination->m_spUnit != nullptr && pUnloadDestination->m_spUnit->m_owner == &GetCurrentPlayer()) {
-						vecActions.emplace_back(Action::Type::Repair, x, y, Action::Direction::North);
-					}
 				}
 				// east
 				result = m_spmap->TryGetTile(x + 1, y, &pUnloadDestination);
 				if (result == Result::Succeeded) {
 					if (pUnloadDestination->m_spUnit == nullptr && pUnloadDestination->GetTerrain().m_movementCostMap.find(pUnloadUnit->m_properties.m_movementType)->second > 0) {
 						vecActions.emplace_back(Action::Type::Unload, x, y, Action::Direction::East, i);
-					}
-
-					if (pUnit->m_properties.m_type == UnitProperties::Type::BlackBoat && pUnloadDestination->m_spUnit != nullptr && pUnloadDestination->m_spUnit->m_owner == &GetCurrentPlayer()) {
-						vecActions.emplace_back(Action::Type::Repair, x, y, Action::Direction::East);
 					}
 				}
 				// south 
@@ -503,10 +505,6 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 					if (pUnloadDestination->m_spUnit == nullptr && pUnloadDestination->GetTerrain().m_movementCostMap.find(pUnloadUnit->m_properties.m_movementType)->second > 0) {
 						vecActions.emplace_back(Action::Type::Unload, x, y, Action::Direction::South, i);
 					}
-
-					if (pUnit->m_properties.m_type == UnitProperties::Type::BlackBoat && pUnloadDestination->m_spUnit != nullptr && pUnloadDestination->m_spUnit->m_owner == &GetCurrentPlayer()) {
-						vecActions.emplace_back(Action::Type::Repair, x, y, Action::Direction::South);
-					}
 				}
 				// west 
 				result = m_spmap->TryGetTile(x - 1, y, &pUnloadDestination);
@@ -514,12 +512,24 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 					if (pUnloadDestination->m_spUnit == nullptr && pUnloadDestination->GetTerrain().m_movementCostMap.find(pUnloadUnit->m_properties.m_movementType)->second > 0) {
 						vecActions.emplace_back(Action::Type::Unload, x, y, Action::Direction::West, i);
 					}
-
-					if (pUnit->m_properties.m_type == UnitProperties::Type::BlackBoat && pUnloadDestination->m_spUnit != nullptr && pUnloadDestination->m_spUnit->m_owner == &GetCurrentPlayer()) {
-						vecActions.emplace_back(Action::Type::Repair, x, y, Action::Direction::West);
-					}
 				}
 			}
+		}
+
+		if (pUnit->m_properties.m_type == UnitProperties::Type::BlackBoat && !pUnit->m_moved) {
+			auto addRepairAction = [&](int xRepair, int yRepair, Action::Direction direction) {
+				const MapTile* pRepairDestination = nullptr;
+				if (m_spmap->TryGetTile(xRepair, yRepair, &pRepairDestination) == Result::Succeeded &&
+					pRepairDestination->m_spUnit != nullptr &&
+					pRepairDestination->m_spUnit->m_owner == &GetCurrentPlayer()) {
+					vecActions.emplace_back(Action::Type::Repair, x, y, direction);
+				}
+			};
+
+			addRepairAction(x, y - 1, Action::Direction::North);
+			addRepairAction(x + 1, y, Action::Direction::East);
+			addRepairAction(x, y + 1, Action::Direction::South);
+			addRepairAction(x - 1, y, Action::Direction::West);
 		}
 
 		if (pUnit->m_moved) {
@@ -770,10 +780,65 @@ Result GameState::DoAction(const Action& action) noexcept {
 	case Action::Type::MoveWait:
 		return DoMoveAction(x, y, action);
 	case Action::Type::Repair:
-		return Result::Failed;
+		return DoRepairAction(x, y, action);
 	case Action::Type::Unload:
 		return DoUnloadAction(x, y, action);
 	}
+	return Result::Succeeded;
+}
+
+Result GameState::DoRepairAction(int x, int y, const Action& action) {
+	if (!action.m_optDirection.has_value()) {
+		return Result::Failed;
+	}
+
+	MapTile* pSourceTile = nullptr;
+	IfFailedReturn(m_spmap->TryGetTile(x, y, &pSourceTile));
+
+	Unit* pBlackBoat = pSourceTile->TryGetUnit();
+	if (pBlackBoat == nullptr ||
+		pBlackBoat->m_owner != &GetCurrentPlayer() ||
+		pBlackBoat->m_properties.m_type != UnitProperties::Type::BlackBoat ||
+		pBlackBoat->m_moved) {
+		return Result::Failed;
+	}
+
+	MapTile* pTargetTile = nullptr;
+	switch (action.m_optDirection.value()) {
+	case Action::Direction::North:
+		IfFailedReturn(m_spmap->TryGetTile(x, y - 1, &pTargetTile));
+		break;
+	case Action::Direction::East:
+		IfFailedReturn(m_spmap->TryGetTile(x + 1, y, &pTargetTile));
+		break;
+	case Action::Direction::South:
+		IfFailedReturn(m_spmap->TryGetTile(x, y + 1, &pTargetTile));
+		break;
+	case Action::Direction::West:
+		IfFailedReturn(m_spmap->TryGetTile(x - 1, y, &pTargetTile));
+		break;
+	default:
+		return Result::Failed;
+	}
+
+	Unit* pTargetUnit = pTargetTile->TryGetUnit();
+	if (pTargetUnit == nullptr || pTargetUnit->m_owner != &GetCurrentPlayer()) {
+		return Result::Failed;
+	}
+
+	pTargetUnit->m_properties.m_fuel = GetUnitInfo(pTargetUnit->m_properties.m_type).m_fuel;
+	pTargetUnit->m_properties.m_ammo = GetUnitInfo(pTargetUnit->m_properties.m_type).m_ammo;
+
+	if (pTargetUnit->health < 100) {
+		int repairAmount = std::min(100 - pTargetUnit->health, 10);
+		int unitRepairFunds = Unit::GetUnitCost(pTargetUnit->m_properties.m_type) * (repairAmount / 10);
+		if (unitRepairFunds <= GetCurrentPlayer().m_funds) {
+			GetCurrentPlayer().m_funds -= unitRepairFunds;
+			pTargetUnit->health += repairAmount;
+		}
+	}
+
+	pBlackBoat->m_moved = true;
 	return Result::Succeeded;
 }
 
@@ -803,7 +868,16 @@ Result GameState::DoUnloadAction(int x, int y, const Action& action) {
 	MapTile* ptile = nullptr;
 	IfFailedReturn(m_spmap->TryGetTile(x, y, &ptile));
 	Unit* punitTransport = ptile->TryGetUnit();
-	Unit* pUnit = punitTransport->Unload(*action.m_optUnloadIndex);
+	if (punitTransport == nullptr) {
+		return Result::Failed;
+	}
+
+	int unloadIndex = action.m_optUnloadIndex.value_or(0);
+	if (unloadIndex < 0 || unloadIndex >= punitTransport->CLoadedUnits()) {
+		return Result::Failed;
+	}
+
+	Unit* pUnit = punitTransport->Unload(unloadIndex);
 	pmaptileDest->TryAddUnit(pUnit);
 	pUnit->m_moved = true;
 	return Result::Succeeded;
@@ -1478,26 +1552,29 @@ bool GameState::CheckPlayerResigns() noexcept {
 		return false;
 	}
 
-	if (m_nTurnCount < 14) {
+	if (m_nTurnCount < 5) {
 		return false;
-	}
-
-	if (m_nTurnCount > 100) {
-		m_fGameOver = true;
-		m_winningPlayer = 2;
-		std::cout << "Turn count exceeded" << std::endl;
-		std::cout << "Winning player: " << m_winningPlayer << std::endl;
-		return true;
 	}
 
 	int nCurrentPlayerArmyValue = 0;
 	int nCurrentPlayerUnits = 0;
 	int nEnemyPlayerArmyValue = 0;
 	int nEnemyPlayerUnits = 0;
+	int nCurrentIncome = 0;
+	int nEnemyIncome = 0;
 	for (int x = 0; x < m_spmap->GetCols(); ++x) {
 		for (int y = 0; y < m_spmap->GetRows(); ++y) {
 			const MapTile* pTile = nullptr;
 			m_spmap->TryGetTile(x, y, &pTile);
+			const Terrain& terrain = pTile->GetTerrain();
+			if (MapTile::IsProperty(terrain.m_type) && terrain.m_type != Terrain::Type::ComTower && terrain.m_type != Terrain::Type::Lab) {
+				if (pTile->m_spPropertyInfo->m_owner == &GetCurrentPlayer()) {
+					++nCurrentIncome;
+				}
+				else if (pTile->m_spPropertyInfo->m_owner == &GetEnemyPlayer()) {
+					++nEnemyIncome;
+				}
+			}
 			const Unit* punit = pTile->TryGetUnit();
 			if (punit != nullptr) {
 				if (punit->m_owner == &GetCurrentPlayer()) {
@@ -1512,17 +1589,17 @@ bool GameState::CheckPlayerResigns() noexcept {
 		}
 	}
 
-	// if army value is less than half opponent value
-	// if army units is less than half opponent units
+	// if army value is significantly less than opponent value
+	// if army units is significantly less than opponent units
 	// forfeit
-	if ((nCurrentPlayerArmyValue < (nEnemyPlayerArmyValue / 3)) && (nCurrentPlayerUnits < (nEnemyPlayerUnits / 3))) {
-		std::cout << "CAM: " << nCurrentPlayerArmyValue << std::endl;
-		std::cout << "EAM: " << nEnemyPlayerArmyValue << std::endl;
-		std::cout << "CU: " << nCurrentPlayerUnits << std::endl;
-		std::cout << "EU: " << nEnemyPlayerUnits << std::endl;
+	if ((nCurrentPlayerArmyValue < (nEnemyPlayerArmyValue / 2)) && (nCurrentPlayerUnits < (nEnemyPlayerUnits / 2)) && nCurrentIncome < nEnemyIncome) {
+		//std::cout << "CAM: " << nCurrentPlayerArmyValue << std::endl;
+		//std::cout << "EAM: " << nEnemyPlayerArmyValue << std::endl;
+		//std::cout << "CU: " << nCurrentPlayerUnits << std::endl;
+		//std::cout << "EU: " << nEnemyPlayerUnits << std::endl;
 		m_winningPlayer = m_isFirstPlayerTurn ? 1 : 0;
-		std::cout << "Forfeit by player" << (m_isFirstPlayerTurn ? 0 : 1) << std::endl;
-		std::cout << "Winning player" << m_winningPlayer << std::endl;
+		//std::cout << "Forfeit by player" << (m_isFirstPlayerTurn ? 0 : 1) << std::endl;
+		//std::cout << "Winning player" << m_winningPlayer << std::endl;
 		m_fGameOver = true;
 	}
 
@@ -1699,6 +1776,7 @@ void from_json(json& j, Action& action) {
 	if (j.contains("unloadIndex")) {
 		int unloadIndex = -1;
 		j.at("unloadIndex").get_to(unloadIndex);
+		action.m_optUnloadIndex = unloadIndex;
 	}
 }
 

--- a/AdvanceWarsServer/src/Unit.cpp
+++ b/AdvanceWarsServer/src/Unit.cpp
@@ -213,7 +213,11 @@ bool Unit::CanLoad(UnitProperties::Type type) const noexcept {
 		unitTypeIsOk = (type == UnitProperties::Type::Infantry || type == UnitProperties::Type::Mech);
 	}
 
-	if (m_properties.m_type == UnitProperties::Type::Crusier || m_properties.m_type == UnitProperties::Type::Carrier) {
+	if (m_properties.m_type == UnitProperties::Type::Crusier) {
+		unitTypeIsOk = type == UnitProperties::Type::BCopter || type == UnitProperties::Type::TCopter;
+	}
+
+	if (m_properties.m_type == UnitProperties::Type::Carrier) {
 		unitTypeIsOk = UnitProperties::IsAirUnit(type);
 	}
 

--- a/AdvanceWarsServer/test/json/transport/blackboat/repair-no-funds-resupplies-only.json
+++ b/AdvanceWarsServer/test/json/transport/blackboat/repair-no-funds-resupplies-only.json
@@ -1,0 +1,167 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-no-funds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 12,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "repair",
+      "source": [ 2, 0 ],
+      "direction": "west"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-no-funds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/blackboat/repair-resupply.json
+++ b/AdvanceWarsServer/test/json/transport/blackboat/repair-resupply.json
@@ -1,0 +1,167 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-resupply",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 12,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "repair",
+      "source": [ 2, 0 ],
+      "direction": "west"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-resupply",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 1300,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/blackboat/unload-second-unit.json
+++ b/AdvanceWarsServer/test/json/transport/blackboat/unload-second-unit.json
@@ -1,0 +1,196 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-unload-second-unit",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 0,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "infantry"
+              },
+              {
+                "ammo": 3,
+                "fuel": 70,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "mech"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "unload",
+      "source": [ 2, 0 ],
+      "direction": "east",
+      "unloadIndex": 1
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-unload-second-unit",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 0,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "infantry"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 3,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/carrier/loaded-air-resupply-begin-turn.json
+++ b/AdvanceWarsServer/test/json/transport/carrier/loaded-air-resupply-begin-turn.json
@@ -1,0 +1,181 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-loaded-air-resupply",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 3,
+                "fuel": 12,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bomber"
+              },
+              {
+                "ammo": 2,
+                "fuel": 7,
+                "health": 100,
+                "hidden": true,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "stealth"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-loaded-air-resupply",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 98,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 9,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bomber"
+              },
+              {
+                "ammo": 6,
+                "fuel": 60,
+                "health": 100,
+                "hidden": true,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "stealth"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 3000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/carrier/unload-hidden-stealth.json
+++ b/AdvanceWarsServer/test/json/transport/carrier/unload-hidden-stealth.json
@@ -1,0 +1,186 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-unload-hidden-stealth",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ],
+      [
+        {
+          "terrain": 28
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 6,
+                "fuel": 60,
+                "health": 100,
+                "hidden": true,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "stealth"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "terrain": 28
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "unload",
+      "source": [ 1, 1 ],
+      "direction": "north",
+      "unloadIndex": 0
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-unload-hidden-stealth",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 6,
+            "fuel": 60,
+            "health": 100,
+            "hidden": true,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "stealth"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ],
+      [
+        {
+          "terrain": 28
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "terrain": 28
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/crusier/loaded-copters-resupply-begin-turn.json
+++ b/AdvanceWarsServer/test/json/transport/crusier/loaded-copters-resupply-begin-turn.json
@@ -1,0 +1,181 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "cruiser-loaded-copters-resupply",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 1,
+                "fuel": 12,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bcopter"
+              },
+              {
+                "ammo": 0,
+                "fuel": 7,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "tcopter"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "crusier"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "cruiser-loaded-copters-resupply",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 98,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 6,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bcopter"
+              },
+              {
+                "ammo": 0,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "tcopter"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "crusier"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 3000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/invalid-loads.json
+++ b/AdvanceWarsServer/test/json/transport/invalid-loads.json
@@ -1,0 +1,184 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "invalid-transport-loads",
+    "map": [
+      [
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "apc"
+          }
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tcopter"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "fighter"
+          }
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "crusier"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "lander"
+          }
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "move-load",
+      "source": [ 0, 0 ],
+      "target": [ 1, 0 ]
+    },
+    {
+      "type": "move-load",
+      "source": [ 0, 0 ],
+      "target": [ 2, 0 ]
+    },
+    {
+      "type": "move-load",
+      "source": [ 0, 0 ],
+      "target": [ 3, 0 ]
+    },
+    {
+      "type": "move-load",
+      "source": [ 0, 1 ],
+      "target": [ 1, 1 ]
+    },
+    {
+      "type": "move-load",
+      "source": [ 0, 1 ],
+      "target": [ 2, 1 ]
+    },
+    {
+      "type": "move-load",
+      "source": [ 0, 0 ],
+      "target": [ 3, 1 ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/transport/lander/no-unload-at-sea.json
+++ b/AdvanceWarsServer/test/json/transport/lander/no-unload-at-sea.json
@@ -1,0 +1,93 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lander-no-unload-at-sea",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 28
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 9,
+                "fuel": 70,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "tank"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "lander"
+          }
+        },
+        {
+          "terrain": 28
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "unload",
+      "source": [ 2, 0 ],
+      "direction": "west"
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/transport/lander/unload-second-unit.json
+++ b/AdvanceWarsServer/test/json/transport/lander/unload-second-unit.json
@@ -1,0 +1,196 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lander-unload-second-unit",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 9,
+                "fuel": 70,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "tank"
+              },
+              {
+                "ammo": 8,
+                "fuel": 50,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "medium-tank"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "lander"
+          }
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "unload",
+      "source": [ 2, 0 ],
+      "direction": "east",
+      "unloadIndex": 1
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lander-unload-second-unit",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 9,
+                "fuel": 70,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "tank"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "lander"
+          }
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 8,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "medium-tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/loaded-units-destroyed-with-transport.json
+++ b/AdvanceWarsServer/test/json/transport/loaded-units-destroyed-with-transport.json
@@ -1,0 +1,166 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "loaded-units-destroyed-with-transport",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "anti-air"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 0,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "blue-moon",
+                "type": "infantry"
+              }
+            ],
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tcopter"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [ 0, 0 ],
+      "direction": "east",
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "loaded-units-destroyed-with-transport",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 8,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "anti-air"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 2500,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 5000,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/unload-invalid-index-fails.json
+++ b/AdvanceWarsServer/test/json/transport/unload-invalid-index-fails.json
@@ -1,0 +1,86 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "transport-unload-invalid-index-fails",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 0,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "infantry"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "apc"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "unload",
+      "source": [ 1, 0 ],
+      "direction": "east",
+      "unloadIndex": 1
+    },
+    {
+      "type": "unload",
+      "source": [ 1, 0 ],
+      "direction": "west",
+      "unloadIndex": -1
+    }
+  ]
+}

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -1,0 +1,45 @@
+# Build And Test
+
+This project can be built from the Visual Studio solution with MSBuild.
+
+## Prerequisites
+
+- Visual Studio 2022 with the v143 C++ toolset.
+- Windows SDK 10.0.
+- The local dependency paths referenced by `AdvanceWarsServer/AdvanceWarsServer.vcxproj`, including libtorch, nlohmann-json, asio, and via-httplib.
+
+## Build
+
+From the repository root:
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal
+```
+
+Release x64:
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Release /p:Platform=x64 /v:minimal
+```
+
+## Run Tests
+
+Run tests from the `AdvanceWarsServer` project directory so the relative `test/json` path resolves:
+
+```powershell
+Set-Location .\AdvanceWarsServer
+..\x64\Debug\AdvanceWarsServer.exe -test test/json
+```
+
+Release:
+
+```powershell
+Set-Location .\AdvanceWarsServer
+..\x64\Release\AdvanceWarsServer.exe -test test/json
+```
+
+You can also run a subset:
+
+```powershell
+..\x64\Debug\AdvanceWarsServer.exe -test test/json/transport
+```

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -1,0 +1,96 @@
+# Advance Wars Self-Play Training Loop Work Items
+
+This file tracks the major work needed to turn the current Advance Wars simulator into an AlphaZero-style self-play training system.
+
+## Current Direction
+
+- Use action-level MCTS first. A full player turn is represented as a sequence of same-player atomic actions ending with `EndTurn`.
+- Keep the game engine as the single source of truth for legal actions and state transitions.
+- Start with deterministic or seedable simulations before adding stochastic luck back into training.
+- Build self-play data generation before attempting full neural network training.
+
+## Open Product Decisions
+
+- [ ] Decide whether v1 targets full AWBW fidelity or a simplified deterministic subset.
+- [ ] Decide how combat luck should work during self-play: disabled, averaged, or seeded.
+- [ ] Decide whether v1 includes fog, hidden units, CO powers, transports, naval units, and all unit types.
+- [ ] Decide the first map set for self-play. Small maps will make early iteration much faster.
+- [ ] Decide whether training should run inside the C++ executable only, or whether C++ should expose an environment API for a Python training process.
+
+## Phase 0: Stabilize The Simulator
+
+- [ ] Run the JSON subsystem tests from a current build and make failures visible in CI or local output.
+- [ ] Fix action deserialization for `unloadIndex`; it is read but not assigned to `Action::m_optUnloadIndex`.
+- [ ] Fix capture-limit property counting. The current lab/com tower exclusion condition appears to use `||` where `&&` was likely intended.
+- [ ] Audit unit count caching around load/unload, clone, add, and destroy paths before relying on unit-cap logic in training.
+- [ ] Replace hardcoded local paths such as `D:/awai`, `D:/MNIST`, and local libtorch directories with config or command-line options.
+- [ ] Add a maximum turn/action limit outcome for self-play games so training cannot hang indefinitely.
+- [ ] Make combat RNG deterministic, seedable, or policy-controlled from the self-play runner.
+
+## Phase 1: Trainable Environment API
+
+- [ ] Add a small environment wrapper around `GameState`.
+- [ ] Expose `reset`, `legalActions`, `step`, `isTerminal`, `currentPlayer`, and `winner` operations.
+- [ ] Add stable state serialization for replay data.
+- [ ] Add state tensor encoding in `Tensor.cpp`.
+- [ ] Add a stable action encoding scheme for every `Action` variant.
+- [ ] Add legal action masks aligned with the action encoding.
+- [ ] Add tests proving encode/decode preserves actions, including move-attack, unload, buy, powers, and end-turn.
+
+## Phase 2: MCTS Improvements
+
+- [ ] Separate pure rollout MCTS from neural-network-guided MCTS.
+- [ ] Expand one child at a time or track unexpanded actions to avoid expanding every legal action immediately.
+- [ ] Replace `rand()` rollout action selection with a seeded RNG object.
+- [ ] Add PUCT selection using policy priors once a policy head exists.
+- [ ] Store visit counts per legal action for training targets.
+- [ ] Handle same-player action sequences explicitly in value backup. The player only changes on `EndTurn`.
+- [ ] Add temperature controls for early-game exploration and late-game exploitation.
+- [ ] Add MCTS search limits by simulations, wall-clock time, or node count.
+
+## Phase 3: Self-Play Data Generation
+
+- [ ] Add a self-play command-line entry point.
+- [ ] Generate games using MCTS-selected actions.
+- [ ] Record each training sample as state tensor, legal action mask, MCTS visit policy, current player, and final outcome.
+- [ ] Store replay data in a versioned format.
+- [ ] Add replay validation that can reconstruct a game from recorded actions.
+- [ ] Add basic metrics: game length, winner, resignations, average branching factor, and search time per move.
+- [ ] Add parallel self-play workers after the single-worker path is reliable.
+
+## Phase 4: Neural Network
+
+- [ ] Define model input planes for terrain, ownership, units, health, ammo, fuel, moved flags, capture points, funds, powers, turn/player context, and optional fog state.
+- [ ] Define policy head output shape matching the action encoding.
+- [ ] Define value head output as win/loss value from the current player's perspective.
+- [ ] Add model save/load checkpoints.
+- [ ] Add inference batching for MCTS.
+- [ ] Add CPU-only fallback so development does not depend on CUDA being configured.
+
+## Phase 5: Training Loop
+
+- [ ] Add supervised-style training over replay samples.
+- [ ] Train policy with cross entropy against MCTS visit distributions.
+- [ ] Train value with mean squared error or cross entropy against final outcomes.
+- [ ] Add replay buffer sampling and retention policy.
+- [ ] Add checkpoint promotion/evaluation against previous models.
+- [ ] Add command-line options for epochs, batch size, learning rate, device, checkpoint path, and replay path.
+
+## Phase 6: Evaluation And Iteration
+
+- [ ] Add head-to-head evaluation between checkpoints.
+- [ ] Add random-player and heuristic-player baselines.
+- [ ] Add deterministic smoke tests for short self-play games.
+- [ ] Track win rate, average value loss, policy loss, game length, invalid action count, and search throughput.
+- [ ] Add regression maps that cover captures, purchases, transport logic, indirect combat, powers, and end-game conditions.
+
+## Candidate GitHub Issues
+
+- [ ] Create deterministic combat RNG for self-play.
+- [ ] Implement state tensor encoding.
+- [ ] Implement action encoding and legal action masks.
+- [ ] Refactor MCTS for action-level self-play and same-player turn sequences.
+- [ ] Add self-play replay writer.
+- [ ] Add policy/value network scaffold.
+- [ ] Add training command-line entry point.
+- [ ] Add checkpoint evaluation harness.


### PR DESCRIPTION
## Summary

- Fix unload action JSON handling so explicit `unloadIndex` values are preserved, omitted indices default safely to the first loaded unit, and invalid indices fail instead of crashing.
- Add transport behavior coverage for unload indices, invalid load combinations, Black Boat repair/resupply, Carrier/Cruiser cargo resupply, terrain-constrained unloads, hidden Stealth unloads, and cargo destruction with transports.
- Include the previously prepared build/test notes and training-loop work item tracker, plus the current local MCTS/tensor/project changes because this PR intentionally pushes the whole worktree.

## Root Cause

The unload crash came from `from_json` reading `unloadIndex` into a local variable but never assigning it to `Action::m_optUnloadIndex`; `DoUnloadAction` then dereferenced the empty optional.

## Validation

- Debug x64 MSBuild succeeded.
- Release x64 MSBuild succeeded.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/transport`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Release\AdvanceWarsServer.exe -test test/json`