### PR TITLE
Add per-unit fixture coverage manifest

### DIFF
--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -272,6 +272,10 @@ void JsonTestSuite::run() {
 		if (!dir_entry.is_regular_file()) {
 			continue;
 		}
+		if (dir_entry.path().extension() != ".json") {
+			continue;
+		}
+
 		JsonTestRunner runner(dir_entry);
 		Result result = runner.run();
 		if (result == Result::Failed) {

--- a/AdvanceWarsServer/test/json/units/README.md
+++ b/AdvanceWarsServer/test/json/units/README.md
@@ -1,0 +1,41 @@
+# Unit Coverage Manifest
+
+`units/<unit-type>/` is the stable fixture home for each `UnitProperties::Type` value from `AdvanceWarsServer/inc/Unit.h`. Use the same string spelling as `UnitProperties::getTypename()` when adding new unit-owned fixtures.
+
+Existing JSON fixtures stay in their current feature folders for now to avoid path churn. Move them into the unit home when a follow-up is already changing that behavior, or cross-link them here when keeping a feature folder is clearer.
+
+The JSON suite discovers tests recursively under `test/json`; non-`.json` files in this manifest tree are documentation or placeholders.
+
+Coverage key:
+
+- `yes`: at least one JSON fixture exercises the unit as the behavior owner.
+- `partial`: fixtures mention the unit or cover one narrow behavior, but the unit does not yet have full owner coverage.
+- `none`: no meaningful fixture coverage for that status yet.
+
+| UnitProperties::Type | JSON type | Fixture home | Happy path | Boundary | Existing coverage notes |
+| --- | --- | --- | --- | --- | --- |
+| AntiAir | `anti-air` | `units/anti-air/` | partial | partial | Present as infantry combat target/opponent and production option. Needs anti-air owned attack tests. |
+| Apc | `apc` | `units/apc/` | yes | yes | `transport/apc/` covers load, unload, resupply, movement, and capacity boundaries. |
+| Artillery | `artillery` | `units/artillery/` | partial | partial | Present as infantry combat target/opponent and indirect rout fixture. Needs artillery owned range/ammo tests. |
+| BCopter | `bcopter` | `units/bcopter/` | partial | partial | Present as infantry combat target/opponent and cruiser cargo. Needs B-copter owned movement/combat tests. |
+| Battleship | `battleship` | `units/battleship/` | partial | none | Present in production and combat mentions. Needs battleship owned indirect/naval tests. |
+| BlackBoat | `blackboat` | `units/blackboat/` | yes | yes | `transport/blackboat/` covers load, unload, repair, resupply, funds, and sea unload boundaries. |
+| BlackBomb | `blackbomb` | `units/blackbomb/` | partial | none | Present in production fixtures. Explosion behavior is still uncovered. |
+| Bomber | `bomber` | `units/bomber/` | partial | partial | Present as production option and infantry combat target/opponent. Needs bomber owned air attack tests. |
+| Carrier | `carrier` | `units/carrier/` | yes | yes | `transport/carrier/` covers loading air units, hidden stealth unload, and loaded air resupply. |
+| Crusier | `crusier` | `units/crusier/` | yes | yes | Enum and JSON spelling are `crusier`; `transport/crusier/` covers copter loading and loaded resupply. |
+| Fighter | `fighter` | `units/fighter/` | partial | partial | Present in production and as carrier cargo/invalid transport cargo. Needs fighter owned air combat tests. |
+| Infantry | `infantry` | `units/infantry/` | yes | yes | Broad coverage exists in `combat/infantry/`, `captures/`, `joining/`, and transport cargo tests. |
+| Lander | `lander` | `units/lander/` | yes | yes | `transport/lander/` covers multi-load, unload, and no-unload-at-sea boundary. |
+| MediumTank | `medium-tank` | `units/medium-tank/` | partial | partial | Present as production option and infantry combat target/opponent. Needs medium tank owned combat tests. |
+| Mech | `mech` | `units/mech/` | yes | yes | Covered through capture, combat, joining, and transport cargo scenarios. Needs dedicated mech-owned folder tests later. |
+| MegaTank | `megatank` | `units/megatank/` | partial | partial | Present as production option and infantry combat target/opponent. Needs mega tank owned combat tests. |
+| Missile | `missile` | `units/missile/` | partial | partial | Present as production option and infantry combat target/opponent. Needs missile owned range/no-target tests. |
+| Neotank | `neotank` | `units/neotank/` | partial | partial | Present as production option and infantry combat target/opponent. Needs neotank owned combat tests. |
+| Piperunner | `piperunner` | `units/piperunner/` | partial | partial | Present as production option and infantry combat target/opponent. Needs pipe movement and attack tests. |
+| Recon | `recon` | `units/recon/` | partial | partial | Present as production option and infantry combat target/opponent. Needs recon owned movement/vision tests. |
+| Rocket | `rocket` | `units/rocket/` | partial | partial | Present as production option and infantry combat target/opponent. Needs rocket owned indirect/no-ammo tests. |
+| Stealth | `stealth` | `units/stealth/` | partial | partial | Present in production and carrier hidden-cargo fixtures. Hide/unhide and fuel drain behavior are uncovered. |
+| Sub | `sub` | `units/sub/` | partial | none | Present in production fixtures. Dive/hide/fuel/combat behavior is uncovered. |
+| TCopter | `tcopter` | `units/tcopter/` | yes | yes | `transport/tcopter/` covers load, unload, movement unload, and capacity boundaries. |
+| Tank | `tank` | `units/tank/` | yes | yes | `combat/tank/` and broader combat/production fixtures cover basic tank behavior and no-ammo combat. |

--- a/AdvanceWarsServer/test/json/units/anti-air/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/anti-air/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future anti-air JSON fixtures

--- a/AdvanceWarsServer/test/json/units/apc/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/apc/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future apc JSON fixtures

--- a/AdvanceWarsServer/test/json/units/artillery/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/artillery/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future artillery JSON fixtures

--- a/AdvanceWarsServer/test/json/units/battleship/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/battleship/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future battleship JSON fixtures

--- a/AdvanceWarsServer/test/json/units/bcopter/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/bcopter/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future bcopter JSON fixtures

--- a/AdvanceWarsServer/test/json/units/blackboat/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/blackboat/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future blackboat JSON fixtures

--- a/AdvanceWarsServer/test/json/units/blackbomb/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/blackbomb/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future blackbomb JSON fixtures

--- a/AdvanceWarsServer/test/json/units/bomber/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/bomber/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future bomber JSON fixtures

--- a/AdvanceWarsServer/test/json/units/carrier/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/carrier/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future carrier JSON fixtures

--- a/AdvanceWarsServer/test/json/units/crusier/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/crusier/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future crusier JSON fixtures

--- a/AdvanceWarsServer/test/json/units/fighter/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/fighter/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future fighter JSON fixtures

--- a/AdvanceWarsServer/test/json/units/infantry/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/infantry/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future infantry JSON fixtures

--- a/AdvanceWarsServer/test/json/units/lander/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/lander/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future lander JSON fixtures

--- a/AdvanceWarsServer/test/json/units/mech/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/mech/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future mech JSON fixtures

--- a/AdvanceWarsServer/test/json/units/medium-tank/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/medium-tank/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future medium-tank JSON fixtures

--- a/AdvanceWarsServer/test/json/units/megatank/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/megatank/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future megatank JSON fixtures

--- a/AdvanceWarsServer/test/json/units/missile/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/missile/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future missile JSON fixtures

--- a/AdvanceWarsServer/test/json/units/neotank/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/neotank/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future neotank JSON fixtures

--- a/AdvanceWarsServer/test/json/units/piperunner/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/piperunner/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future piperunner JSON fixtures

--- a/AdvanceWarsServer/test/json/units/recon/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/recon/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future recon JSON fixtures

--- a/AdvanceWarsServer/test/json/units/rocket/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/rocket/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future rocket JSON fixtures

--- a/AdvanceWarsServer/test/json/units/stealth/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/stealth/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future stealth JSON fixtures

--- a/AdvanceWarsServer/test/json/units/sub/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/sub/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future sub JSON fixtures

--- a/AdvanceWarsServer/test/json/units/tank/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/tank/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future tank JSON fixtures

--- a/AdvanceWarsServer/test/json/units/tcopter/.gitkeep
+++ b/AdvanceWarsServer/test/json/units/tcopter/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future tcopter JSON fixtures


### PR DESCRIPTION
## Summary
- Add `test/json/units/` with one tracked fixture home for every `UnitProperties::Type` value.
- Add a unit coverage manifest that maps each enum value to its JSON type spelling, fixture home, current happy-path/boundary status, and known gaps.
- Update the JSON suite runner to skip non-`.json` files so README files and placeholders can live under `test/json` without being executed as tests.

## Why
Issue #28 needs the JSON fixture tree to make missing unit coverage obvious before the broader unit coverage work from #13 continues. The runner previously treated every regular file under `test/json` as a JSON fixture, so adding documentation/placeholders there caused the suite to throw before it reached actual test files.

## Tests
- Before the runner guard: `..\x64\Debug\AdvanceWarsServer.exe -test test/json` produced `exception was thrown` after the manifest/placeholders were added.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json` -> `Tests Passed`
- `git diff --cached --check`

## Residual Risk
Existing fixtures were left in their current feature folders to avoid broad path churn. The manifest points at those areas and gives each unit a stable home for follow-up tests.

Closes #28