### PR TITLE
Implement CO power HP effects

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -275,6 +275,14 @@ public:
 	static void to_json(json& j, const GameState& gameState);
 	static void from_json(json& j, GameState& gameState);
 private:
+	enum class MissileTargetingMode {
+		RachelInfantry,
+		RachelCost,
+		RachelHp,
+		Sturm,
+		VonBolt,
+	};
+
 	Result BeginTurn() noexcept;
 	Result ResupplyApcUnits(int x, int y) noexcept;
 	Player& GetCurrentPlayer() noexcept { return m_isFirstPlayerTurn ? m_arrPlayers[0] : m_arrPlayers[1]; }
@@ -313,7 +321,14 @@ private:
 	int GetWeatherMovementCost(const Terrain& terrain, const Player& player, const Unit& unit) const noexcept;
 	void SetTemporaryWeather(WeatherType weather) noexcept;
 	void TickTemporaryWeather() noexcept;
-	void HealUnits(int health);
+	void HealUnits(const Player& player, int health);
+	void DamageUnits(const Player& player, int health, bool halveFuel = false);
+	void DamageUnitsOnUrbanTerrain(const Player& player, int health);
+	std::optional<std::pair<int, int>> FindMissileTarget(MissileTargetingMode mode) const noexcept;
+	void ApplyAreaDamage(const Player& player, int centerX, int centerY, int health, bool stun);
+	void ApplyRachelCoveringFire();
+	void ApplySturmMeteor(int health);
+	void ApplyVonBoltExMachina();
 	bool FAtUnitCap() const noexcept;
 	bool FPlayerRouted(const Player& player) const noexcept;
 private:

--- a/AdvanceWarsServer/inc/Unit.h
+++ b/AdvanceWarsServer/inc/Unit.h
@@ -108,6 +108,7 @@ public:
 	int health = 100;
 	bool m_moved = false;
 	bool m_hidden = false;
+	bool m_stunned = false;
 	std::vector<Unit*> m_vecLanderUnits;
 };
 

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -2,7 +2,9 @@
 #include "UnitInfo.h"
 
 #include <chrono>
+#include <algorithm>
 #include <iostream>
+#include <limits>
 #include <queue>
 #include <random>
 #include <stdexcept>
@@ -40,6 +42,30 @@ GameState::WeatherType WeatherTypeFromString(const std::string& weather) {
 	}
 
 	throw std::invalid_argument("Unknown weather: " + weather);
+}
+
+int ManhattanDistance(int x1, int y1, int x2, int y2) noexcept {
+	return std::abs(x1 - x2) + std::abs(y1 - y2);
+}
+
+bool TopLeftComesFirst(int x, int y, int otherX, int otherY) noexcept {
+	return y < otherY || (y == otherY && x < otherX);
+}
+
+int DamageValueForRachelMissile(const Unit& unit) noexcept {
+	if (unit.health < 10) {
+		return 1;
+	}
+
+	return std::min(unit.health, 30);
+}
+
+int DamageValueForVonBoltMissile(const Unit& unit) noexcept {
+	if (unit.health > 30) {
+		return 30;
+	}
+
+	return std::max(0, ((unit.health + 9) / 10 - 1) * 10);
 }
 }
 
@@ -189,7 +215,13 @@ Result GameState::BeginTurn() noexcept {
 			Unit* pUnit = pTile->m_spUnit.get();
 			if (pUnit != nullptr &&
 				pUnit->m_owner == &GetCurrentPlayer()) {
-				pUnit->m_moved = false;
+				if (pUnit->m_stunned) {
+					pUnit->m_moved = true;
+					pUnit->m_stunned = false;
+				}
+				else {
+					pUnit->m_moved = false;
+				}
 			}
 		}
 	}
@@ -1604,16 +1636,208 @@ Result GameState::DoMoveAction(int& x, int& y, const Action& action) {
 	return Result::Succeeded;
 }
 
-void GameState::HealUnits(int health) {
+void GameState::HealUnits(const Player& player, int health) {
 	for (int x = 0; x < m_spmap->GetCols(); ++x) {
 		for (int y = 0; y < m_spmap->GetRows(); ++y) {
 			MapTile* pTile = nullptr;
 			m_spmap->TryGetTile(x, y, &pTile);
 			Unit* punit = pTile->TryGetUnit();
-			if (punit != nullptr && punit->m_owner == &GetCurrentPlayer()) {
+			if (punit != nullptr && punit->m_owner == &player) {
 				punit->health = std::min(punit->health + health * 10, 100);
 			}
 		}
+	}
+}
+
+void GameState::DamageUnits(const Player& player, int health, bool halveFuel) {
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			MapTile* pTile = nullptr;
+			m_spmap->TryGetTile(x, y, &pTile);
+			Unit* punit = pTile->TryGetUnit();
+			if (punit != nullptr && punit->m_owner == &player) {
+				punit->health = std::max(punit->health - health * 10, 1);
+				if (halveFuel) {
+					punit->m_properties.m_fuel /= 2;
+				}
+			}
+		}
+	}
+}
+
+void GameState::DamageUnitsOnUrbanTerrain(const Player& player, int health) {
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			MapTile* pTile = nullptr;
+			m_spmap->TryGetTile(x, y, &pTile);
+			Unit* punit = pTile->TryGetUnit();
+			if (punit != nullptr && punit->m_owner == &player && MapTile::IsProperty(pTile->GetTerrain().m_type)) {
+				punit->health = std::max(punit->health - health * 10, 1);
+			}
+		}
+	}
+}
+
+std::optional<std::pair<int, int>> GameState::FindMissileTarget(MissileTargetingMode mode) const noexcept {
+	struct Candidate {
+		bool found = false;
+		int x = 0;
+		int y = 0;
+		int value = std::numeric_limits<int>::min();
+		int tieValue = std::numeric_limits<int>::min();
+	};
+
+	Candidate best;
+	const Player& currentPlayer = GetCurrentPlayer();
+	const Player& enemyPlayer = GetEnemyPlayer();
+
+	auto unitValue = [&](const Unit& unit, const MapTile& tile) -> int {
+		switch (mode) {
+		case MissileTargetingMode::RachelInfantry: {
+			int value = DamageValueForRachelMissile(unit);
+			if (unit.IsFootsoldier() && unit.health > 10) {
+				value *= 4;
+				if (tile.m_spPropertyInfo != nullptr && tile.m_spPropertyInfo->m_capturePoints < 20) {
+					value *= 2;
+				}
+			}
+			return value;
+		}
+		case MissileTargetingMode::RachelCost:
+			if (unit.health < 10) {
+				return 2;
+			}
+			return DamageValueForRachelMissile(unit) * Unit::GetUnitCost(unit.m_properties.m_type);
+		case MissileTargetingMode::RachelHp:
+			return DamageValueForRachelMissile(unit);
+		case MissileTargetingMode::Sturm:
+			return unit.health * Unit::GetUnitCost(unit.m_properties.m_type);
+		case MissileTargetingMode::VonBolt:
+			return DamageValueForVonBoltMissile(unit) * Unit::GetUnitCost(unit.m_properties.m_type);
+		default:
+			return 0;
+		}
+	};
+
+	auto tieValue = [&](const Unit& unit) -> int {
+		switch (mode) {
+		case MissileTargetingMode::RachelHp:
+			return unit.health;
+		case MissileTargetingMode::RachelCost:
+		case MissileTargetingMode::VonBolt:
+			return unit.health * Unit::GetUnitCost(unit.m_properties.m_type);
+		default:
+			return 0;
+		}
+	};
+
+	for (int centerX = 0; centerX < m_spmap->GetCols(); ++centerX) {
+		for (int centerY = 0; centerY < m_spmap->GetRows(); ++centerY) {
+			if (mode == MissileTargetingMode::Sturm) {
+				const MapTile* pCenterTile = nullptr;
+				m_spmap->TryGetTile(centerX, centerY, &pCenterTile);
+				const Unit* pCenterUnit = pCenterTile->TryGetUnit();
+				if (pCenterUnit == nullptr || pCenterUnit->m_owner != &enemyPlayer) {
+					continue;
+				}
+			}
+
+			bool hitsEnemy = false;
+			int totalValue = 0;
+			int totalTieValue = 0;
+			for (int x = 0; x < m_spmap->GetCols(); ++x) {
+				for (int y = 0; y < m_spmap->GetRows(); ++y) {
+					if (ManhattanDistance(centerX, centerY, x, y) > 2) {
+						continue;
+					}
+
+					const MapTile* pTile = nullptr;
+					m_spmap->TryGetTile(x, y, &pTile);
+					const Unit* pUnit = pTile->TryGetUnit();
+					if (pUnit == nullptr) {
+						continue;
+					}
+
+					const bool friendly = pUnit->m_owner == &currentPlayer;
+					int value = unitValue(*pUnit, *pTile);
+					totalValue += friendly ? -value : value;
+					if (pUnit->m_owner == &enemyPlayer) {
+						hitsEnemy = true;
+						totalTieValue += tieValue(*pUnit);
+					}
+				}
+			}
+
+			if (!hitsEnemy) {
+				continue;
+			}
+
+			if (!best.found ||
+				totalValue > best.value ||
+				(totalValue == best.value && totalTieValue > best.tieValue) ||
+				(totalValue == best.value && totalTieValue == best.tieValue && TopLeftComesFirst(centerX, centerY, best.x, best.y))) {
+				best = { true, centerX, centerY, totalValue, totalTieValue };
+			}
+		}
+	}
+
+	if (!best.found) {
+		return std::nullopt;
+	}
+
+	return std::make_pair(best.x, best.y);
+}
+
+void GameState::ApplyAreaDamage(const Player& player, int centerX, int centerY, int health, bool stun) {
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			if (ManhattanDistance(centerX, centerY, x, y) > 2) {
+				continue;
+			}
+
+			MapTile* pTile = nullptr;
+			m_spmap->TryGetTile(x, y, &pTile);
+			Unit* punit = pTile->TryGetUnit();
+			if (punit != nullptr && punit->m_owner == &player) {
+				punit->health = std::max(punit->health - health * 10, 1);
+				if (stun) {
+					punit->m_stunned = true;
+				}
+			}
+		}
+	}
+}
+
+void GameState::ApplyRachelCoveringFire() {
+	const std::array<MissileTargetingMode, 3> modes = {
+		MissileTargetingMode::RachelInfantry,
+		MissileTargetingMode::RachelCost,
+		MissileTargetingMode::RachelHp,
+	};
+
+	std::array<std::optional<std::pair<int, int>>, 3> targets;
+	for (std::size_t i = 0; i < modes.size(); ++i) {
+		targets[i] = FindMissileTarget(modes[i]);
+	}
+
+	for (const auto& target : targets) {
+		if (target.has_value()) {
+			ApplyAreaDamage(GetEnemyPlayer(), target->first, target->second, 3, false);
+		}
+	}
+}
+
+void GameState::ApplySturmMeteor(int health) {
+	const auto target = FindMissileTarget(MissileTargetingMode::Sturm);
+	if (target.has_value()) {
+		ApplyAreaDamage(GetEnemyPlayer(), target->first, target->second, health, false);
+	}
+}
+
+void GameState::ApplyVonBoltExMachina() {
+	const auto target = FindMissileTarget(MissileTargetingMode::VonBolt);
+	if (target.has_value()) {
+		ApplyAreaDamage(GetEnemyPlayer(), target->first, target->second, 3, true);
 	}
 }
 
@@ -1628,10 +1852,23 @@ Result GameState::DoCOPowerAction() {
 	currentPlayer.m_powerMeter.UseCop();
 	switch (type) {
 		case CommandingOfficier::Type::Andy:
-			HealUnits(2);
+			HealUnits(currentPlayer, 2);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Drake:
+			DamageUnits(GetEnemyPlayer(), 1, true);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Hawke:
+			HealUnits(currentPlayer, 1);
+			DamageUnits(GetEnemyPlayer(), 1);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Kindle:
+			DamageUnitsOnUrbanTerrain(GetEnemyPlayer(), 3);
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Olaf:
 			SetTemporaryWeather(WeatherType::Snow);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Sturm:
+			ApplySturmMeteor(4);
 			return Result::Succeeded;
 	}
 	return Result::Succeeded;
@@ -1671,16 +1908,31 @@ Result GameState::DoSCOPowerAction() {
 	currentPlayer.m_powerMeter.UseScop();
 	switch (type) {
 		case CommandingOfficier::Type::Andy:
-			HealUnits(5);
+			HealUnits(currentPlayer, 5);
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Drake:
+			DamageUnits(GetEnemyPlayer(), 2, true);
 			SetTemporaryWeather(WeatherType::Rain);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Hawke:
+			HealUnits(currentPlayer, 2);
+			DamageUnits(GetEnemyPlayer(), 2);
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Jess:
 			IfFailedReturn(ResupplyPlayersUnits(&GetCurrentPlayer()));
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Olaf:
+			DamageUnits(GetEnemyPlayer(), 2);
 			SetTemporaryWeather(WeatherType::Snow);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Rachel:
+			ApplyRachelCoveringFire();
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Sturm:
+			ApplySturmMeteor(8);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::VonBolt:
+			ApplyVonBoltExMachina();
 			return Result::Succeeded;
 	}
 	return Result::Succeeded;

--- a/AdvanceWarsServer/src/Unit.cpp
+++ b/AdvanceWarsServer/src/Unit.cpp
@@ -69,6 +69,7 @@ Unit* Unit::Clone(const Player* pNewOwner) const {
 	spClone->health = health;
 	spClone->m_moved = m_moved;
 	spClone->m_hidden = m_hidden;
+	spClone->m_stunned = m_stunned;
 	for (const Unit* pLoadedUnit : m_vecLanderUnits) {
 		spClone->m_vecLanderUnits.emplace_back(pLoadedUnit->Clone(pNewOwner));
 	}
@@ -411,6 +412,9 @@ void to_json(json& j, const Unit& unit) {
 	j["health"] = unit.health;
 	j["moved"] = unit.m_moved;
 	j["hidden"] = unit.m_hidden;
+	if (unit.m_stunned) {
+		j["stunned"] = unit.m_stunned;
+	}
 	if (unit.m_vecLanderUnits.size() == 1) {
 		json loadedUnit;
 		to_json(loadedUnit, *unit.m_vecLanderUnits[0]);
@@ -440,6 +444,9 @@ void from_json(const std::array<Player, 2>& arrPlayers, json& j, Unit& unit) {
 
 	j.at("moved").get_to(unit.m_moved);
 	j.at("hidden").get_to(unit.m_hidden);
+	if (j.contains("stunned")) {
+		j.at("stunned").get_to(unit.m_stunned);
+	}
 
 	if (j.contains("loaded-units")) {
 		for (auto& jUnit : j.at("loaded-units")) {

--- a/AdvanceWarsServer/test/json/co/power-actions/drake-cop-tsunami-damages-enemies-and-halves-fuel.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/drake-cop-tsunami-damages-enemies-and-halves-fuel.json
@@ -1,0 +1,137 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "drake-cop-tsunami-damages-enemies-and-halves-fuel",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 15,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Drake",
+        "funds": 0,
+        "power-meter": {
+          "charge": 36000,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "drake-cop-tsunami-damages-enemies-and-halves-fuel",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 49,
+            "health": 5,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Drake",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/drake-scop-typhoon-damages-enemies-halves-fuel-and-rain.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/drake-scop-typhoon-damages-enemies-halves-fuel-and-rain.json
@@ -1,0 +1,139 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "drake-scop-typhoon-damages-enemies-halves-fuel-and-rain",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 41,
+            "health": 15,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Drake",
+        "funds": 0,
+        "power-meter": {
+          "charge": 63000,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "drake-scop-typhoon-damages-enemies-halves-fuel-and-rain",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 20,
+            "health": 1,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Drake",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "weather-turns-remaining": 2,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/hawke-cop-black-wave-drains-enemies-and-heals-allies.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/hawke-cop-black-wave-drains-enemies-and-heals-allies.json
@@ -1,0 +1,137 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hawke-cop-black-wave-drains-enemies-and-heals-allies",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 95,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 8,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hawke",
+        "funds": 0,
+        "power-meter": {
+          "charge": 45000,
+          "cop-stars": 5,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hawke-cop-black-wave-drains-enemies-and-heals-allies",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hawke",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 5,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/hawke-scop-black-storm-drains-enemies-and-heals-allies.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/hawke-scop-black-storm-drains-enemies-and-heals-allies.json
@@ -1,0 +1,137 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hawke-scop-black-storm-drains-enemies-and-heals-allies",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 85,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 15,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hawke",
+        "funds": 0,
+        "power-meter": {
+          "charge": 81000,
+          "cop-stars": 5,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hawke-scop-black-storm-drains-enemies-and-heals-allies",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hawke",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 5,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/kindle-cop-urban-blight-damages-enemies-on-properties.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/kindle-cop-urban-blight-damages-enemies-on-properties.json
@@ -1,0 +1,177 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kindle-cop-urban-blight-damages-enemies-on-properties",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kindle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kindle-cop-urban-blight-damages-enemies-on-properties",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 5,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kindle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/kindle-scop-high-society-does-not-apply-urban-blight-damage.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/kindle-scop-high-society-does-not-apply-urban-blight-damage.json
@@ -1,0 +1,153 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kindle-scop-high-society-does-not-apply-urban-blight-damage",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 43,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kindle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kindle-scop-high-society-does-not-apply-urban-blight-damage",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 43,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 35,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kindle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/olaf-scop-winter-fury-damages-enemies-and-snow.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/olaf-scop-winter-fury-damages-enemies-and-snow.json
@@ -1,0 +1,139 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "olaf-scop-winter-fury-damages-enemies-and-snow",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 15,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Olaf",
+        "funds": 0,
+        "power-meter": {
+          "charge": 63000,
+          "cop-stars": 3,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "olaf-scop-winter-fury-damages-enemies-and-snow",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 50,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Olaf",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "snow",
+    "weather-turns-remaining": 2,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/rachel-scop-covering-fire-damages-enemies.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/rachel-scop-covering-fire-damages-enemies.json
@@ -1,0 +1,169 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-scop-covering-fire-damages-enemies",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-scop-covering-fire-damages-enemies",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 10,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/rachel-scop-covering-fire-selects-all-targets-before-damage.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/rachel-scop-covering-fire-selects-all-targets-before-damage.json
@@ -1,0 +1,167 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-scop-covering-fire-selects-all-targets-before-damage",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "mech"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-scop-covering-fire-selects-all-targets-before-damage",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 10,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "mech"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/sturm-cop-meteor-strike-damages-enemy-cluster.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/sturm-cop-meteor-strike-damages-enemy-cluster.json
@@ -1,0 +1,169 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-cop-meteor-strike-damages-enemy-cluster",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sturm",
+        "funds": 0,
+        "power-meter": {
+          "charge": 45000,
+          "cop-stars": 5,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-cop-meteor-strike-damages-enemy-cluster",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 60,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sturm",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 5,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/sturm-cop-meteor-targeting-penalizes-friendly-units-in-area.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/sturm-cop-meteor-targeting-penalizes-friendly-units-in-area.json
@@ -1,0 +1,173 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-cop-meteor-targeting-penalizes-friendly-units-in-area",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 3,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "megatank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sturm",
+        "funds": 0,
+        "power-meter": {
+          "charge": 45000,
+          "cop-stars": 5,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-cop-meteor-targeting-penalizes-friendly-units-in-area",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 3,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "megatank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 70,
+            "health": 60,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sturm",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 5,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/sturm-scop-meteor-strike-damages-enemy-cluster.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/sturm-scop-meteor-strike-damages-enemy-cluster.json
@@ -1,0 +1,169 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-scop-meteor-strike-damages-enemy-cluster",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sturm",
+        "funds": 0,
+        "power-meter": {
+          "charge": 90000,
+          "cop-stars": 5,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-scop-meteor-strike-damages-enemy-cluster",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 20,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sturm",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 5,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/vonbolt-scop-ex-machina-damages-and-stuns-next-turn.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/vonbolt-scop-ex-machina-damages-and-stuns-next-turn.json
@@ -1,0 +1,172 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "vonbolt-scop-ex-machina-damages-and-stuns-next-turn",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "VonBolt",
+        "funds": 0,
+        "power-meter": {
+          "charge": 90000,
+          "cop-stars": 0,
+          "scop-stars": 10,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "vonbolt-scop-ex-machina-damages-and-stuns-next-turn",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 70,
+            "hidden": false,
+            "moved": true,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "VonBolt",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 0,
+          "scop-stars": 10,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/vonbolt-scop-ex-machina-stun-expires-after-skipped-turn.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/vonbolt-scop-ex-machina-stun-expires-after-skipped-turn.json
@@ -1,0 +1,178 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "vonbolt-scop-ex-machina-stun-expires-after-skipped-turn",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "VonBolt",
+        "funds": 0,
+        "power-meter": {
+          "charge": 90000,
+          "cop-stars": 0,
+          "scop-stars": 10,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "end-turn"
+    },
+    {
+      "type": "end-turn"
+    },
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "vonbolt-scop-ex-machina-stun-expires-after-skipped-turn",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 70,
+            "health": 70,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ],
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "VonBolt",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 0,
+          "scop-stars": 10,
+          "star-value": 10800
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -12,6 +12,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Andy COP/SCOP healing.
 - Jess SCOP resupply.
 - Active weather JSON parsing/serialization, weather movement/fuel costs, and Drake/Olaf weather-changing powers.
+- Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
@@ -21,11 +22,17 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Rain and snow movement costs follow the AWBW weather tables, including Drake rain immunity, Olaf snow immunity, and Olaf treating rain like snow.
 - Rain vision penalties are intentionally deferred because this simulator does not yet have fog-of-war or vision state; that broader subsystem is tracked by #25.
 
+## HP Effect Notes
+
+- Out-of-combat HP damage and HP drain are applied in true-health units, where 1 displayed HP equals 10 stored health. These effects floor targets at 1 stored health, so they cannot destroy units directly; healing caps at 100.
+- Drake's Tsunami and Typhoon halve enemy fuel with integer truncation, then apply their HP damage. Typhoon also keeps the existing rain side effect.
+- Rachel, Sturm, and Von Bolt missile-style powers use a 2-range diamond area. Target scoring follows the AWBW wiki criteria using the simulator's two-player friendly/enemy model, unit HP, unit cost, and property capture state. Loaded units are excluded because they are not represented as map occupants.
+- Rachel's three Covering Fire target centers are selected before damage is applied, then each missile applies damage. Von Bolt's stun is represented internally until the affected player's next `BeginTurn`, where stunned units remain `"moved": true` for that turn.
+
 ## Tracked Follow-Up Issues
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#21](https://github.com/ryparikh/AdvanceWarsServer/issues/21): mass damage, healing, and HP-drain CO power effects.
 - [#22](https://github.com/ryparikh/AdvanceWarsServer/issues/22): CO economy and unit-cost effects.
 - [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
 - [#24](https://github.com/ryparikh/AdvanceWarsServer/issues/24): Eagle extra-action CO power behavior.


### PR DESCRIPTION
## Summary
- Implemented HP/healing/fuel/stun side effects for Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP actions.
- Added missile-style area targeting for Rachel, Sturm, and Von Bolt using AWBW-style scoring over the simulator's two-player map state.
- Added focused JSON regression coverage for each affected CO and updated `CO_SUPPORT.md` to remove #21 from the unimplemented list.

## Root Cause
`DoCOPowerAction` and `DoSCOPowerAction` spent meters and set power status, but most non-chart HP effects were still no-ops. Existing behavior only covered Andy healing, Jess SCOP resupply, and Drake/Olaf weather side effects.

## Tests
- Failing-first observed: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/power-actions` failed on the new CO power JSON regressions before implementation because HP/fuel/missile/stun effects were not applied.
- Passing: `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- Passing: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/power-actions`
- Passing: `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- Passing: `git diff --check` (line-ending conversion warnings only)

## Notes / Residual Risk
- Rachel, Sturm, and Von Bolt area effects use a 2-range diamond and exclude loaded units because loaded units are not map occupants in this simulator.
- Von Bolt stun is represented internally and materializes as `moved: true` at the affected player's next `BeginTurn`.

Closes #21