### PR TITLE
[codex] Add deterministic combat RNG

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <memory>
+#include <optional>
+#include <random>
 
 #include "Map.h"
 #include "Player.h"
@@ -9,8 +12,6 @@
 #include "Reward.h"
 
 class Map;
-
-#include <optional>
 
 struct Action {
 	enum class Type {
@@ -263,6 +264,8 @@ public:
 	}
 
 	bool FEnemyHasLabs() const noexcept;
+	void SetCombatRngSeed(std::uint32_t seed);
+	void ClearCombatRngSeed() noexcept;
 	static void to_json(json& j, const GameState& gameState);
 	static void from_json(json& j, GameState& gameState);
 private:
@@ -299,6 +302,7 @@ private:
 
 	int GetMaxGoodLuck(const Player& player) noexcept;
 	int GetMaxBadLuck(const Player& player) noexcept;
+	int RollCombatLuck(int min, int max);
 	int GetCOMovementBonus(const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
 	void HealUnits(int health);
 	bool FAtUnitCap() const noexcept;
@@ -313,5 +317,7 @@ private:
 	bool m_isFirstPlayerTurn{ true };
 	bool m_fGameOver = false;
 	int m_winningPlayer = -1;
+	std::optional<std::uint32_t> m_combatRngSeed;
+	std::optional<std::mt19937> m_combatRng;
 };
 

--- a/AdvanceWarsServer/inc/SubsystemTest.h
+++ b/AdvanceWarsServer/inc/SubsystemTest.h
@@ -9,6 +9,8 @@ struct JsonSubsystemTest {
 	GameState finalGameState;
 	std::vector<Action> vecActions;
 	std::vector<Action> vecFailedActions;
+	bool fHasFinalGameState{ false };
+	bool fDeterministicReplay{ false };
 };
 
 void from_json(json& j, JsonSubsystemTest& test);

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include <cstdint>
 #include <random>
 #include <thread>
 #include <future>
@@ -14,7 +15,7 @@ int main(int argc, char* argv[]) noexcept {
 		if (argc < 2) { // Check if the user provided exactly one argument
 			std::cerr << "Usage: " << argv[0] << " <option>\n";
 			std::cerr << "Options:\n";
-			std::cerr << "  -sim-random-move-game : Simulate a random move game.\n";
+			std::cerr << "  -sim-random-move-game [seed] : Simulate a random move game.\n";
 			std::cerr << "  -sim-mcts-game        : Simulate an MCTS game.\n";
 			std::cerr << "  -server               : Act as game server.\n";
 			return 1; // Return an error code
@@ -89,6 +90,12 @@ int main(int argc, char* argv[]) noexcept {
 			}
 		}
 		else if (argument == "-sim-random-move-game") {
+			std::uint32_t randomMoveSeed = std::random_device{}();
+			if (argc >= 3) {
+				randomMoveSeed = static_cast<std::uint32_t>(std::stoul(argv[2]));
+			}
+			std::cout << "Random move game seed: " << randomMoveSeed << std::endl;
+
 			// Determine the number of available CPU cores.
 			unsigned int maxConcurrentGames = std::thread::hardware_concurrency();
 			if (maxConcurrentGames == 0) {
@@ -110,14 +117,14 @@ int main(int argc, char* argv[]) noexcept {
 				filestream >> jsonState;
 				GameState rootState;
 				GameState::from_json(jsonState, rootState);
+				rootState.SetCombatRngSeed(randomMoveSeed);
 
 				std::ofstream outFile("D:/awai/random-move-game/" + Platform::createUuid() + ".awai");
 
 				time_point startTime = std::chrono::steady_clock::now();
 				std::cout << "GameState: " << std::endl << jsonState.dump() << std::endl;
 				outFile << "GameState: " << std::endl << jsonState.dump() << std::endl;
-				std::random_device rd;
-				std::mt19937 luckGen(rd());
+				std::mt19937 luckGen(randomMoveSeed);
 				int totalActions = 0;
 				while (!rootState.isTerminal()) {
 					std::vector<Action> vecActions;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -19,6 +19,16 @@ GameState::GameState() noexcept
 {
 }
 
+void GameState::SetCombatRngSeed(std::uint32_t seed) {
+	m_combatRngSeed = seed;
+	m_combatRng.emplace(seed);
+}
+
+void GameState::ClearCombatRngSeed() noexcept {
+	m_combatRngSeed.reset();
+	m_combatRng.reset();
+}
+
 Result GameState::InitializeGame() noexcept {
 	MapParser parser;
 	time_point fileStartTime = std::chrono::steady_clock::now();
@@ -1244,10 +1254,7 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 		return -1;
 	}
 
-	std::random_device rd;
-	std::mt19937 luckGen(rd());
 	std::uniform_int_distribution<int> goodLuckDistribution(0, GetMaxGoodLuck(*pattackingplayer));
-	// Generate a random number
 	int goodLuckRoll = 0;
 	if (pattackingplayer->m_luckPolicy == LuckPolicy::AlwaysLowestValue) {
 		goodLuckRoll = goodLuckDistribution.min();
@@ -1256,11 +1263,11 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 		goodLuckRoll = goodLuckDistribution.max();
 	}
 	else {
-		goodLuckRoll = goodLuckDistribution(luckGen);
+		goodLuckRoll = RollCombatLuck(goodLuckDistribution.min(), goodLuckDistribution.max());
 	}
 
 	std::uniform_int_distribution<int> badLuckDistribution(0, GetMaxBadLuck(*pattackingplayer));
-	int badLuckRoll = badLuckDistribution(luckGen);
+	int badLuckRoll = 0;
 	if (pattackingplayer->m_luckPolicy == LuckPolicy::AlwaysLowestValue) {
 		badLuckRoll = badLuckDistribution.max();
 	}
@@ -1268,7 +1275,7 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 		badLuckRoll = badLuckDistribution.min();
 	}
 	else {
-		badLuckRoll = badLuckDistribution(luckGen);
+		badLuckRoll = RollCombatLuck(badLuckDistribution.min(), badLuckDistribution.max());
 	}
 
 	int nComTowers = 0;
@@ -1350,6 +1357,16 @@ int GameState::GetCOTerrainModifier(const Player& player, const CommandingOffici
 		break;
 	}
 	return 0;
+}
+
+int GameState::RollCombatLuck(int min, int max) {
+	std::uniform_int_distribution<int> distribution(min, max);
+	if (m_combatRng.has_value()) {
+		return distribution(*m_combatRng);
+	}
+
+	static thread_local std::mt19937 unseededCombatRng{ std::random_device{}() };
+	return distribution(unseededCombatRng);
 }
 
 int GameState::GetMaxGoodLuck(const Player& player) noexcept {
@@ -1617,6 +1634,8 @@ GameState::GameState(const GameState& other) noexcept :
 	m_isFirstPlayerTurn = other.m_isFirstPlayerTurn;
 	m_fGameOver = other.m_fGameOver;
 	m_winningPlayer = other.m_winningPlayer;
+	m_combatRngSeed = other.m_combatRngSeed;
+	m_combatRng = other.m_combatRng;
 }
 
 GameState GameState::Clone() {
@@ -1638,6 +1657,8 @@ GameState& GameState::operator=(const GameState& other) noexcept {
 		m_isFirstPlayerTurn = other.m_isFirstPlayerTurn;
 		m_fGameOver = other.m_fGameOver;
 		m_winningPlayer = other.m_winningPlayer;
+		m_combatRngSeed = other.m_combatRngSeed;
+		m_combatRng = other.m_combatRng;
 	}
 	return *this;
 }
@@ -1654,6 +1675,10 @@ void GameState::to_json(json& j, const GameState& gameState) {
 		  { "game-over", gameState.m_fGameOver },
 		  { "winner", gameState.m_winningPlayer },
 	};
+
+	if (gameState.m_combatRngSeed.has_value()) {
+		j["combat-rng-seed"] = gameState.m_combatRngSeed.value();
+	}
 }
 
 void to_json(json& j, const Action& action) {
@@ -1803,4 +1828,13 @@ void GameState::from_json(json& j, GameState& gameState) {
 	int activePlayer;
 	j.at("activePlayer").get_to(activePlayer);
 	gameState.m_isFirstPlayerTurn = activePlayer == 0;
+
+	if (j.contains("combat-rng-seed")) {
+		std::uint32_t combatRngSeed;
+		j.at("combat-rng-seed").get_to(combatRngSeed);
+		gameState.SetCombatRngSeed(combatRngSeed);
+	}
+	else {
+		gameState.ClearCombatRngSeed();
+	}
 }

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -5,10 +5,32 @@
 
 #include "GameState.h"
 
+namespace {
+Result BuildActionTrace(GameState gameState, const std::vector<Action>& actions, std::string& traceDump) {
+	json trace = json::array();
+	json initialState;
+	GameState::to_json(initialState, gameState);
+	trace.push_back(std::move(initialState));
+
+	for (const Action& action : actions) {
+		IfFailedReturn(gameState.DoAction(action));
+		gameState.CheckPlayerResigns();
+
+		json actedGameState;
+		GameState::to_json(actedGameState, gameState);
+		trace.push_back(std::move(actedGameState));
+	}
+
+	traceDump = trace.dump();
+	return Result::Succeeded;
+}
+}
+
 void from_json(json& j, JsonSubsystemTest& test) {
 	GameState::from_json(j.at("initial-game-state"), test.initialGameState);
 	if (j.contains("final-game-state")) {
 		GameState::from_json(j.at("final-game-state"), test.finalGameState);
+		test.fHasFinalGameState = true;
 	}
 
 	if (j.contains("actions")) {
@@ -25,6 +47,10 @@ void from_json(json& j, JsonSubsystemTest& test) {
 			from_json(jAction, action);
 			test.vecFailedActions.emplace_back(action);
 		}
+	}
+
+	if (j.contains("deterministic-replay")) {
+		j.at("deterministic-replay").get_to(test.fDeterministicReplay);
 	}
 }
 
@@ -49,7 +75,7 @@ Result JsonTestRunner::run() {
 	JsonSubsystemTest test;
 	from_json(j, test);
 
-	if (!test.vecActions.empty()) {
+	if (!test.vecActions.empty() && test.fHasFinalGameState) {
 		for (const Action& action : test.vecActions) {
 			IfFailedReturn(test.initialGameState.DoAction(action));
 		}
@@ -62,6 +88,23 @@ Result JsonTestRunner::run() {
 		m_strExpected = expectedGameState.dump();
 
 		if (m_strActual != m_strExpected) {
+			return Result::Failed;
+		}
+	}
+
+	if (test.fDeterministicReplay) {
+		if (test.vecActions.empty()) {
+			return Result::Failed;
+		}
+
+		std::string firstTrace;
+		std::string secondTrace;
+		IfFailedReturn(BuildActionTrace(test.initialGameState, test.vecActions, firstTrace));
+		IfFailedReturn(BuildActionTrace(test.initialGameState, test.vecActions, secondTrace));
+
+		m_strExpected = firstTrace;
+		m_strActual = secondTrace;
+		if (firstTrace != secondTrace) {
 			return Result::Failed;
 		}
 	}

--- a/AdvanceWarsServer/test/json/self-play/deterministic-combat-rng.json
+++ b/AdvanceWarsServer/test/json/self-play/deterministic-combat-rng.json
@@ -1,0 +1,287 @@
+{
+  "deterministic-replay": true,
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "combat-rng-seed": 8675309,
+    "game-over": false,
+    "gameId": "seeded-combat-rng-replay",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [2, 0],
+      "direction": "east",
+      "target": [2, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [4, 0],
+      "direction": "east",
+      "target": [4, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [6, 0],
+      "direction": "east",
+      "target": [6, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [8, 0],
+      "direction": "east",
+      "target": [8, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [10, 0],
+      "direction": "east",
+      "target": [10, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [12, 0],
+      "direction": "east",
+      "target": [12, 0]
+    },
+    {
+      "type": "move-attack",
+      "source": [14, 0],
+      "direction": "east",
+      "target": [14, 0]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add optional seeded combat RNG state to `GameState` and use it for combat good/bad luck rolls.
- Preserve fixed luck policy behavior for always-lowest and always-highest rolls.
- Add a deterministic replay JSON regression that runs the same self-play action trace twice from the same seed.
- Let `-sim-random-move-game` accept/pass a seed for deterministic action selection and combat resolution.

## Validation

- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/self-play`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`

Closes #2