### PR TITLE
Implement CO economy and unit-cost effects

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -313,6 +313,10 @@ private:
 	int calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain);
 	int GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Terrain::Type& terrainType) const noexcept;
 	int GetCOIndirectRangeModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
+	int GetCOBuildCost(const Player& player, UnitProperties::Type unitType) const noexcept;
+	int GetCOIncomeForProperty(const Player& player, Terrain::Type terrainType) const noexcept;
+	int GetCOFundsAttackModifier(const Player& player, const CommandingOfficier::Type& co) const noexcept;
+	int CountOwnedProperties(const Player& player) const noexcept;
 
 	int GetMaxGoodLuck(const Player& player) noexcept;
 	int GetMaxBadLuck(const Player& player) noexcept;
@@ -329,6 +333,8 @@ private:
 	void ApplyRachelCoveringFire();
 	void ApplySturmMeteor(int health);
 	void ApplyVonBoltExMachina();
+	void ApplySashaMarketCrash(Player& currentPlayer) noexcept;
+	void AddSashaWarBondsFunds(Player& attackingPlayer, int damageValue) noexcept;
 	bool FAtUnitCap() const noexcept;
 	bool FPlayerRouted(const Player& player) const noexcept;
 private:

--- a/AdvanceWarsServer/inc/Player.h
+++ b/AdvanceWarsServer/inc/Player.h
@@ -16,6 +16,7 @@ public:
 
 	void UseCop() noexcept;
 	void UseScop() noexcept;
+	void ReduceCharge(int charge) noexcept;
 	inline int GetCharge() const noexcept {
 		return m_nCharge;
 	}

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -44,6 +44,16 @@ GameState::WeatherType WeatherTypeFromString(const std::string& weather) {
 	throw std::invalid_argument("Unknown weather: " + weather);
 }
 
+bool FProducesIncome(Terrain::Type terrainType) noexcept {
+	return MapTile::IsProperty(terrainType) &&
+		terrainType != Terrain::Type::ComTower &&
+		terrainType != Terrain::Type::Lab;
+}
+
+bool FKindleUrbanTerrain(Terrain::Type terrainType) noexcept {
+	return MapTile::IsProperty(terrainType);
+}
+
 int ManhattanDistance(int x1, int y1, int x2, int y2) noexcept {
 	return std::abs(x1 - x2) + std::abs(y1 - y2);
 }
@@ -135,8 +145,8 @@ Result GameState::BeginTurn() noexcept {
 			const MapTile* pTile = nullptr;
 			m_spmap->TryGetTile(x, y, &pTile);
 			const Terrain& terrain = pTile->GetTerrain();
-			if (MapTile::IsProperty(terrain.m_type) && terrain.m_type != Terrain::Type::ComTower && terrain.m_type != Terrain::Type::Lab && pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[player]) {
-				newFunds += 1000;
+			if (FProducesIncome(terrain.m_type) && pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[player]) {
+				newFunds += GetCOIncomeForProperty(m_arrPlayers[player], terrain.m_type);
 			}
 		}
 	}
@@ -819,7 +829,7 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 		case Terrain::Type::Airport:
 			for (auto unit : vrgUnits) {
 				int funds = GetCurrentPlayer().m_funds;
-				if (unit.m_movementType == MovementTypes::Air && Unit::GetUnitCost(unit.m_type) * 10 <= funds) {
+				if (unit.m_movementType == MovementTypes::Air && GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
 					vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
 				}
 			}
@@ -832,7 +842,7 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 					unit.m_movementType == MovementTypes::Pipe ||
 					unit.m_movementType == MovementTypes::Tires ||
 					unit.m_movementType == MovementTypes::Treads) &&
-					Unit::GetUnitCost(unit.m_type) * 10 <= funds) {
+					GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
 					// TODO: How to win if players both build pipe runners
 					if (unit.m_type != UnitProperties::Type::Piperunner) {
 						vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
@@ -843,7 +853,7 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 		case Terrain::Type::Port:
 			for (auto unit : vrgUnits) {
 				int funds = GetCurrentPlayer().m_funds;
-				if ((unit.m_movementType == MovementTypes::Sea || unit.m_movementType == MovementTypes::Lander) && Unit::GetUnitCost(unit.m_type) * 10 <= funds) {
+				if ((unit.m_movementType == MovementTypes::Sea || unit.m_movementType == MovementTypes::Lander) && GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
 					vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
 				}
 			}
@@ -1220,15 +1230,16 @@ Result GameState::DoBuyAction(int x, int y, const Action& action) {
 		return Result::Failed;
 	}
 
-	int cost = Unit::GetUnitCost(unitType) * 10;
+	int cost = GetCOBuildCost(*currentPlayer, unitType);
 	if (currentPlayer->m_funds >= cost) {
 		currentPlayer->m_funds -= cost;
 		IfFailedReturn(ptile->TryAddUnit(unitType, currentPlayer));
 		Unit* punit = ptile->TryGetUnit();
 		punit->m_moved = true;
+		return Result::Succeeded;
 	}
 
-	return Result::Succeeded;
+	return Result::Failed;
 }
 
 Result GameState::DoAttackAction(int x, int y, const Action& action) {
@@ -1297,6 +1308,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		if (pattackingplayer->PowerStatus() == 0) {
 			pattackingplayer->m_powerMeter.AddCharge(0.5 * defenderUnitCost);
 		}
+		AddSashaWarBondsFunds(*pattackingplayer, defenderUnitCost);
 
 		if (pdefendingplayer->PowerStatus() == 0) {
 			pdefendingplayer->m_powerMeter.AddCharge(defenderUnitCost);
@@ -1333,6 +1345,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		if (pdefendingplayer->PowerStatus() == 0) {
 			pdefendingplayer->m_powerMeter.AddCharge(0.5 * attackerUnitCost);
 		}
+		AddSashaWarBondsFunds(*pdefendingplayer, attackerUnitCost);
 		if (pattackingplayer->PowerStatus() == 0) {
 			pattackingplayer->m_powerMeter.AddCharge(attackerUnitCost);
 		}
@@ -1444,6 +1457,7 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 	int attackValue = rgCharts[static_cast<int>(attackerCO)][pattackingplayer->PowerStatus()][static_cast<int>(attacker.m_properties.m_type)].first + 10 * nComTowers;
 	int defenceValue = rgCharts[static_cast<int>(defenderCO)][pdefendingplayer->PowerStatus()][static_cast<int>(defender.m_properties.m_type)].second;
 
+	attackValue += GetCOFundsAttackModifier(*pattackingplayer, attackerCO);
 	attackValue += GetCOTerrainModifier(*pattackingplayer, attackerCO, attackerTerrain.m_type);
 	if (defender.IsAirUnit()) {
 		defenderTerrainStars = 0;
@@ -1504,10 +1518,82 @@ int GameState::GetCOTerrainModifier(const Player& player, const CommandingOffici
 		}
 		
 		return 10;
+	case CommandingOfficier::Type::Kindle:
+		if (!FKindleUrbanTerrain(terrainType)) {
+			break;
+		}
+
+		if (player.m_powerStatus == 1) {
+			return 80;
+		}
+		else if (player.m_powerStatus == 2) {
+			return 130;
+		}
+
+		return 40;
 	default:
 		break;
 	}
 	return 0;
+}
+
+int GameState::GetCOBuildCost(const Player& player, UnitProperties::Type unitType) const noexcept {
+	int cost = Unit::GetUnitCost(unitType) * 10;
+	switch (player.m_co.m_type) {
+	case CommandingOfficier::Type::Colin:
+		return cost * 80 / 100;
+	case CommandingOfficier::Type::Hachi:
+		if (player.PowerStatus() != 0) {
+			return cost * 50 / 100;
+		}
+		return cost * 90 / 100;
+	case CommandingOfficier::Type::Kanbei:
+		return cost * 120 / 100;
+	default:
+		return cost;
+	}
+}
+
+int GameState::GetCOIncomeForProperty(const Player& player, Terrain::Type) const noexcept {
+	if (player.m_co.m_type == CommandingOfficier::Type::Sasha) {
+		return 1100;
+	}
+
+	return 1000;
+}
+
+int GameState::GetCOFundsAttackModifier(const Player& player, const CommandingOfficier::Type& co) const noexcept {
+	switch (co) {
+	case CommandingOfficier::Type::Colin:
+		if (player.PowerStatus() == 2) {
+			return (player.m_funds / 1000) * 3;
+		}
+		break;
+	case CommandingOfficier::Type::Kindle:
+		if (player.PowerStatus() == 2) {
+			return CountOwnedProperties(player) * 3;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+int GameState::CountOwnedProperties(const Player& player) const noexcept {
+	int properties = 0;
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			const MapTile* pTile = nullptr;
+			m_spmap->TryGetTile(x, y, &pTile);
+			if (MapTile::IsProperty(pTile->GetTerrain().m_type) && pTile->m_spPropertyInfo->m_owner == &player) {
+				++properties;
+			}
+		}
+	}
+
+	return properties;
 }
 
 int GameState::RollCombatLuck(int min, int max) {
@@ -1854,6 +1940,9 @@ Result GameState::DoCOPowerAction() {
 		case CommandingOfficier::Type::Andy:
 			HealUnits(currentPlayer, 2);
 			return Result::Succeeded;
+		case CommandingOfficier::Type::Colin:
+			currentPlayer.m_funds += currentPlayer.m_funds / 2;
+			return Result::Succeeded;
 		case CommandingOfficier::Type::Drake:
 			DamageUnits(GetEnemyPlayer(), 1, true);
 			return Result::Succeeded;
@@ -1867,11 +1956,26 @@ Result GameState::DoCOPowerAction() {
 		case CommandingOfficier::Type::Olaf:
 			SetTemporaryWeather(WeatherType::Snow);
 			return Result::Succeeded;
+		case CommandingOfficier::Type::Sasha:
+			ApplySashaMarketCrash(currentPlayer);
+			return Result::Succeeded;
 		case CommandingOfficier::Type::Sturm:
 			ApplySturmMeteor(4);
 			return Result::Succeeded;
 	}
 	return Result::Succeeded;
+}
+
+void GameState::ApplySashaMarketCrash(Player& currentPlayer) noexcept {
+	Player& enemyPlayer = GetEnemyPlayer();
+	const int reduction = enemyPlayer.m_powerMeter.GetTotalCharge() * currentPlayer.m_funds / 50000;
+	enemyPlayer.m_powerMeter.ReduceCharge(reduction);
+}
+
+void GameState::AddSashaWarBondsFunds(Player& attackingPlayer, int damageValue) noexcept {
+	if (attackingPlayer.m_co.m_type == CommandingOfficier::Type::Sasha && attackingPlayer.PowerStatus() == 2) {
+		attackingPlayer.m_funds += damageValue / 2;
+	}
 }
 
 Result GameState::ResupplyPlayersUnits(const Player* player) {

--- a/AdvanceWarsServer/src/Player.cpp
+++ b/AdvanceWarsServer/src/Player.cpp
@@ -1,5 +1,6 @@
 #include "Player.h"
 
+#include <algorithm>
 #include <stdexcept>
 
 PowerMeter::PowerMeter(const CommandingOfficier::Type& type) {
@@ -84,6 +85,10 @@ PowerMeter::PowerMeter(const CommandingOfficier::Type& type) {
 
 void PowerMeter::AddCharge(int charge) noexcept {
 	m_nCharge = std::min(charge + m_nCharge, GetTotalCharge());
+}
+
+void PowerMeter::ReduceCharge(int charge) noexcept {
+	m_nCharge = std::max(m_nCharge - charge, 0);
 }
 
 void PowerMeter::UseScop() noexcept {

--- a/AdvanceWarsServer/test/json/co/economy/colin-cost-and-gold-rush.json
+++ b/AdvanceWarsServer/test/json/co/economy/colin-cost-and-gold-rush.json
@@ -1,0 +1,117 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "colin-cost-and-gold-rush",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Colin",
+        "funds": 7000,
+        "power-meter": {
+          "charge": 18000,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    },
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "colin-cost-and-gold-rush",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Colin",
+        "funds": 2100,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/economy/colin-power-of-money.json
+++ b/AdvanceWarsServer/test/json/co/economy/colin-power-of-money.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "colin-power-of-money",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Colin",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [ 0, 0 ],
+      "direction": "east",
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "colin-power-of-money",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 86,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 23,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Colin",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 750,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/economy/hachi-barter-cost.json
+++ b/AdvanceWarsServer/test/json/co/economy/hachi-barter-cost.json
@@ -1,0 +1,117 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-barter-cost",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 3500,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    },
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-barter-cost",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/economy/hachi-day-to-day-cost.json
+++ b/AdvanceWarsServer/test/json/co/economy/hachi-day-to-day-cost.json
@@ -1,0 +1,114 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-day-to-day-cost",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 6300,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-day-to-day-cost",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/economy/kanbei-insufficient-funds.json
+++ b/AdvanceWarsServer/test/json/co/economy/kanbei-insufficient-funds.json
@@ -1,0 +1,57 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-insufficient-funds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kanbei",
+        "funds": 7000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 4,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/economy/kindle-high-society-property-attack.json
+++ b/AdvanceWarsServer/test/json/co/economy/kindle-high-society-property-attack.json
@@ -1,0 +1,154 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kindle-high-society-property-attack",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kindle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [ 1, 0 ],
+      "direction": "east",
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kindle-high-society-property-attack",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 81,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 38,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Kindle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 650,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/economy/sasha-income-and-market-crash.json
+++ b/AdvanceWarsServer/test/json/co/economy/sasha-income-and-market-crash.json
@@ -1,0 +1,148 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sasha-income-and-market-crash",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 134
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sasha",
+        "funds": 0,
+        "power-meter": {
+          "charge": 18000,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 20000,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    },
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sasha-income-and-market-crash",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 134
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sasha",
+        "funds": 2200,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 18020,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/economy/sasha-war-bonds.json
+++ b/AdvanceWarsServer/test/json/co/economy/sasha-war-bonds.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sasha-war-bonds",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sasha",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [ 0, 0 ],
+      "direction": "east",
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sasha-war-bonds",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 81,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 40,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sasha",
+        "funds": 300,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 650,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -13,6 +13,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Jess SCOP resupply.
 - Active weather JSON parsing/serialization, weather movement/fuel costs, and Drake/Olaf weather-changing powers.
 - Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
+- Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
@@ -29,11 +30,15 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Rachel, Sturm, and Von Bolt missile-style powers use a 2-range diamond area. Target scoring follows the AWBW wiki criteria using the simulator's two-player friendly/enemy model, unit HP, unit cost, and property capture state. Loaded units are excluded because they are not represented as map occupants.
 - Rachel's three Covering Fire target centers are selected before damage is applied, then each missile applies damage. Von Bolt's stun is represented internally until the affected player's next `BeginTurn`, where stunned units remain `"moved": true` for that turn.
 
+## Economy Notes
+
+- Colin, Hachi, and Kanbei cost modifiers currently apply to unit construction. Hachi's Merchant Union city deployment remains part of the broader production-effects follow-up.
+- Sasha's Market Crash applies to the single opposing player in this simulator's two-player model.
+
 ## Tracked Follow-Up Issues
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#22](https://github.com/ryparikh/AdvanceWarsServer/issues/22): CO economy and unit-cost effects.
 - [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
 - [#24](https://github.com/ryparikh/AdvanceWarsServer/issues/24): Eagle extra-action CO power behavior.
 - [#25](https://github.com/ryparikh/AdvanceWarsServer/issues/25): fog, vision, hiding, and terrain-defense CO effects.


### PR DESCRIPTION
Closes #22.

## Summary

- Add CO-aware build costs for Colin, Hachi, and Kanbei, including Hachi's Barter discount while powered.
- Add Colin Gold Rush and Power of Money, Sasha income/Market Crash/War Bonds, and Kindle property/High Society attack effects.
- Add focused JSON regression coverage for buying, funds changes, power activation, insufficient funds, and economy-linked combat effects.
- Update CO support docs with the implemented economy behavior and simplified AWBW differences.

## Root Cause

The existing buy, income, combat, and power activation paths used flat costs/income and generic power handling, so CO economy behavior parsed by the simulator was not yet applied in game state transitions.

## Verification

- Confirmed the new `test/json/co/economy` fixtures failed against the pre-change binary for the expected missing behavior.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/economy`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check` (clean; Git only reported normal LF-to-CRLF working-tree normalization warnings)

## Notes

- Hachi Merchant Union city deployment remains deferred to the production-effects follow-up tracked separately in #23.
- Sasha Market Crash is modeled against the single opposing player used by this simulator's two-player game state.