### PR TITLE
Implement Eagle Lightning Strike refresh

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -335,6 +335,7 @@ private:
 	void ApplyVonBoltExMachina();
 	void ApplySashaMarketCrash(Player& currentPlayer) noexcept;
 	void AddSashaWarBondsFunds(Player& attackingPlayer, int damageValue) noexcept;
+	void RefreshEagleLightningStrikeUnits(const Player& player) noexcept;
 	bool FAtUnitCap() const noexcept;
 	bool FPlayerRouted(const Player& player) const noexcept;
 private:

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1978,6 +1978,21 @@ void GameState::AddSashaWarBondsFunds(Player& attackingPlayer, int damageValue) 
 	}
 }
 
+void GameState::RefreshEagleLightningStrikeUnits(const Player& player) noexcept {
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			MapTile* pTile = nullptr;
+			m_spmap->TryGetTile(x, y, &pTile);
+			Unit* pUnit = pTile->TryGetUnit();
+			if (pUnit != nullptr &&
+				pUnit->m_owner == &player &&
+				!pUnit->IsFootsoldier()) {
+				pUnit->m_moved = false;
+			}
+		}
+	}
+}
+
 Result GameState::ResupplyPlayersUnits(const Player* player) {
 	auto tryResupplyUnit = [&](int xResupply, int yResupply) -> Result {
 		MapTile* pTile = nullptr;
@@ -2017,6 +2032,9 @@ Result GameState::DoSCOPowerAction() {
 		case CommandingOfficier::Type::Drake:
 			DamageUnits(GetEnemyPlayer(), 2, true);
 			SetTemporaryWeather(WeatherType::Rain);
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Eagle:
+			RefreshEagleLightningStrikeUnits(currentPlayer);
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Hawke:
 			HealUnits(currentPlayer, 2);

--- a/AdvanceWarsServer/test/json/co/power-actions/eagle-cop-lightning-drive-does-not-refresh-units.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/eagle-cop-lightning-drive-does-not-refresh-units.json
@@ -1,0 +1,113 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-cop-lightning-drive-does-not-refresh-units",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-cop-lightning-drive-does-not-refresh-units",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-allows-newly-built-non-footsoldier-to-act.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-allows-newly-built-non-footsoldier-to-act.json
@@ -1,0 +1,128 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-allows-newly-built-non-footsoldier-to-act",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 7000,
+        "power-meter": {
+          "charge": 81000,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    },
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "move-wait",
+      "source": [ 0, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-allows-newly-built-non-footsoldier-to-act",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 69,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-keeps-capturing-footsoldiers-unavailable.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-keeps-capturing-footsoldiers-unavailable.json
@@ -1,0 +1,126 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-keeps-capturing-footsoldiers-unavailable",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 81000,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 0, 0 ]
+    },
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-keeps-capturing-footsoldiers-unavailable",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-refreshes-blackboat-for-second-repair.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-refreshes-blackboat-for-second-repair.json
@@ -1,0 +1,147 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-refreshes-blackboat-for-second-repair",
+    "map": [
+      [
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 12,
+            "health": 80,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 81000,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "repair",
+      "source": [ 1, 0 ],
+      "direction": "west"
+    },
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "repair",
+      "source": [ 1, 0 ],
+      "direction": "west"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-refreshes-blackboat-for-second-repair",
+    "map": [
+      [
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 600,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-refreshes-non-footsoldiers.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-refreshes-non-footsoldiers.json
@@ -1,0 +1,231 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-refreshes-non-footsoldiers",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 3,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 6,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bcopter"
+              }
+            ],
+            "moved": true,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 81000,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-refreshes-non-footsoldiers",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 3,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 6,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bcopter"
+              }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-unloaded-units-remain-unavailable.json
+++ b/AdvanceWarsServer/test/json/co/power-actions/eagle-scop-unloaded-units-remain-unavailable.json
@@ -1,0 +1,145 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-unloaded-units-remain-unavailable",
+    "map": [
+      [
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              {
+                "ammo": 6,
+                "fuel": 99,
+                "health": 100,
+                "hidden": false,
+                "moved": true,
+                "owner": "orange-star",
+                "type": "bcopter"
+              }
+            ],
+            "moved": true,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 81000,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "unload",
+      "source": [ 0, 0 ],
+      "direction": "east",
+      "unloadIndex": 0
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-scop-unloaded-units-remain-unavailable",
+    "map": [
+      [
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "carrier"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -15,6 +15,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
+- Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
 ## Weather Notes
@@ -35,12 +36,19 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Colin, Hachi, and Kanbei cost modifiers currently apply to unit construction. Hachi's Merchant Union city deployment remains part of the broader production-effects follow-up.
 - Sasha's Market Crash applies to the single opposing player in this simulator's two-player model.
 
+## Action-State Notes
+
+- Eagle's Lightning Drive COP only activates the COP stat chart; it does not clear moved flags.
+- Eagle's Lightning Strike SCOP clears `"moved"` for the current player's map-present non-footsoldier units, including vehicles, air units, sea units, transports, Black Boats, and newly built non-footsoldier units.
+- Infantry and Mechs are footsoldiers, so their capture progress and spent action state are preserved through Lightning Strike.
+- Loaded units are not refreshed while they are cargo because they are not map occupants. If a transport unloads after Lightning Strike, the unloaded unit still becomes `"moved": true` under the simulator's existing unload rule.
+- Lightning Strike is not a `BeginTurn`: it does not grant income, property repairs, property resupply, APC resupply, fuel-day processing, or capture-point changes. Black Boat repair is a normal action, so a Black Boat that repaired before Lightning Strike can repair again after being refreshed.
+
 ## Tracked Follow-Up Issues
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
 - [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
-- [#24](https://github.com/ryparikh/AdvanceWarsServer/issues/24): Eagle extra-action CO power behavior.
 - [#25](https://github.com/ryparikh/AdvanceWarsServer/issues/25): fog, vision, hiding, and terrain-defense CO effects.
 - [#26](https://github.com/ryparikh/AdvanceWarsServer/issues/26): remaining indirect-range CO effects.
 - [#27](https://github.com/ryparikh/AdvanceWarsServer/issues/27): capture-specific CO power behavior.


### PR DESCRIPTION
## Summary
- Add Eagle Lightning Strike SCOP action-state behavior by refreshing map-present non-footsoldier units.
- Cover COP no-refresh, SCOP refresh, newly built non-footsoldier follow-up movement, capture preservation, loaded-unit unload behavior, and Black Boat repair refresh with JSON fixtures.
- Document the Eagle action-state policy in `CO_SUPPORT.md`.

## Root Cause
Eagle's chart modifiers and power-meter/status behavior existed, but `DoSCOPowerAction()` had no Eagle-specific side effect, so already-moved vehicles, transports, air units, sea units, and newly built non-footsoldiers stayed unavailable after Lightning Strike.

## Tests
- Failing before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/power-actions` failed the new Eagle SCOP refresh/follow-up fixtures for unchanged `moved` flags and invalid post-SCOP actions.
- Passing after implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/power-actions`
- Passing broader CO suite: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co`
- Passing full JSON suite: `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- Build: MSBuild Debug x64 succeeded with existing dependency/conversion warnings.

## Residual Risk
The implementation intentionally follows the simulator's current unload model: loaded units are not refreshed while cargo, and an unloaded unit is marked moved by `DoUnloadAction()`.

Closes #24