### PR TITLE
Implement weather mechanics

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -180,6 +180,12 @@ public:
 #include <iostream>
 class GameState {
 public:
+	enum class WeatherType {
+		Clear,
+		Rain,
+		Snow,
+	};
+
 	GameState() noexcept;
 	GameState(std::string guid, std::array<Player, 2>&& arrPlayers) noexcept;
 	GameState(const GameState& other) noexcept;
@@ -275,7 +281,7 @@ private:
 	Player& GetEnemyPlayer() noexcept { return m_isFirstPlayerTurn ? m_arrPlayers[1] : m_arrPlayers[0]; }
 	const Player& GetEnemyPlayer() const noexcept { return m_isFirstPlayerTurn ? m_arrPlayers[1] : m_arrPlayers[0]; }
 	const Player& GetCurrentPlayer() const noexcept { return m_isFirstPlayerTurn ? m_arrPlayers[0] : m_arrPlayers[1]; }
-	std::pair<int, int> movementRemainingAfterStep(int x, int y, MovementTypes movementType, int maxMovement, int maxFuel) const noexcept;
+	std::pair<int, int> movementRemainingAfterStep(int x, int y, const Unit& unit, int maxMovement, int maxFuel) const noexcept;
 	Result AddIndirectAttackActions(int x, int y, const Unit& attacker, int minAttackRange, int maxAttackRange, std::vector<Action>& vecActions) const noexcept;
 	bool CanUnitAttack(const Unit& attacker, const Unit& defender) const noexcept;
 	bool FAttackUsesAmmo(const Unit& attacker, const Unit& defender) const noexcept;
@@ -304,6 +310,9 @@ private:
 	int GetMaxBadLuck(const Player& player) noexcept;
 	int RollCombatLuck(int min, int max);
 	int GetCOMovementBonus(const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
+	int GetWeatherMovementCost(const Terrain& terrain, const Player& player, const Unit& unit) const noexcept;
+	void SetTemporaryWeather(WeatherType weather) noexcept;
+	void TickTemporaryWeather() noexcept;
 	void HealUnits(int health);
 	bool FAtUnitCap() const noexcept;
 	bool FPlayerRouted(const Player& player) const noexcept;
@@ -319,5 +328,7 @@ private:
 	int m_winningPlayer = -1;
 	std::optional<std::uint32_t> m_combatRngSeed;
 	std::optional<std::mt19937> m_combatRng;
+	WeatherType m_weather{ WeatherType::Clear };
+	std::optional<int> m_weatherTurnsRemaining;
 };
 

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -5,11 +5,44 @@
 #include <iostream>
 #include <queue>
 #include <random>
+#include <stdexcept>
 
 #include "MapParser.h"
 const std::string mapChoiceFilePath = R"(.\res\AWBW\MapSources\Lefty.txt)";
 
 using time_point = std::chrono::time_point<std::chrono::steady_clock>;
+
+namespace {
+const char* WeatherTypeToString(GameState::WeatherType weather) {
+	switch (weather) {
+	case GameState::WeatherType::Clear:
+		return "clear";
+	case GameState::WeatherType::Rain:
+		return "rain";
+	case GameState::WeatherType::Snow:
+		return "snow";
+	default:
+		return "";
+	}
+}
+
+GameState::WeatherType WeatherTypeFromString(const std::string& weather) {
+	if (weather == "clear") {
+		return GameState::WeatherType::Clear;
+	}
+
+	if (weather == "rain") {
+		return GameState::WeatherType::Rain;
+	}
+
+	if (weather == "snow") {
+		return GameState::WeatherType::Snow;
+	}
+
+	throw std::invalid_argument("Unknown weather: " + weather);
+}
+}
+
 GameState::GameState(std::string guid, std::array<Player, 2>&& arrPlayers) noexcept :
 	m_guid(guid),
 	m_arrPlayers(std::move(arrPlayers)) {
@@ -63,6 +96,8 @@ Result GameState::BeginTurn() noexcept {
 	if (m_isFirstPlayerTurn) {
 		++m_nTurnCount;
 	}
+
+	TickTemporaryWeather();
 
 	GetCurrentPlayer().m_powerStatus = 0;
 
@@ -190,7 +225,7 @@ Result GameState::ResupplyApcUnits(int x, int y) noexcept {
 	return Result::Succeeded;
 }
 
-std::pair<int, int> GameState::movementRemainingAfterStep(int x, int y, MovementTypes movementType, int maxMovement, int maxFuel) const noexcept {
+std::pair<int, int> GameState::movementRemainingAfterStep(int x, int y, const Unit& unit, int maxMovement, int maxFuel) const noexcept {
 	const MapTile* pSearchTile = nullptr;
 	Result result = m_spmap->TryGetTile(x, y, &pSearchTile);
 	if (result == Result::Failed) {
@@ -201,7 +236,7 @@ std::pair<int, int> GameState::movementRemainingAfterStep(int x, int y, Movement
 		return { -1, -1 };
 	}
 
-	int terrainCost = pSearchTile->GetTerrain().m_movementCostMap.find(movementType)->second;
+	int terrainCost = GetWeatherMovementCost(pSearchTile->GetTerrain(), GetCurrentPlayer(), unit);
 	if (terrainCost < 1) {
 		return { -1, -1 };
 	}
@@ -365,6 +400,92 @@ int GameState::GetCOMovementBonus(const CommandingOfficier::Type& co, const Unit
 	}
 }
 
+int GameState::GetWeatherMovementCost(const Terrain& terrain, const Player& player, const Unit& unit) const noexcept {
+	auto iterMovementCost = terrain.m_movementCostMap.find(unit.m_properties.m_movementType);
+	if (iterMovementCost == terrain.m_movementCostMap.end()) {
+		return -1;
+	}
+
+	int baseCost = iterMovementCost->second;
+	if (baseCost < 1 || m_weather == WeatherType::Clear) {
+		return baseCost;
+	}
+
+	WeatherType effectiveWeather = m_weather;
+	if (m_weather == WeatherType::Rain && player.m_co.m_type == CommandingOfficier::Type::Drake) {
+		return baseCost;
+	}
+	else if (m_weather == WeatherType::Rain && player.m_co.m_type == CommandingOfficier::Type::Olaf) {
+		effectiveWeather = WeatherType::Snow;
+	}
+	else if (m_weather == WeatherType::Snow && player.m_co.m_type == CommandingOfficier::Type::Olaf) {
+		return baseCost;
+	}
+
+	if (effectiveWeather == WeatherType::Rain) {
+		if ((unit.m_properties.m_movementType == MovementTypes::Treads ||
+			unit.m_properties.m_movementType == MovementTypes::Tires) &&
+			(terrain.m_type == Terrain::Type::Plain || terrain.m_type == Terrain::Type::Forest)) {
+			return baseCost + 1;
+		}
+
+		return baseCost;
+	}
+
+	if (effectiveWeather == WeatherType::Snow) {
+		if (unit.m_properties.m_type == UnitProperties::Type::Piperunner) {
+			return baseCost;
+		}
+
+		if (unit.m_properties.m_movementType == MovementTypes::Foot &&
+			(terrain.m_type == Terrain::Type::Plain ||
+				terrain.m_type == Terrain::Type::Mountain ||
+				terrain.m_type == Terrain::Type::Forest)) {
+			return baseCost * 2;
+		}
+
+		if (unit.m_properties.m_movementType == MovementTypes::Boots &&
+			terrain.m_type == Terrain::Type::Mountain) {
+			return baseCost * 2;
+		}
+
+		if ((unit.m_properties.m_movementType == MovementTypes::Treads ||
+			unit.m_properties.m_movementType == MovementTypes::Tires) &&
+			terrain.m_type == Terrain::Type::Plain) {
+			return baseCost + 1;
+		}
+
+		if (unit.m_properties.m_movementType == MovementTypes::Air) {
+			return baseCost * 2;
+		}
+
+		if ((unit.m_properties.m_movementType == MovementTypes::Sea ||
+			unit.m_properties.m_movementType == MovementTypes::Lander) &&
+			(terrain.m_type == Terrain::Type::Sea || terrain.m_type == Terrain::Type::Port)) {
+			return baseCost * 2;
+		}
+	}
+
+	return baseCost;
+}
+
+void GameState::SetTemporaryWeather(WeatherType weather) noexcept {
+	m_weather = weather;
+	m_weatherTurnsRemaining = 2;
+}
+
+void GameState::TickTemporaryWeather() noexcept {
+	if (!m_weatherTurnsRemaining.has_value()) {
+		return;
+	}
+
+	--(*m_weatherTurnsRemaining);
+	if (*m_weatherTurnsRemaining <= 0) {
+		m_weather = WeatherType::Clear;
+		m_weatherTurnsRemaining.reset();
+	}
+}
+
 Result GameState::GetValidActions(std::vector<Action>& vecActions) const noexcept {
 	for (int x = 0; x < m_spmap->GetCols(); ++x) {
 		for (int y = 0; y < m_spmap->GetRows(); ++y) {
@@ -408,7 +529,6 @@ int GameState::GetFuelAfterMove(int xSrc, int ySrc, int xDest, int yDest) {
 	const MapTile* pmaptile;
 	m_spmap->TryGetTile(xSrc, ySrc, &pmaptile);
 	const Unit* pUnit = pmaptile->TryGetUnit();
-	MovementTypes movementType = pUnit->m_properties.m_movementType;
 	int maxMovement = pUnit->m_properties.m_movement + GetCOMovementBonus(GetCurrentPlayer().m_co.m_type, *pUnit);
 	std::vector<std::unique_ptr<MoveNode>> vecNodes;
 	vecNodes.emplace_back(new MoveNode(maxMovement, pUnit->m_properties.m_fuel, xSrc, ySrc));
@@ -437,7 +557,7 @@ int GameState::GetFuelAfterMove(int xSrc, int ySrc, int xDest, int yDest) {
 		// TODO: Refactor
 		// Search north
 		if (pTop->m_pnorth == nullptr || pTop->m_pnorth->m_visited == false) {
-			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y - 1, movementType, pTop->m_movement, pTop->m_fuel);
+			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y - 1, *pUnit, pTop->m_movement, pTop->m_fuel);
 			if (movementRemaining >= 0 && fuelRemaining >= 0) {
 				queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_pnorth, movementRemaining, fuelRemaining, pTop->m_x, pTop->m_y - 1));
 			}
@@ -445,21 +565,21 @@ int GameState::GetFuelAfterMove(int xSrc, int ySrc, int xDest, int yDest) {
 
 		// Search east
 		if (pTop->m_peast == nullptr || pTop->m_peast->m_visited == false) {
-			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x + 1, pTop->m_y, movementType, pTop->m_movement, pTop->m_fuel);
+			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x + 1, pTop->m_y, *pUnit, pTop->m_movement, pTop->m_fuel);
 			if (movementRemaining >= 0 && fuelRemaining >= 0) {
 				queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_peast, movementRemaining, fuelRemaining, pTop->m_x + 1, pTop->m_y));
 			}
 		}
 		// Search south 
 		if (pTop->m_psouth == nullptr || pTop->m_psouth->m_visited == false) {
-			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y + 1, movementType, pTop->m_movement, pTop->m_fuel);
+			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y + 1, *pUnit, pTop->m_movement, pTop->m_fuel);
 			if (movementRemaining >= 0 && fuelRemaining >= 0) {
 				queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_psouth, movementRemaining, fuelRemaining, pTop->m_x, pTop->m_y + 1));
 			}
 		}
 		// Search west
 		if (pTop->m_pwest == nullptr || pTop->m_pwest->m_visited == false) {
-			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x - 1, pTop->m_y, movementType, pTop->m_movement, pTop->m_fuel);
+			auto[movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x - 1, pTop->m_y, *pUnit, pTop->m_movement, pTop->m_fuel);
 			if (movementRemaining >= 0 && fuelRemaining >= 0) {
 				queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_pwest, movementRemaining, fuelRemaining, pTop->m_x - 1, pTop->m_y));
 			}
@@ -546,7 +666,6 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 			return Result::Succeeded;
 		}
 
-		MovementTypes movementType = pUnit->m_properties.m_movementType;
 		std::vector<std::pair<int, int>> vecTargets;
 		std::vector<std::unique_ptr<MoveNode>> vecNodes;
 		int maxMovement = pUnit->m_properties.m_movement + GetCOMovementBonus(GetCurrentPlayer().m_co.m_type, *pUnit);
@@ -625,7 +744,7 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 			// TODO: Refactor
 			// Search north
 			if (pTop->m_pnorth == nullptr || pTop->m_pnorth->m_visited == false) {
-				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y - 1, movementType, pTop->m_movement, pTop->m_fuel);
+				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y - 1, *pUnit, pTop->m_movement, pTop->m_fuel);
 				if (movementRemaining >= 0 && fuelRemaining >= 0) {
 					queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_pnorth, movementRemaining, fuelRemaining, pTop->m_x, pTop->m_y - 1));
 				}
@@ -633,21 +752,21 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 
 			// Search east
 			if (pTop->m_peast == nullptr || pTop->m_peast->m_visited == false) {
-				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x + 1, pTop->m_y, movementType, pTop->m_movement, pTop->m_fuel);
+				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x + 1, pTop->m_y, *pUnit, pTop->m_movement, pTop->m_fuel);
 				if (movementRemaining >= 0 && fuelRemaining >= 0) {
 					queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_peast, movementRemaining, fuelRemaining, pTop->m_x + 1, pTop->m_y));
 				}
 			}
 			// Search south 
 			if (pTop->m_psouth == nullptr || pTop->m_psouth->m_visited == false) {
-				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y + 1, movementType, pTop->m_movement, pTop->m_fuel);
+				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x, pTop->m_y + 1, *pUnit, pTop->m_movement, pTop->m_fuel);
 				if (movementRemaining >= 0 && fuelRemaining >= 0) {
 					queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_psouth, movementRemaining, fuelRemaining, pTop->m_x, pTop->m_y + 1));
 				}
 			}
 			// Search west
 			if (pTop->m_pwest == nullptr || pTop->m_pwest->m_visited == false) {
-				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x - 1, pTop->m_y, movementType, pTop->m_movement, pTop->m_fuel);
+				auto [movementRemaining, fuelRemaining] = movementRemainingAfterStep(pTop->m_x - 1, pTop->m_y, *pUnit, pTop->m_movement, pTop->m_fuel);
 				if (movementRemaining >= 0 && fuelRemaining >= 0) {
 					queueMoveNodes.push(AddNewNodeToGraph(vecActions, vecNodes, &pTop->m_pwest, movementRemaining, fuelRemaining, pTop->m_x - 1, pTop->m_y));
 				}
@@ -1511,6 +1630,9 @@ Result GameState::DoCOPowerAction() {
 		case CommandingOfficier::Type::Andy:
 			HealUnits(2);
 			return Result::Succeeded;
+		case CommandingOfficier::Type::Olaf:
+			SetTemporaryWeather(WeatherType::Snow);
+			return Result::Succeeded;
 	}
 	return Result::Succeeded;
 }
@@ -1551,8 +1673,14 @@ Result GameState::DoSCOPowerAction() {
 		case CommandingOfficier::Type::Andy:
 			HealUnits(5);
 			return Result::Succeeded;
+		case CommandingOfficier::Type::Drake:
+			SetTemporaryWeather(WeatherType::Rain);
+			return Result::Succeeded;
 		case CommandingOfficier::Type::Jess:
 			IfFailedReturn(ResupplyPlayersUnits(&GetCurrentPlayer()));
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Olaf:
+			SetTemporaryWeather(WeatherType::Snow);
 			return Result::Succeeded;
 	}
 	return Result::Succeeded;
@@ -1646,6 +1774,8 @@ GameState::GameState(const GameState& other) noexcept :
 	m_winningPlayer = other.m_winningPlayer;
 	m_combatRngSeed = other.m_combatRngSeed;
 	m_combatRng = other.m_combatRng;
+	m_weather = other.m_weather;
+	m_weatherTurnsRemaining = other.m_weatherTurnsRemaining;
 }
 
 GameState GameState::Clone() {
@@ -1669,6 +1799,8 @@ GameState& GameState::operator=(const GameState& other) noexcept {
 		m_winningPlayer = other.m_winningPlayer;
 		m_combatRngSeed = other.m_combatRngSeed;
 		m_combatRng = other.m_combatRng;
+		m_weather = other.m_weather;
+		m_weatherTurnsRemaining = other.m_weatherTurnsRemaining;
 	}
 	return *this;
 }
@@ -1688,6 +1820,14 @@ void GameState::to_json(json& j, const GameState& gameState) {
 
 	if (gameState.m_combatRngSeed.has_value()) {
 		j["combat-rng-seed"] = gameState.m_combatRngSeed.value();
+	}
+
+	if (gameState.m_weather != WeatherType::Clear) {
+		j["weather"] = WeatherTypeToString(gameState.m_weather);
+	}
+
+	if (gameState.m_weatherTurnsRemaining.has_value()) {
+		j["weather-turns-remaining"] = gameState.m_weatherTurnsRemaining.value();
 	}
 }
 
@@ -1846,5 +1986,29 @@ void GameState::from_json(json& j, GameState& gameState) {
 	}
 	else {
 		gameState.ClearCombatRngSeed();
+	}
+
+	if (j.contains("weather")) {
+		std::string weather;
+		j.at("weather").get_to(weather);
+		gameState.m_weather = WeatherTypeFromString(weather);
+	}
+	else {
+		gameState.m_weather = WeatherType::Clear;
+	}
+
+	if (j.contains("weather-turns-remaining")) {
+		int weatherTurnsRemaining;
+		j.at("weather-turns-remaining").get_to(weatherTurnsRemaining);
+		if (weatherTurnsRemaining > 0) {
+			gameState.m_weatherTurnsRemaining = weatherTurnsRemaining;
+		}
+		else {
+			gameState.m_weatherTurnsRemaining.reset();
+			gameState.m_weather = WeatherType::Clear;
+		}
+	}
+	else {
+		gameState.m_weatherTurnsRemaining.reset();
 	}
 }

--- a/AdvanceWarsServer/test/json/weather/drake-scop-creates-rain.json
+++ b/AdvanceWarsServer/test/json/weather/drake-scop-creates-rain.json
@@ -1,0 +1,97 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "drake-scop-creates-rain",
+    "map": [
+      [
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Drake",
+        "funds": 0,
+        "power-meter": {
+          "charge": 63000,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "drake-scop-creates-rain",
+    "map": [
+      [
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Drake",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "weather-turns-remaining": 2,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/weather/olaf-cop-creates-snow.json
+++ b/AdvanceWarsServer/test/json/weather/olaf-cop-creates-snow.json
@@ -1,0 +1,97 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "olaf-cop-creates-snow",
+    "map": [
+      [
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Olaf",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "olaf-cop-creates-snow",
+    "map": [
+      [
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Olaf",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "snow",
+    "weather-turns-remaining": 2,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/weather/rain-increases-tread-fuel-cost.json
+++ b/AdvanceWarsServer/test/json/weather/rain-increases-tread-fuel-cost.json
@@ -1,0 +1,129 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rain-increases-tread-fuel-cost",
+    "map": [
+      [
+        {
+          "terrain": 1,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-wait",
+      "source": [
+        0,
+        0
+      ],
+      "target": [
+        1,
+        0
+      ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rain-increases-tread-fuel-cost",
+    "map": [
+      [
+        {
+          "terrain": 1
+        },
+        {
+          "terrain": 1,
+          "unit": {
+            "ammo": 0,
+            "fuel": 7,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/weather/temporary-weather-expires-on-begin-turn.json
+++ b/AdvanceWarsServer/test/json/weather/temporary-weather-expires-on-begin-turn.json
@@ -1,0 +1,97 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "temporary-weather-expires-on-begin-turn",
+    "map": [
+      [
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "weather-turns-remaining": 1,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "temporary-weather-expires-on-begin-turn",
+    "map": [
+      [
+        {
+          "terrain": 1
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -11,14 +11,20 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - All checked-in normal/COP/SCOP attack and defense chart values.
 - Andy COP/SCOP healing.
 - Jess SCOP resupply.
+- Active weather JSON parsing/serialization, weather movement/fuel costs, and Drake/Olaf weather-changing powers.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+
+## Weather Notes
+
+- Weather JSON uses `"weather": "rain"` or `"weather": "snow"`. CO-created weather also writes `"weather-turns-remaining"` and expires on a later `BeginTurn`.
+- Rain and snow movement costs follow the AWBW weather tables, including Drake rain immunity, Olaf snow immunity, and Olaf treating rain like snow.
+- Rain vision penalties are intentionally deferred because this simulator does not yet have fog-of-war or vision state; that broader subsystem is tracked by #25.
 
 ## Tracked Follow-Up Issues
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#20](https://github.com/ryparikh/AdvanceWarsServer/issues/20): weather mechanics and weather-changing CO powers.
 - [#21](https://github.com/ryparikh/AdvanceWarsServer/issues/21): mass damage, healing, and HP-drain CO power effects.
 - [#22](https://github.com/ryparikh/AdvanceWarsServer/issues/22): CO economy and unit-cost effects.
 - [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.


### PR DESCRIPTION
## Summary
- Add active weather state to `GameState` with JSON parsing/serialization and temporary weather duration support.
- Apply AWBW rain/snow movement costs to legal movement and fuel spent while moving, including Drake/Olaf weather immunity behavior.
- Wire Drake SCOP to rain and Olaf COP/SCOP to snow, with JSON regression coverage for movement, powers, and expiry.
- Document the implemented weather contract and the intentional fog/vision deferral.

## Why
Issue #20 noted that weather existed only as names/docs, not as active gameplay behavior. AWBW weather changes terrain movement costs and can be created by Drake/Olaf powers; this now lives in game state and affects move generation/fuel.

## Tests
- Added `test/json/weather/rain-increases-tread-fuel-cost.json`; it initially failed because rain still charged the clear-weather tank movement cost.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/weather`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `git diff --check`

## Notes / Risk
- Rain vision penalties are intentionally deferred because this simulator does not yet model fog-of-war or unit vision state; that larger subsystem is already tracked by #25.
- Random/default lobby weather is not implemented here; JSON can set persistent active rain/snow, and CO powers create expiring weather.

Closes #20