### PR TITLE
[codex] Add AWBW wiki project notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Project Notes
+
+- Use the Advance Wars By Web Wiki as the main gameplay-rules reference when checking mechanics, unit behavior, terrain, CO powers, or AWBW-specific differences: https://awbw.fandom.com/wiki/Advance_Wars_By_Web_Wiki
+- Prefer the local source code and JSON tests as the source of truth for current implementation behavior. When implementation and wiki behavior differ, call out the gap before changing code.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with repo-specific guidance to use the Advance Wars By Web Wiki as the primary gameplay-rules reference.
- Note that local source and JSON tests remain the source of truth for current implementation behavior, and wiki/code gaps should be called out before code changes.

## Validation

- Documentation-only change; no build or test run needed.