### PR TITLE
Implement Sami capture power behavior

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -316,6 +316,7 @@ private:
 	int GetCOBuildCost(const Player& player, UnitProperties::Type unitType) const noexcept;
 	int GetCOIncomeForProperty(const Player& player, Terrain::Type terrainType) const noexcept;
 	int GetCOFundsAttackModifier(const Player& player, const CommandingOfficier::Type& co) const noexcept;
+	int GetCOCaptureProgress(const Player& player, const Unit& unit) const noexcept;
 	int CountOwnedProperties(const Player& player) const noexcept;
 
 	int GetMaxGoodLuck(const Player& player) noexcept;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1151,7 +1151,7 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 	}
 
 	int& cp = ptile->m_spPropertyInfo->m_capturePoints;
-	cp -= ((pUnit->health + 9)/ 10);
+	cp -= GetCOCaptureProgress(GetCurrentPlayer(), *pUnit);
 	if (cp <= 0) {
 		bool fHqCapture = ptile->m_pterrain->m_type == Terrain::Type::Headquarters;
 		ptile->Capture(&GetCurrentPlayer());
@@ -1190,6 +1190,19 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 	}
 
 	return Result::Succeeded;
+}
+
+int GameState::GetCOCaptureProgress(const Player& player, const Unit& unit) const noexcept {
+	int displayedHp = (unit.health + 9) / 10;
+	if (player.m_co.m_type == CommandingOfficier::Type::Sami && unit.IsFootsoldier()) {
+		if (player.PowerStatus() == 2) {
+			return 20;
+		}
+
+		return displayedHp * 3 / 2;
+	}
+
+	return displayedHp;
 }
 
 bool GameState::FEnemyHasLabs() const noexcept {

--- a/AdvanceWarsServer/test/json/co/sami/capture-blocked-by-enemy-unit-fails.json
+++ b/AdvanceWarsServer/test/json/co/sami/capture-blocked-by-enemy-unit-fails.json
@@ -1,0 +1,78 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-blocked-by-enemy-unit-fails",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/sami/capture-cop-damaged-mech-bonus.json
+++ b/AdvanceWarsServer/test/json/co/sami/capture-cop-damaged-mech-bonus.json
@@ -1,0 +1,126 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-cop-damaged-mech-bonus",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 70,
+            "health": 70,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    },
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-cop-damaged-mech-bonus",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 70,
+            "health": 70,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sami/capture-interrupted-resets.json
+++ b/AdvanceWarsServer/test/json/co/sami/capture-interrupted-resets.json
@@ -1,0 +1,137 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-interrupted-resets",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "property": {
+            "capture-points": 5,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-wait",
+      "source": [ 1, 0 ],
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-interrupted-resets",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 98,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sami/capture-normal-bonus.json
+++ b/AdvanceWarsServer/test/json/co/sami/capture-normal-bonus.json
@@ -1,0 +1,123 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-normal-bonus",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-normal-bonus",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 5,
+            "owner": "neutral"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sami/capture-scop-damaged-infantry-instant.json
+++ b/AdvanceWarsServer/test/json/co/sami/capture-scop-damaged-infantry-instant.json
@@ -1,0 +1,126 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-scop-damaged-infantry-instant",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 43,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 72000,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-scop-damaged-infantry-instant",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sami/capture-scop-damaged-mech-move-instant.json
+++ b/AdvanceWarsServer/test/json/co/sami/capture-scop-damaged-mech-move-instant.json
@@ -1,0 +1,129 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-scop-damaged-mech-move-instant",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 70,
+            "health": 40,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 0, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sami-capture-scop-damaged-mech-move-instant",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 69,
+            "health": 40,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sami",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 5,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -15,6 +15,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
+- Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
@@ -44,6 +45,12 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Loaded units are not refreshed while they are cargo because they are not map occupants. If a transport unloads after Lightning Strike, the unloaded unit still becomes `"moved": true` under the simulator's existing unload rule.
 - Lightning Strike is not a `BeginTurn`: it does not grant income, property repairs, property resupply, APC resupply, fuel-day processing, or capture-point changes. Black Boat repair is a normal action, so a Black Boat that repaired before Lightning Strike can repair again after being refreshed.
 
+## Capture Notes
+
+- Capture progress uses the simulator's displayed-HP calculation, where partial true-health values round up to the current displayed HP before applying capture modifiers.
+- Sami's Double Time keeps the same 150% rounded-down capture bonus as her day-to-day ability. Victory March completes captures immediately for Infantry and Mechs, including damaged footsoldiers.
+- Interrupted captures still reset to 20 capture points when the capturing unit leaves the property, and blocked captures remain unavailable while an enemy unit occupies the property.
+
 ## Tracked Follow-Up Issues
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
@@ -51,4 +58,3 @@ These AWBW mechanics are not implemented yet. They are tracked as GitHub issues 
 - [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
 - [#25](https://github.com/ryparikh/AdvanceWarsServer/issues/25): fog, vision, hiding, and terrain-defense CO effects.
 - [#26](https://github.com/ryparikh/AdvanceWarsServer/issues/26): remaining indirect-range CO effects.
-- [#27](https://github.com/ryparikh/AdvanceWarsServer/issues/27): capture-specific CO power behavior.


### PR DESCRIPTION
## Summary
- Add Sami-specific capture progress for Infantry and Mechs: 150% displayed HP rounded down during day-to-day/COP and instant captures during Victory March.
- Add focused JSON fixtures for normal capture, Double Time capture, Victory March instant captures, damaged infantry/mechs, moved captures, interrupted capture resets, and blocked captures.
- Update CO support notes to mark capture-specific behavior as implemented.

## Root Cause
Capture actions always subtracted the capturing unit's displayed HP from the property's capture points. That skipped Sami's AWBW capture modifier and Victory March's instant-capture behavior.

## Tests
- Before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/sami` failed on the new normal/COP/SCOP Sami capture fixtures because capture progress was calculated as normal displayed HP and SCOP did not capture instantly.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/sami`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/captures`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --cached --check`

## Residual Risk
- No intentional AWBW simplification for Sami capture behavior in this change. The implementation follows the simulator's existing displayed-HP capture convention, documented in `CO_SUPPORT.md`.

References: https://awbw.fandom.com/wiki/Sami and https://awbw.fandom.com/wiki/Properties

Closes #27