### PR TITLE
Add airport and port capture/production tests

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -326,6 +326,7 @@
     <None Include="test\json\captures\infantry100FlipNeutralBase.json" />
     <None Include="test\json\captures\infantry100FlipNeutralCity.json" />
     <None Include="test\json\captures\infantry100FlipNeutralPort.json" />
+    <None Include="test\json\captures\airport-port-capture-progress-and-transfer.json" />
     <None Include="test\json\captures\infantry44CaptureNeutralCity20.json" />
     <None Include="test\json\captures\infantry91CaptureNeutralCity15.json" />
     <None Include="test\json\joining\basic-supply.json" />
@@ -346,6 +347,8 @@
     <None Include="test\json\misc\end-game-rout-direct-attack.json" />
     <None Include="test\json\misc\end-game-rout-indirect-attack.json" />
     <None Include="test\json\misc\end-game-rout-no-gas-unit.json" />
+    <None Include="test\json\production\airport-port-buy-actions.json" />
+    <None Include="test\json\production\airport-port-valid-actions.json" />
     <None Include="test\json\transport\apc\load-infantry.json" />
     <None Include="test\json\transport\apc\load-mech.json" />
     <None Include="test\json\transport\apc\load-multiple-infantry-fails.json" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -289,6 +289,7 @@
     <None Include="test\json\captures\infantry100FlipNeutralPort.json" />
     <None Include="test\json\captures\infantry100FlipNeutralComTower.json" />
     <None Include="test\json\captures\infantry100FlipNeutralLab.json" />
+    <None Include="test\json\captures\airport-port-capture-progress-and-transfer.json" />
     <None Include="test\json\joining\full-health-join-hurt.json" />
     <None Include="test\json\joining\hurt-join-full-health-fail.json" />
     <None Include="test\json\joining\basic-supply.json" />
@@ -312,5 +313,7 @@
     <None Include="test\json\combat\infantry\road\road\infantryRoad0-infantryRoad0-enemycopower.json" />
     <None Include="test\json\misc\begin-turn-no-repair-enemy-property.json" />
     <None Include="test\json\combat\infantry\forest\city\infantry-infantry.json" />
+    <None Include="test\json\production\airport-port-buy-actions.json" />
+    <None Include="test\json\production\airport-port-valid-actions.json" />
   </ItemGroup>
 </Project>

--- a/AdvanceWarsServer/inc/SubsystemTest.h
+++ b/AdvanceWarsServer/inc/SubsystemTest.h
@@ -9,6 +9,7 @@ struct JsonSubsystemTest {
 	GameState finalGameState;
 	std::vector<Action> vecActions;
 	std::vector<Action> vecFailedActions;
+	std::vector<std::pair<std::pair<int, int>, std::vector<Action>>> vecValidActions;
 	bool fHasFinalGameState{ false };
 	bool fDeterministicReplay{ false };
 };

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -787,7 +787,7 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 		case Terrain::Type::Airport:
 			for (auto unit : vrgUnits) {
 				int funds = GetCurrentPlayer().m_funds;
-				if (unit.m_type != UnitProperties::Type::BlackBomb && unit.m_movementType == MovementTypes::Air && Unit::GetUnitCost(unit.m_type) * 10 <= funds) {
+				if (unit.m_movementType == MovementTypes::Air && Unit::GetUnitCost(unit.m_type) * 10 <= funds) {
 					vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
 				}
 			}

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -138,6 +138,22 @@ void from_json(json& j, JsonSubsystemTest& test) {
 		}
 	}
 
+	if (j.contains("validActions")) {
+		for (auto& jValidActions : j.at("validActions")) {
+			std::pair<int, int> source;
+			jValidActions.at("source").get_to(source);
+
+			std::vector<Action> actions;
+			for (auto& jAction : jValidActions.at("expected")) {
+				Action action;
+				from_json(jAction, action);
+				actions.emplace_back(action);
+			}
+
+			test.vecValidActions.emplace_back(std::move(source), std::move(actions));
+		}
+	}
+
 	if (j.contains("deterministic-replay")) {
 		j.at("deterministic-replay").get_to(test.fDeterministicReplay);
 	}
@@ -210,6 +226,33 @@ Result JsonTestRunner::run() {
 	if (!test.vecFailedActions.empty()) {
 		for (const Action& action : test.vecFailedActions) {
 			if (test.initialGameState.DoAction(action) == Result::Succeeded) {
+				return Result::Failed;
+			}
+		}
+	}
+
+	if (!test.vecValidActions.empty()) {
+		for (const auto& validActions : test.vecValidActions) {
+			std::vector<Action> actualActions;
+			IfFailedReturn(test.initialGameState.GetValidActions(validActions.first.first, validActions.first.second, actualActions));
+
+			json expectedActions = json::array();
+			for (const Action& action : validActions.second) {
+				json jAction;
+				to_json(jAction, action);
+				expectedActions.push_back(std::move(jAction));
+			}
+
+			json actualActionsJson = json::array();
+			for (const Action& action : actualActions) {
+				json jAction;
+				to_json(jAction, action);
+				actualActionsJson.push_back(std::move(jAction));
+			}
+
+			m_strExpected = expectedActions.dump();
+			m_strActual = actualActionsJson.dump();
+			if (m_strActual != m_strExpected) {
 				return Result::Failed;
 			}
 		}

--- a/AdvanceWarsServer/test/json/captures/airport-port-capture-progress-and-transfer.json
+++ b/AdvanceWarsServer/test/json/captures/airport-port-capture-progress-and-transfer.json
@@ -1,0 +1,234 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "airport-port-capture-progress-and-transfer",
+    "map": [
+      [
+        {
+          "terrain": 36,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 91,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 37,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 44,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 36,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "blue-moon"
+          }
+        },
+        {
+          "terrain": 37,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "blue-moon"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 0, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 2, 0 ],
+      "target": [ 2, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 3, 0 ],
+      "target": [ 3, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "airport-port-capture-progress-and-transfer",
+    "map": [
+      [
+        {
+          "terrain": 36,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 91,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 37,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 44,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 15,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 36,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "terrain": 37,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/production/airport-port-buy-actions.json
+++ b/AdvanceWarsServer/test/json/production/airport-port-buy-actions.json
@@ -1,0 +1,142 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "airport-port-buy-actions",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 36
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 37
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 100000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "blackbomb"
+    },
+    {
+      "type": "buy",
+      "source": [ 1, 0 ],
+      "unit": "carrier"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "airport-port-buy-actions",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 36,
+          "unit": {
+            "ammo": 0,
+            "fuel": 45,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "blackbomb"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 37,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 45000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/production/airport-port-valid-actions.json
+++ b/AdvanceWarsServer/test/json/production/airport-port-valid-actions.json
@@ -1,0 +1,255 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "airport-port-valid-actions",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 36
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 37
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 36
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 36
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 36,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 37
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 37
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 37,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 300000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": [
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "bcopter"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "blackbomb"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "bomber"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "fighter"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "stealth"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "tcopter"
+        }
+      ]
+    },
+    {
+      "source": [ 1, 0 ],
+      "expected": [
+        {
+          "type": "buy",
+          "source": [ 1, 0 ],
+          "unit": "battleship"
+        },
+        {
+          "type": "buy",
+          "source": [ 1, 0 ],
+          "unit": "blackboat"
+        },
+        {
+          "type": "buy",
+          "source": [ 1, 0 ],
+          "unit": "carrier"
+        },
+        {
+          "type": "buy",
+          "source": [ 1, 0 ],
+          "unit": "crusier"
+        },
+        {
+          "type": "buy",
+          "source": [ 1, 0 ],
+          "unit": "lander"
+        },
+        {
+          "type": "buy",
+          "source": [ 1, 0 ],
+          "unit": "sub"
+        }
+      ]
+    },
+    {
+      "source": [ 2, 0 ],
+      "expected": []
+    },
+    {
+      "source": [ 3, 0 ],
+      "expected": []
+    },
+    {
+      "source": [ 4, 0 ],
+      "expected": []
+    },
+    {
+      "source": [ 5, 0 ],
+      "expected": []
+    },
+    {
+      "source": [ 6, 0 ],
+      "expected": []
+    },
+    {
+      "source": [ 7, 0 ],
+      "expected": []
+    }
+  ],
+  "failedActions": [
+    {
+      "type": "buy",
+      "source": [ 2, 0 ],
+      "unit": "bcopter"
+    },
+    {
+      "type": "buy",
+      "source": [ 3, 0 ],
+      "unit": "bcopter"
+    },
+    {
+      "type": "buy",
+      "source": [ 4, 0 ],
+      "unit": "bcopter"
+    },
+    {
+      "type": "buy",
+      "source": [ 5, 0 ],
+      "unit": "battleship"
+    },
+    {
+      "type": "buy",
+      "source": [ 6, 0 ],
+      "unit": "battleship"
+    },
+    {
+      "type": "buy",
+      "source": [ 7, 0 ],
+      "unit": "battleship"
+    },
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "lander"
+    },
+    {
+      "type": "buy",
+      "source": [ 1, 0 ],
+      "unit": "bcopter"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add JSON coverage for airport/port capture progress and ownership transfer.
- Add production fixtures for owned airport/port buys, exact legal airport/port rosters, and blocked production on neutral, enemy, and occupied properties.
- Extend the JSON subsystem runner with `validActions` expectations for tile-specific legal action assertions.

## Root Cause
Airport and port capture behavior had some existing coverage, but there was no fixture-level way to assert exact legal production rosters. While adding that coverage against the AWBW wiki roster, airport valid actions were missing Black Bomb even though AWBW lists it as an Airport-produced air unit.

## Tests
- First focused run before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/production` failed because `blackbomb` was missing from airport valid actions and direct Black Bomb buy was rejected.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/production`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/captures`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`

## Risk
Low. The production behavior change is limited to allowing Black Bomb in airport-generated buy actions; `DoBuyAction` already treats Black Bomb as an air unit.

Closes #45