### PR TITLE
Add indirect unit range and ammo coverage

### DIFF
--- a/AdvanceWarsServer/test/json/units/README.md
+++ b/AdvanceWarsServer/test/json/units/README.md
@@ -16,13 +16,13 @@ Coverage key:
 | --- | --- | --- | --- | --- | --- |
 | AntiAir | `anti-air` | `units/anti-air/` | partial | partial | Present as infantry combat target/opponent and production option. Needs anti-air owned attack tests. |
 | Apc | `apc` | `units/apc/` | yes | yes | `transport/apc/` covers load, unload, resupply, movement, and capacity boundaries. |
-| Artillery | `artillery` | `units/artillery/` | partial | partial | Present as infantry combat target/opponent and indirect rout fixture. Needs artillery owned range/ammo tests. |
+| Artillery | `artillery` | `units/artillery/` | yes | yes | `units/artillery/` covers indirect min/max range, ammo consumption, no ammo, invalid air target, and move-fire rejection. |
 | BCopter | `bcopter` | `units/bcopter/` | partial | partial | Present as infantry combat target/opponent and cruiser cargo. Needs B-copter owned movement/combat tests. |
-| Battleship | `battleship` | `units/battleship/` | partial | none | Present in production and combat mentions. Needs battleship owned indirect/naval tests. |
+| Battleship | `battleship` | `units/battleship/` | yes | yes | `units/battleship/` covers indirect min/max range, ammo consumption, no ammo, invalid air target, and move-fire rejection. |
 | BlackBoat | `blackboat` | `units/blackboat/` | yes | yes | `transport/blackboat/` covers load, unload, repair, resupply, funds, and sea unload boundaries. |
 | BlackBomb | `blackbomb` | `units/blackbomb/` | partial | none | Present in production fixtures. Explosion behavior is still uncovered. |
 | Bomber | `bomber` | `units/bomber/` | partial | partial | Present as production option and infantry combat target/opponent. Needs bomber owned air attack tests. |
-| Carrier | `carrier` | `units/carrier/` | yes | yes | `transport/carrier/` covers loading air units, hidden stealth unload, and loaded air resupply. |
+| Carrier | `carrier` | `units/carrier/` | yes | yes | `transport/carrier/` covers loading/resupply; `units/carrier/` covers indirect anti-air range, ammo, invalid ground target, and move-fire rejection. |
 | Crusier | `crusier` | `units/crusier/` | yes | yes | Enum and JSON spelling are `crusier`; `transport/crusier/` covers copter loading and loaded resupply. |
 | Fighter | `fighter` | `units/fighter/` | partial | partial | Present in production and as carrier cargo/invalid transport cargo. Needs fighter owned air combat tests. |
 | Infantry | `infantry` | `units/infantry/` | yes | yes | Broad coverage exists in `combat/infantry/`, `captures/`, `joining/`, and transport cargo tests. |
@@ -30,11 +30,11 @@ Coverage key:
 | MediumTank | `medium-tank` | `units/medium-tank/` | partial | partial | Present as production option and infantry combat target/opponent. Needs medium tank owned combat tests. |
 | Mech | `mech` | `units/mech/` | yes | yes | Covered through capture, combat, joining, and transport cargo scenarios. Needs dedicated mech-owned folder tests later. |
 | MegaTank | `megatank` | `units/megatank/` | partial | partial | Present as production option and infantry combat target/opponent. Needs mega tank owned combat tests. |
-| Missile | `missile` | `units/missile/` | partial | partial | Present as production option and infantry combat target/opponent. Needs missile owned range/no-target tests. |
+| Missile | `missile` | `units/missile/` | yes | yes | `units/missile/` covers indirect anti-air min/max range, ammo consumption, no ammo, invalid ground target, and move-fire rejection. |
 | Neotank | `neotank` | `units/neotank/` | partial | partial | Present as production option and infantry combat target/opponent. Needs neotank owned combat tests. |
-| Piperunner | `piperunner` | `units/piperunner/` | partial | partial | Present as production option and infantry combat target/opponent. Needs pipe movement and attack tests. |
+| Piperunner | `piperunner` | `units/piperunner/` | partial | partial | `units/piperunner/` covers indirect min/max range, ammo consumption, no ammo, empty target, and move-fire rejection. Pipe movement still needs dedicated fixtures. |
 | Recon | `recon` | `units/recon/` | partial | partial | Present as production option and infantry combat target/opponent. Needs recon owned movement/vision tests. |
-| Rocket | `rocket` | `units/rocket/` | partial | partial | Present as production option and infantry combat target/opponent. Needs rocket owned indirect/no-ammo tests. |
+| Rocket | `rocket` | `units/rocket/` | yes | yes | `units/rocket/` covers indirect min/max range, ammo consumption, no ammo, invalid air target, and move-fire rejection. |
 | Stealth | `stealth` | `units/stealth/` | partial | partial | Present in production and carrier hidden-cargo fixtures. Hide/unhide and fuel drain behavior are uncovered. |
 | Sub | `sub` | `units/sub/` | partial | none | Present in production fixtures. Dive/hide/fuel/combat behavior is uncovered. |
 | TCopter | `tcopter` | `units/tcopter/` | yes | yes | `transport/tcopter/` covers load, unload, movement unload, and capacity boundaries. |

--- a/AdvanceWarsServer/test/json/units/artillery/indirect-boundaries.json
+++ b/AdvanceWarsServer/test/json/units/artillery/indirect-boundaries.json
@@ -1,0 +1,52 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "artillery-indirect-boundaries",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [1, 0] },
+    { "type": "attack", "source": [0, 0], "target": [4, 0] },
+    { "type": "attack", "source": [0, 1], "target": [2, 1] },
+    { "type": "attack", "source": [0, 2], "target": [2, 2] },
+    { "type": "move-attack", "source": [0, 3], "target": [1, 3], "direction": "east" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/artillery/indirect-range-ammo.json
+++ b/AdvanceWarsServer/test/json/units/artillery/indirect-range-ammo.json
@@ -1,0 +1,60 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "artillery-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [2, 0] },
+    { "type": "attack", "source": [0, 1], "target": [3, 1] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "artillery-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 30, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 30, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 4900, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 9800, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/battleship/indirect-boundaries.json
+++ b/AdvanceWarsServer/test/json/units/battleship/indirect-boundaries.json
@@ -1,0 +1,64 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "battleship-indirect-boundaries",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [1, 0] },
+    { "type": "attack", "source": [0, 0], "target": [7, 0] },
+    { "type": "attack", "source": [0, 1], "target": [2, 1] },
+    { "type": "attack", "source": [0, 2], "target": [2, 2] },
+    { "type": "move-attack", "source": [0, 3], "target": [1, 3], "direction": "east" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/battleship/indirect-range-ammo.json
+++ b/AdvanceWarsServer/test/json/units/battleship/indirect-range-ammo.json
@@ -1,0 +1,72 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "battleship-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [2, 0] },
+    { "type": "attack", "source": [0, 1], "target": [6, 1] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "battleship-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 8, "fuel": 99, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 8, "fuel": 99, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 5600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 11200, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/carrier/indirect-boundaries.json
+++ b/AdvanceWarsServer/test/json/units/carrier/indirect-boundaries.json
@@ -1,0 +1,72 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-indirect-boundaries",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [2, 0] },
+    { "type": "attack", "source": [0, 0], "target": [9, 0] },
+    { "type": "attack", "source": [0, 1], "target": [3, 1] },
+    { "type": "attack", "source": [0, 2], "target": [3, 2] },
+    { "type": "move-attack", "source": [0, 3], "target": [1, 3], "direction": "east" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/carrier/indirect-range-ammo.json
+++ b/AdvanceWarsServer/test/json/units/carrier/indirect-range-ammo.json
@@ -1,0 +1,80 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 50, "hidden": false, "moved": false, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 50, "hidden": false, "moved": false, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [3, 0] },
+    { "type": "attack", "source": [0, 1], "target": [8, 1] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "carrier-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 8, "fuel": 99, "health": 50, "hidden": false, "moved": true, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 50, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 8, "fuel": 99, "health": 50, "hidden": false, "moved": true, "owner": "orange-star", "type": "carrier" } },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28 },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 50, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 10000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 20000, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/missile/indirect-boundaries.json
+++ b/AdvanceWarsServer/test/json/units/missile/indirect-boundaries.json
@@ -1,0 +1,60 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "missile-indirect-boundaries",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [2, 0] },
+    { "type": "attack", "source": [0, 0], "target": [6, 0] },
+    { "type": "attack", "source": [0, 1], "target": [3, 1] },
+    { "type": "attack", "source": [0, 2], "target": [3, 2] },
+    { "type": "move-attack", "source": [0, 3], "target": [1, 3], "direction": "east" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/missile/indirect-range-ammo.json
+++ b/AdvanceWarsServer/test/json/units/missile/indirect-range-ammo.json
@@ -1,0 +1,68 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "missile-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 50, "hidden": false, "moved": false, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 50, "hidden": false, "moved": false, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [3, 0] },
+    { "type": "attack", "source": [0, 1], "target": [5, 1] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "missile-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 5, "fuel": 50, "health": 50, "hidden": false, "moved": true, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 40, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 5, "fuel": 50, "health": 50, "hidden": false, "moved": true, "owner": "orange-star", "type": "missile" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 40, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 5400, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 10800, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/piperunner/indirect-boundaries.json
+++ b/AdvanceWarsServer/test/json/units/piperunner/indirect-boundaries.json
@@ -1,0 +1,60 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "piperunner-indirect-boundaries",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [1, 0] },
+    { "type": "attack", "source": [0, 0], "target": [6, 0] },
+    { "type": "attack", "source": [0, 1], "target": [2, 1] },
+    { "type": "attack", "source": [0, 2], "target": [2, 2] },
+    { "type": "move-attack", "source": [0, 3], "target": [1, 3], "direction": "east" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/piperunner/indirect-range-ammo.json
+++ b/AdvanceWarsServer/test/json/units/piperunner/indirect-range-ammo.json
@@ -1,0 +1,68 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "piperunner-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [2, 0] },
+    { "type": "attack", "source": [0, 1], "target": [5, 1] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "piperunner-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 99, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 99, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "piperunner" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 5600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 11200, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/rocket/indirect-boundaries.json
+++ b/AdvanceWarsServer/test/json/units/rocket/indirect-boundaries.json
@@ -1,0 +1,60 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rocket-indirect-boundaries",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [2, 0] },
+    { "type": "attack", "source": [0, 0], "target": [6, 0] },
+    { "type": "attack", "source": [0, 1], "target": [3, 1] },
+    { "type": "attack", "source": [0, 2], "target": [3, 2] },
+    { "type": "move-attack", "source": [0, 3], "target": [1, 3], "direction": "east" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/rocket/indirect-range-ammo.json
+++ b/AdvanceWarsServer/test/json/units/rocket/indirect-range-ammo.json
@@ -1,0 +1,68 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rocket-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [3, 0] },
+    { "type": "attack", "source": [0, 1], "target": [5, 1] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rocket-indirect-range-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 5, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 5, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "rocket" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 5600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 11200, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}


### PR DESCRIPTION
## Summary
- Add actor-owned indirect combat fixtures for artillery, rocket, missile, battleship, carrier, and piperunner.
- Cover min and max range attacks, ammo consumption, no-counterattack outcomes, no-ammo failures, too-close/too-far failures, target restrictions where applicable, and move-fire rejection.
- Update the unit coverage manifest with the new indirect fixture coverage.

## Why
Issue #30 breaks out indirect-unit coverage from #13. The existing implementation already enforced these actions through valid-action filtering, so this PR captures that behavior as focused JSON regression coverage.

## Tests
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/units`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`

## Residual Risk
- Piperunner pipe movement remains documented as needing dedicated coverage outside this indirect combat slice.

Closes #30