### PR TITLE
Complete CO parsing and contract coverage

### DIFF
--- a/AdvanceWarsServer/inc/Player.h
+++ b/AdvanceWarsServer/inc/Player.h
@@ -4,14 +4,14 @@
 class PowerMeter final {
 public:
 	PowerMeter() {}
-	PowerMeter(const CommandingOfficier::Type& type) noexcept;
+	PowerMeter(const CommandingOfficier::Type& type);
 	void AddCharge(int charge) noexcept;
 	bool FCopCharged() const noexcept {
-		return m_nCharge > m_nCopStars * m_nStarValue;
+		return m_nCopStars > 0 && m_nCharge >= m_nCopStars * m_nStarValue;
 	}
 
 	bool FScopCharged() const noexcept {
-		return m_nCharge == GetTotalCharge();
+		return m_nCharge >= GetTotalCharge();
 	}
 
 	void UseCop() noexcept;

--- a/AdvanceWarsServer/src/CommandingOfficier.cpp
+++ b/AdvanceWarsServer/src/CommandingOfficier.cpp
@@ -1,4 +1,6 @@
 #include "CommandingOfficier.h"
+
+#include <stdexcept>
 										/*Anti-air*/	/*Apc*/		/*Artillery*/	/*BCopter*/	/*Battleship*/	/*Blackboat*/	/*Blackbomb*/	/*Bomber*/	/*Carrier*/	/*Crusier*/	/*Fighter*/	/*Infantry*/	/*Lander*/	/*Medium Tank*/	/*Mech*/	/*Mega tank*/	/*Missile*/	/*Neotank*/	/*Piperunner*/	/*Recon*/	/*Rocket*/	/*Stealth*/	/*Sub*/		/*TCopter*/	/*Tank*/
 constexpr DamageChart c_adderNormal	{{	{100, 100},		{0, 100},	{100, 100},		{100, 100},	{100, 100},		{0, 100},		{0, 100},		{100, 100},	{100, 100},	{100, 100},	{100, 100},	{100, 100},		{0, 100},	{100, 100},		{100, 100},	{100, 100},		{100, 100},	{100, 100},	{100, 100},		{100, 100},	{100, 100},	{100, 100},	{100, 100},	{0, 100},	{100, 100}	}};
 constexpr DamageChart c_adderCOP	{{	{110, 110},		{0, 110},	{110, 110},		{110, 110},	{110, 110},		{0, 110},		{0, 110},		{110, 110},	{110, 110},	{110, 110},	{110, 110},	{110, 110},		{0, 110},	{110, 110},		{110, 110},	{110, 110},		{110, 110},	{110, 110},	{110, 110},		{110, 110},	{110, 110},	{110, 110},	{110, 110},	{0, 110},	{110, 110}	}};
@@ -148,67 +150,59 @@ constexpr DamageCharts c_vonbolt{ c_vonboltNormal, c_vonboltCOP, c_vonboltSCOP }
 	c_vonbolt
 };
 
-std::string CommandingOfficier::to_string() const {
-	switch (m_type) {
-	case Type::Adder:
-		return "Adder";
-	case Type::Andy:
-		return "Andy";
-	case Type::Colin:
-		return "Colin";
-	case Type::Drake:
-		return "Drake";
-	case Type::Eagle:
-		return "Eagle";
-	case Type::Flak:
-		return "Flak";
-	case Type::Grimm:
-		return "Grimm";
-	case Type::Grit:
-		return "Grit";
-	case Type::Hachi:
-		return "Hachi";
-	case Type::Hawke:
-		return "Hawke";
-	case Type::Jake:
-		return "Jake";
-	case Type::Javier:
-		return "Javier";
-	case Type::Jess:
-		return "Jess";
-	case Type::Jugger:
-		return "Jugger";
-	case Type::Kanbei:
-		return "Kanbei";
-	case Type::Kindle:
-		return "Kindle";
-	case Type::Koal:
-		return "Koal";
-	case Type::Lash:
-		return "Lash";
-	case Type::Max:
-		return "Max";
-	case Type::Nell:
-		return "Nell";
-	case Type::Olaf:
-		return "Olaf";
-	case Type::Rachel:
-		return "Rachel";
-	case Type::Sami:
-		return "Sami";
-	case Type::Sasha:
-		return "Sasha";
-	case Type::Sensei:
-		return "Sensei";
-	case Type::Sonja:
-		return "Sonja";
-	case Type::Sturm:
-		return "Sturm";
-	case Type::VonBolt:
-		return "VonBolt";
-	default:
-		return "";
+namespace {
+using COType = CommandingOfficier::Type;
+
+constexpr std::array<std::pair<const char*, COType>, static_cast<int>(COType::Size)> c_commandingOfficiers{ {
+	{ "Adder", COType::Adder },
+	{ "Andy", COType::Andy },
+	{ "Colin", COType::Colin },
+	{ "Drake", COType::Drake },
+	{ "Eagle", COType::Eagle },
+	{ "Flak", COType::Flak },
+	{ "Grimm", COType::Grimm },
+	{ "Grit", COType::Grit },
+	{ "Hachi", COType::Hachi },
+	{ "Hawke", COType::Hawke },
+	{ "Jake", COType::Jake },
+	{ "Javier", COType::Javier },
+	{ "Jess", COType::Jess },
+	{ "Jugger", COType::Jugger },
+	{ "Kanbei", COType::Kanbei },
+	{ "Kindle", COType::Kindle },
+	{ "Koal", COType::Koal },
+	{ "Lash", COType::Lash },
+	{ "Max", COType::Max },
+	{ "Nell", COType::Nell },
+	{ "Olaf", COType::Olaf },
+	{ "Rachel", COType::Rachel },
+	{ "Sami", COType::Sami },
+	{ "Sasha", COType::Sasha },
+	{ "Sensei", COType::Sensei },
+	{ "Sonja", COType::Sonja },
+	{ "Sturm", COType::Sturm },
+	{ "VonBolt", COType::VonBolt },
+} };
+
+COType CommandingOfficierTypeFromString(const std::string& coName) {
+	for (const auto& [name, type] : c_commandingOfficiers) {
+		if (coName == name) {
+			return type;
+		}
 	}
+
+	throw std::invalid_argument("Unknown commanding officer: " + coName);
+}
+}
+
+std::string CommandingOfficier::to_string() const {
+	for (const auto& [name, type] : c_commandingOfficiers) {
+		if (m_type == type) {
+			return name;
+		}
+	}
+
+	return "";
 }
 
 void to_json(json& j, const CommandingOfficier& co) {
@@ -216,11 +210,7 @@ void to_json(json& j, const CommandingOfficier& co) {
 }
 
 void from_json(json& j, CommandingOfficier& co) {
-	if (j == "Adder") {
-		co = { CommandingOfficier::Type::Adder };
-	}
-
-	if (j == "Andy") {
-		co = { CommandingOfficier::Type::Andy};
-	}
+	std::string coName;
+	j.get_to(coName);
+	co = { CommandingOfficierTypeFromString(coName) };
 }

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1499,9 +1499,14 @@ void GameState::HealUnits(int health) {
 }
 
 Result GameState::DoCOPowerAction() {
-	CommandingOfficier::Type type = GetCurrentPlayer().m_co.m_type;
-	GetCurrentPlayer().SetPowerStatus(1);
-	GetCurrentPlayer().m_powerMeter.UseCop();
+	Player& currentPlayer = GetCurrentPlayer();
+	if (!currentPlayer.m_powerMeter.FCopCharged()) {
+		return Result::Failed;
+	}
+
+	CommandingOfficier::Type type = currentPlayer.m_co.m_type;
+	currentPlayer.SetPowerStatus(1);
+	currentPlayer.m_powerMeter.UseCop();
 	switch (type) {
 		case CommandingOfficier::Type::Andy:
 			HealUnits(2);
@@ -1534,9 +1539,14 @@ Result GameState::ResupplyPlayersUnits(const Player* player) {
 }
 
 Result GameState::DoSCOPowerAction() {
-	CommandingOfficier::Type type = GetCurrentPlayer().m_co.m_type;
-	GetCurrentPlayer().SetPowerStatus(2);
-	GetCurrentPlayer().m_powerMeter.UseScop();
+	Player& currentPlayer = GetCurrentPlayer();
+	if (!currentPlayer.m_powerMeter.FScopCharged()) {
+		return Result::Failed;
+	}
+
+	CommandingOfficier::Type type = currentPlayer.m_co.m_type;
+	currentPlayer.SetPowerStatus(2);
+	currentPlayer.m_powerMeter.UseScop();
 	switch (type) {
 		case CommandingOfficier::Type::Andy:
 			HealUnits(5);

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -2,10 +2,99 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 #include "GameState.h"
 
 namespace {
+void SetMismatch(std::string& expected, std::string& actual, const std::string& message, const std::string& expectedValue, const std::string& actualValue) {
+	expected = message + ": " + expectedValue;
+	actual = actualValue;
+}
+
+std::string StatToString(const std::pair<int, int>& stat) {
+	std::ostringstream oss;
+	oss << stat.first << "/" << stat.second;
+	return oss.str();
+}
+
+Result RunCommandingOfficierContract(json& jContract, std::string& expected, std::string& actual) {
+	std::string coName;
+	jContract.at("name").get_to(coName);
+
+	json coJson = coName;
+	CommandingOfficier co;
+	from_json(coJson, co);
+	if (co.m_type == CommandingOfficier::Type::Invalid) {
+		SetMismatch(expected, actual, "CO parser should recognize", coName, "Invalid");
+		return Result::Failed;
+	}
+
+	json roundTrip;
+	to_json(roundTrip, co);
+	if (roundTrip != coName) {
+		SetMismatch(expected, actual, "CO should round trip", coName, roundTrip.dump());
+		return Result::Failed;
+	}
+
+	PowerMeter powerMeter(co.m_type);
+	json actualPowerMeter;
+	PowerMeter::to_json(actualPowerMeter, powerMeter);
+	const json& expectedPowerMeter = jContract.at("power-meter");
+	if (actualPowerMeter["cop-stars"] != expectedPowerMeter.at("cop-stars") ||
+		actualPowerMeter["scop-stars"] != expectedPowerMeter.at("scop-stars")) {
+		expected = expectedPowerMeter.dump();
+		actual = actualPowerMeter.dump();
+		return Result::Failed;
+	}
+
+	const DamageCharts& charts = rgCharts[static_cast<int>(co.m_type)];
+	for (auto& statContract : jContract.at("stats")) {
+		std::string unitName;
+		statContract.at("unit").get_to(unitName);
+		UnitProperties::Type unitType = UnitProperties::unitTypeFromString(unitName);
+		if (unitType == UnitProperties::Type::Invalid) {
+			SetMismatch(expected, actual, "Unit parser should recognize", unitName, "Invalid");
+			return Result::Failed;
+		}
+
+		const std::array<std::pair<const char*, int>, 3> powerStatuses{ {
+			{ "normal", 0 },
+			{ "cop", 1 },
+			{ "scop", 2 },
+		} };
+		for (const auto& [statusName, statusIndex] : powerStatuses) {
+			std::pair<int, int> expectedStat;
+			statContract.at(statusName).at(0).get_to(expectedStat.first);
+			statContract.at(statusName).at(1).get_to(expectedStat.second);
+			std::pair<int, int> actualStat = charts[statusIndex][static_cast<int>(unitType)];
+			if (actualStat != expectedStat) {
+				SetMismatch(expected, actual, coName + " " + unitName + " " + statusName, StatToString(expectedStat), StatToString(actualStat));
+				return Result::Failed;
+			}
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+Result RunInvalidCommandingOfficierContract(json& jInvalidCo, std::string& expected, std::string& actual) {
+	std::string coName;
+	jInvalidCo.get_to(coName);
+
+	json coJson = coName;
+	CommandingOfficier co;
+	try {
+		from_json(coJson, co);
+	}
+	catch (const std::exception&) {
+		return Result::Succeeded;
+	}
+
+	SetMismatch(expected, actual, "Unknown CO should throw", coName, co.to_string());
+	return Result::Failed;
+}
+
 Result BuildActionTrace(GameState gameState, const std::vector<Action>& actions, std::string& traceDump) {
 	json trace = json::array();
 	json initialState;
@@ -72,6 +161,15 @@ Result JsonTestRunner::run() {
 
 	json j;
 	filestream >> j;
+
+	if (j.contains("co-contract")) {
+		return RunCommandingOfficierContract(j.at("co-contract"), m_strExpected, m_strActual);
+	}
+
+	if (j.contains("invalid-co")) {
+		return RunInvalidCommandingOfficierContract(j.at("invalid-co"), m_strExpected, m_strActual);
+	}
+
 	JsonSubsystemTest test;
 	from_json(j, test);
 

--- a/AdvanceWarsServer/src/Player.cpp
+++ b/AdvanceWarsServer/src/Player.cpp
@@ -1,6 +1,8 @@
 #include "Player.h"
 
-PowerMeter::PowerMeter(const CommandingOfficier::Type& type) noexcept {
+#include <stdexcept>
+
+PowerMeter::PowerMeter(const CommandingOfficier::Type& type) {
 	switch (type) {
 	case CommandingOfficier::Type::Adder:
 		m_nCopStars = 2;
@@ -10,8 +12,73 @@ PowerMeter::PowerMeter(const CommandingOfficier::Type& type) noexcept {
 		m_nCopStars = 3;
 		m_nScopStars = 3;
 		break;
+	case CommandingOfficier::Type::Colin:
+		m_nCopStars = 2;
+		m_nScopStars = 4;
+		break;
+	case CommandingOfficier::Type::Drake:
+		m_nCopStars = 4;
+		m_nScopStars = 3;
+		break;
+	case CommandingOfficier::Type::Eagle:
+		m_nCopStars = 3;
+		m_nScopStars = 6;
+		break;
+	case CommandingOfficier::Type::Flak:
+	case CommandingOfficier::Type::Grimm:
+	case CommandingOfficier::Type::Grit:
+	case CommandingOfficier::Type::Jake:
+	case CommandingOfficier::Type::Javier:
+	case CommandingOfficier::Type::Jess:
+	case CommandingOfficier::Type::Kindle:
+	case CommandingOfficier::Type::Max:
+	case CommandingOfficier::Type::Nell:
+	case CommandingOfficier::Type::Rachel:
+		m_nCopStars = 3;
+		m_nScopStars = 3;
+		break;
+	case CommandingOfficier::Type::Hachi:
+	case CommandingOfficier::Type::Koal:
+	case CommandingOfficier::Type::Sonja:
+		m_nCopStars = 3;
+		m_nScopStars = 2;
+		break;
+	case CommandingOfficier::Type::Hawke:
+		m_nCopStars = 5;
+		m_nScopStars = 4;
+		break;
+	case CommandingOfficier::Type::Jugger:
+	case CommandingOfficier::Type::Olaf:
+		m_nCopStars = 3;
+		m_nScopStars = 4;
+		break;
+	case CommandingOfficier::Type::Kanbei:
+		m_nCopStars = 4;
+		m_nScopStars = 3;
+		break;
+	case CommandingOfficier::Type::Lash:
+		m_nCopStars = 4;
+		m_nScopStars = 3;
+		break;
+	case CommandingOfficier::Type::Sami:
+		m_nCopStars = 3;
+		m_nScopStars = 5;
+		break;
+	case CommandingOfficier::Type::Sasha:
+	case CommandingOfficier::Type::Sensei:
+		m_nCopStars = 2;
+		m_nScopStars = 4;
+		break;
+	case CommandingOfficier::Type::Sturm:
+		m_nCopStars = 5;
+		m_nScopStars = 5;
+		break;
+	case CommandingOfficier::Type::VonBolt:
+		m_nCopStars = 0;
+		m_nScopStars = 10;
+		break;
 	default:
-		throw;
+		throw std::invalid_argument("Unknown commanding officer power meter");
 	}
 }
 
@@ -20,7 +87,7 @@ void PowerMeter::AddCharge(int charge) noexcept {
 }
 
 void PowerMeter::UseScop() noexcept {
-	m_nCharge -= m_nScopStars * m_nStarValue;
+	m_nCharge = 0;
 	IncreaseStarCost();
 }
 
@@ -30,7 +97,7 @@ void PowerMeter::UseCop() noexcept {
 }
 
 void PowerMeter::IncreaseStarCost() noexcept {
-	m_nStarValue = std::min(m_nStarValue * 1.2, 55720.0);
+	m_nStarValue = std::min(static_cast<int>(m_nStarValue * 1.2), 55720);
 }
 
 std::string Player::getArmyTypeJson() const {

--- a/AdvanceWarsServer/test/json/co/adder/contract.json
+++ b/AdvanceWarsServer/test/json/co/adder/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Adder",
+    "power-meter": {
+      "cop-stars": 2,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/andy/contract.json
+++ b/AdvanceWarsServer/test/json/co/andy/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Andy",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          120,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          120,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/colin/contract.json
+++ b/AdvanceWarsServer/test/json/co/colin/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Colin",
+    "power-meter": {
+      "cop-stars": 2,
+      "scop-stars": 4
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/drake/contract.json
+++ b/AdvanceWarsServer/test/json/co/drake/contract.json
@@ -1,0 +1,56 @@
+{
+  "co-contract": {
+    "name": "Drake",
+    "power-meter": {
+      "cop-stars": 4,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "bcopter",
+        "normal": [
+          70,
+          100
+        ],
+        "cop": [
+          80,
+          110
+        ],
+        "scop": [
+          80,
+          110
+        ]
+      },
+      {
+        "unit": "battleship",
+        "normal": [
+          100,
+          110
+        ],
+        "cop": [
+          110,
+          120
+        ],
+        "scop": [
+          110,
+          120
+        ]
+      },
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/eagle/contract.json
+++ b/AdvanceWarsServer/test/json/co/eagle/contract.json
@@ -1,0 +1,56 @@
+{
+  "co-contract": {
+    "name": "Eagle",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 6
+    },
+    "stats": [
+      {
+        "unit": "bcopter",
+        "normal": [
+          115,
+          110
+        ],
+        "cop": [
+          130,
+          130
+        ],
+        "scop": [
+          130,
+          130
+        ]
+      },
+      {
+        "unit": "battleship",
+        "normal": [
+          70,
+          100
+        ],
+        "cop": [
+          80,
+          110
+        ],
+        "scop": [
+          80,
+          110
+        ]
+      },
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/flak/contract.json
+++ b/AdvanceWarsServer/test/json/co/flak/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Flak",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/grimm/contract.json
+++ b/AdvanceWarsServer/test/json/co/grimm/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Grimm",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          130,
+          80
+        ],
+        "cop": [
+          160,
+          90
+        ],
+        "scop": [
+          190,
+          90
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          130,
+          80
+        ],
+        "cop": [
+          160,
+          90
+        ],
+        "scop": [
+          190,
+          90
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/grit/contract.json
+++ b/AdvanceWarsServer/test/json/co/grit/contract.json
@@ -1,0 +1,56 @@
+{
+  "co-contract": {
+    "name": "Grit",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "artillery",
+        "normal": [
+          120,
+          100
+        ],
+        "cop": [
+          150,
+          110
+        ],
+        "scop": [
+          150,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          80,
+          100
+        ],
+        "cop": [
+          90,
+          110
+        ],
+        "scop": [
+          90,
+          110
+        ]
+      },
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/hachi/contract.json
+++ b/AdvanceWarsServer/test/json/co/hachi/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Hachi",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 2
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/hawke/contract.json
+++ b/AdvanceWarsServer/test/json/co/hawke/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Hawke",
+    "power-meter": {
+      "cop-stars": 5,
+      "scop-stars": 4
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/invalid/unknown-co-fails.json
+++ b/AdvanceWarsServer/test/json/co/invalid/unknown-co-fails.json
@@ -1,0 +1,3 @@
+{
+  "invalid-co": "NotACO"
+}

--- a/AdvanceWarsServer/test/json/co/jake/contract.json
+++ b/AdvanceWarsServer/test/json/co/jake/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Jake",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/contract.json
+++ b/AdvanceWarsServer/test/json/co/javier/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Javier",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/jess/contract.json
+++ b/AdvanceWarsServer/test/json/co/jess/contract.json
@@ -1,0 +1,56 @@
+{
+  "co-contract": {
+    "name": "Jess",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "tank",
+        "normal": [
+          110,
+          100
+        ],
+        "cop": [
+          130,
+          110
+        ],
+        "scop": [
+          150,
+          110
+        ]
+      },
+      {
+        "unit": "bcopter",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          100,
+          110
+        ],
+        "scop": [
+          100,
+          110
+        ]
+      },
+      {
+        "unit": "infantry",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          100,
+          110
+        ],
+        "scop": [
+          100,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/jugger/contract.json
+++ b/AdvanceWarsServer/test/json/co/jugger/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Jugger",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 4
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/contract.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Kanbei",
+    "power-meter": {
+      "cop-stars": 4,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          130,
+          130
+        ],
+        "cop": [
+          150,
+          140
+        ],
+        "scop": [
+          150,
+          160
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          130,
+          130
+        ],
+        "cop": [
+          150,
+          140
+        ],
+        "scop": [
+          150,
+          160
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kindle/contract.json
+++ b/AdvanceWarsServer/test/json/co/kindle/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Kindle",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/koal/contract.json
+++ b/AdvanceWarsServer/test/json/co/koal/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Koal",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 2
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/contract.json
+++ b/AdvanceWarsServer/test/json/co/lash/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Lash",
+    "power-meter": {
+      "cop-stars": 4,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/max/contract.json
+++ b/AdvanceWarsServer/test/json/co/max/contract.json
@@ -1,0 +1,56 @@
+{
+  "co-contract": {
+    "name": "Max",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "tank",
+        "normal": [
+          120,
+          100
+        ],
+        "cop": [
+          140,
+          110
+        ],
+        "scop": [
+          160,
+          110
+        ]
+      },
+      {
+        "unit": "artillery",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          100,
+          110
+        ],
+        "scop": [
+          100,
+          110
+        ]
+      },
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/nell/contract.json
+++ b/AdvanceWarsServer/test/json/co/nell/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Nell",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/olaf/contract.json
+++ b/AdvanceWarsServer/test/json/co/olaf/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Olaf",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 4
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/co-power-requires-charge.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/co-power-requires-charge.json
@@ -1,0 +1,51 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "co-power-requires-charge",
+    "map": [
+      [
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 26999,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "co-power"
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/super-co-power-spends-full-meter.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/super-co-power-spends-full-meter.json
@@ -1,0 +1,113 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "super-co-power-spends-full-meter",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "super-co-power-spends-full-meter",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/vonbolt-has-no-co-power.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/vonbolt-has-no-co-power.json
@@ -1,0 +1,51 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "vonbolt-has-no-co-power",
+    "map": [
+      [
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "VonBolt",
+        "funds": 0,
+        "power-meter": {
+          "charge": 90000,
+          "cop-stars": 0,
+          "scop-stars": 10,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "co-power"
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/rachel/contract.json
+++ b/AdvanceWarsServer/test/json/co/rachel/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Rachel",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sami/contract.json
+++ b/AdvanceWarsServer/test/json/co/sami/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Sami",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 5
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          130,
+          100
+        ],
+        "cop": [
+          160,
+          110
+        ],
+        "scop": [
+          180,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          100,
+          110
+        ],
+        "scop": [
+          100,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sasha/contract.json
+++ b/AdvanceWarsServer/test/json/co/sasha/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Sasha",
+    "power-meter": {
+      "cop-stars": 2,
+      "scop-stars": 4
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sensei/contract.json
+++ b/AdvanceWarsServer/test/json/co/sensei/contract.json
@@ -1,0 +1,56 @@
+{
+  "co-contract": {
+    "name": "Sensei",
+    "power-meter": {
+      "cop-stars": 2,
+      "scop-stars": 4
+    },
+    "stats": [
+      {
+        "unit": "bcopter",
+        "normal": [
+          150,
+          100
+        ],
+        "cop": [
+          175,
+          110
+        ],
+        "scop": [
+          175,
+          110
+        ]
+      },
+      {
+        "unit": "infantry",
+        "normal": [
+          140,
+          100
+        ],
+        "cop": [
+          150,
+          110
+        ],
+        "scop": [
+          150,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          90,
+          100
+        ],
+        "cop": [
+          100,
+          110
+        ],
+        "scop": [
+          100,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/contract.json
+++ b/AdvanceWarsServer/test/json/co/sonja/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Sonja",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 2
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          100,
+          100
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          110,
+          110
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sturm/contract.json
+++ b/AdvanceWarsServer/test/json/co/sturm/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "Sturm",
+    "power-meter": {
+      "cop-stars": 5,
+      "scop-stars": 5
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          80,
+          120
+        ],
+        "cop": [
+          90,
+          130
+        ],
+        "scop": [
+          90,
+          130
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          80,
+          120
+        ],
+        "cop": [
+          90,
+          130
+        ],
+        "scop": [
+          90,
+          130
+        ]
+      }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/co/vonbolt/contract.json
+++ b/AdvanceWarsServer/test/json/co/vonbolt/contract.json
@@ -1,0 +1,41 @@
+{
+  "co-contract": {
+    "name": "VonBolt",
+    "power-meter": {
+      "cop-stars": 0,
+      "scop-stars": 10
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [
+          110,
+          110
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          120,
+          120
+        ]
+      },
+      {
+        "unit": "tank",
+        "normal": [
+          110,
+          110
+        ],
+        "cop": [
+          110,
+          110
+        ],
+        "scop": [
+          120,
+          120
+        ]
+      }
+    ]
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -14,14 +14,15 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
-## Intentionally Unsupported
+## Tracked Follow-Up Issues
 
-These AWBW CO effects are not implemented yet. The simulator keeps their chart stat changes where present, but does not model the listed special effects.
+These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- Mass damage, healing, or draining beyond Andy/Jess: Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt.
-- Economy and unit-cost effects: Colin, Hachi, Kanbei, Kindle, and Sasha.
-- Production effects: Hachi city deployment and Sensei unit spawning.
-- Turn and action-state effects: Eagle's extra actions.
-- Fog, vision, hiding, and terrain-defense special effects: Javier, Lash, Sonja vision, and related fog-only behavior.
-- Indirect-range special effects outside the currently implemented Jake helper, including Grit.
-- Capture-specific power behavior beyond chart damage modifiers, including Sami's instant capture behavior.
+- [#20](https://github.com/ryparikh/AdvanceWarsServer/issues/20): weather mechanics and weather-changing CO powers.
+- [#21](https://github.com/ryparikh/AdvanceWarsServer/issues/21): mass damage, healing, and HP-drain CO power effects.
+- [#22](https://github.com/ryparikh/AdvanceWarsServer/issues/22): CO economy and unit-cost effects.
+- [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
+- [#24](https://github.com/ryparikh/AdvanceWarsServer/issues/24): Eagle extra-action CO power behavior.
+- [#25](https://github.com/ryparikh/AdvanceWarsServer/issues/25): fog, vision, hiding, and terrain-defense CO effects.
+- [#26](https://github.com/ryparikh/AdvanceWarsServer/issues/26): remaining indirect-range CO effects.
+- [#27](https://github.com/ryparikh/AdvanceWarsServer/issues/27): capture-specific CO power behavior.

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -1,0 +1,27 @@
+# Commanding Officer Support
+
+The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page](https://awbw.fandom.com/wiki/CO). The simulator currently supports a simplified CO model: JSON identity, power-meter costs, power-status transitions, and the checked-in normal/COP/SCOP damage charts are treated as source-of-truth behavior.
+
+## Supported
+
+- JSON parsing and serialization for every `CommandingOfficier::Type` value.
+- Loud failure for unknown CO strings during JSON parsing.
+- Power-meter star costs for every CO, including Von Bolt's SCOP-only meter.
+- COP and SCOP action charge gates, power-status transitions, star-cost increase, and meter spending.
+- All checked-in normal/COP/SCOP attack and defense chart values.
+- Andy COP/SCOP healing.
+- Jess SCOP resupply.
+- Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
+- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+
+## Intentionally Unsupported
+
+These AWBW CO effects are not implemented yet. The simulator keeps their chart stat changes where present, but does not model the listed special effects.
+
+- Mass damage, healing, or draining beyond Andy/Jess: Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt.
+- Economy and unit-cost effects: Colin, Hachi, Kanbei, Kindle, and Sasha.
+- Production effects: Hachi city deployment and Sensei unit spawning.
+- Turn and action-state effects: Eagle's extra actions.
+- Fog, vision, hiding, and terrain-defense special effects: Javier, Lash, Sonja vision, and related fog-only behavior.
+- Indirect-range special effects outside the currently implemented Jake helper, including Grit.
+- Capture-specific power behavior beyond chart damage modifiers, including Sami's instant capture behavior.


### PR DESCRIPTION
## Summary
- Add JSON parsing/round-trip support for every `CommandingOfficier::Type`, with an exception for unknown CO strings.
- Add power-meter costs for every CO, charge gates for COP/SCOP actions, full SCOP meter spending, and Von Bolt SCOP-only handling.
- Add per-CO JSON contract fixtures plus focused power-action fixtures, and document the current simplified CO support matrix against the AWBW rules reference.
- Move unsupported CO/weather mechanics out of standalone markdown notes and into follow-up issues #20-#27.

## Root Cause
`from_json(CommandingOfficier&)` only mapped Adder and Andy, and `PowerMeter(CommandingOfficier::Type)` only initialized those two COs. Power actions also bypassed charge validation when submitted directly, and SCOP spent only the extra SCOP segment instead of the full meter.

## Tests
- Before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co` failed on non-Andy/Adder CO round-trips, unknown CO handling, undercharged COP, SCOP spending, and Von Bolt COP rejection.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

## Follow-Up Issues
- #20 weather mechanics and weather-changing CO powers
- #21 mass damage, healing, and HP-drain CO power effects
- #22 CO economy and unit-cost effects
- #23 CO production effects
- #24 Eagle extra-action CO power behavior
- #25 fog, vision, hiding, and terrain-defense CO effects
- #26 remaining indirect-range CO effects
- #27 capture-specific CO power behavior

Closes #14