### PR TITLE
Add unit-cap production enforcement tests

### DIFF
--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1230,6 +1230,10 @@ Result GameState::DoBuyAction(int x, int y, const Action& action) {
 		return Result::Failed;
 	}
 
+	if (FAtUnitCap()) {
+		return Result::Failed;
+	}
+
 	int cost = GetCOBuildCost(*currentPlayer, unitType);
 	if (currentPlayer->m_funds >= cost) {
 		currentPlayer->m_funds -= cost;

--- a/AdvanceWarsServer/src/Unit.cpp
+++ b/AdvanceWarsServer/src/Unit.cpp
@@ -435,11 +435,15 @@ void from_json(const std::array<Player, 2>& arrPlayers, json& j, Unit& unit) {
 
 	std::string armyType;
 	j.at("owner").get_to(armyType);
+	unit.m_owner = nullptr;
 	if (arrPlayers[0].m_armyType == Player::armyTypefromString(armyType)) {
 		unit.m_owner = &arrPlayers[0];
 	}
 	else if (arrPlayers[1].m_armyType == Player::armyTypefromString(armyType)) {
 		unit.m_owner = &arrPlayers[1];
+	}
+	if (unit.m_owner != nullptr) {
+		++unit.m_owner->m_unitsCached;
 	}
 
 	j.at("moved").get_to(unit.m_moved);

--- a/AdvanceWarsServer/test/json/production/unit-cap-1-at-cap-production-blocked.json
+++ b/AdvanceWarsServer/test/json/production/unit-cap-1-at-cap-production-blocked.json
@@ -1,0 +1,75 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "unit-cap-1-at-cap-production-blocked",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 1000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 1,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "infantry"
+    }
+  ],
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": []
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/production/unit-cap-2-under-cap-buy-action-succeeds.json
+++ b/AdvanceWarsServer/test/json/production/unit-cap-2-under-cap-buy-action-succeeds.json
@@ -1,0 +1,138 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "unit-cap-2-under-cap-buy-action-succeeds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 1000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 2,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "infantry"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "unit-cap-2-under-cap-buy-action-succeeds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 2,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/production/unit-cap-2-under-cap-production-allowed.json
+++ b/AdvanceWarsServer/test/json/production/unit-cap-2-under-cap-production-allowed.json
@@ -1,0 +1,74 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "unit-cap-2-under-cap-production-allowed",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 1000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 2,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": [
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "infantry"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add focused JSON fixtures for unit-cap production behavior: at-cap buy rejection, at-cap legal-action suppression, under-cap legal-action control, and under-cap buy execution control.
- Hydrate `m_unitsCached` from JSON-loaded units so predeployed fixture units participate in cap checks.
- Enforce the same unit-cap guard in direct buy execution that legal action generation already used.

## Why
AWBW game settings allow a unit limit, and attempts to build or generate units beyond that cap should be prevented: https://awbw.fandom.com/wiki/AWBW_Guide#Creating_a_Game

The gap was twofold: JSON-loaded units were not counted in the cached unit total, and `DoBuyAction` did not reject buys once the active player was already at cap.

## Tests
- Red before fix: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/production` failed on `unit-cap-1-at-cap-production-blocked.json`.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/production`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

`git diff --check` passed; Git reported only CRLF normalization warnings.

## Risk
Low. The production change is scoped to buy-action cap enforcement and JSON fixture/unit loading count initialization.

Closes #40