### PR TITLE
Implement CO production effects

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -318,6 +318,7 @@ private:
 	int GetCOFundsAttackModifier(const Player& player, const CommandingOfficier::Type& co) const noexcept;
 	int GetCOCaptureProgress(const Player& player, const Unit& unit) const noexcept;
 	int CountOwnedProperties(const Player& player) const noexcept;
+	bool FCanProduceUnitFromTerrain(const Player& player, Terrain::Type terrainType, UnitProperties::Type unitType) const noexcept;
 
 	int GetMaxGoodLuck(const Player& player) noexcept;
 	int GetMaxBadLuck(const Player& player) noexcept;
@@ -337,6 +338,7 @@ private:
 	void ApplySashaMarketCrash(Player& currentPlayer) noexcept;
 	void AddSashaWarBondsFunds(Player& attackingPlayer, int damageValue) noexcept;
 	void RefreshEagleLightningStrikeUnits(const Player& player) noexcept;
+	void SpawnSenseiCityUnits(const Player& player, UnitProperties::Type unitType) noexcept;
 	bool FAtUnitCap() const noexcept;
 	bool FPlayerRouted(const Player& player) const noexcept;
 private:

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -62,6 +62,11 @@ bool TopLeftComesFirst(int x, int y, int otherX, int otherY) noexcept {
 	return y < otherY || (y == otherY && x < otherX);
 }
 
+bool FStandardGroundProductionUnit(UnitProperties::Type unitType) noexcept {
+	return UnitProperties::IsGroundUnit(unitType) &&
+		unitType != UnitProperties::Type::Piperunner;
+}
+
 int DamageValueForRachelMissile(const Unit& unit) noexcept {
 	if (unit.health < 10) {
 		return 1;
@@ -825,39 +830,12 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 			return Result::Succeeded;
 		}
 
-		switch (terrain.m_type) {
-		case Terrain::Type::Airport:
-			for (auto unit : vrgUnits) {
-				int funds = GetCurrentPlayer().m_funds;
-				if (unit.m_movementType == MovementTypes::Air && GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
-					vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
-				}
+		for (auto unit : vrgUnits) {
+			int funds = GetCurrentPlayer().m_funds;
+			if (FCanProduceUnitFromTerrain(GetCurrentPlayer(), terrain.m_type, unit.m_type) &&
+				GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
+				vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
 			}
-			break;
-		case Terrain::Type::Base:
-			for (auto unit : vrgUnits) {
-				int funds = GetCurrentPlayer().m_funds;
-				if ((unit.m_movementType == MovementTypes::Boots ||
-					unit.m_movementType == MovementTypes::Foot ||
-					unit.m_movementType == MovementTypes::Pipe ||
-					unit.m_movementType == MovementTypes::Tires ||
-					unit.m_movementType == MovementTypes::Treads) &&
-					GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
-					// TODO: How to win if players both build pipe runners
-					if (unit.m_type != UnitProperties::Type::Piperunner) {
-						vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
-					}
-				}
-			}
-			break;
-		case Terrain::Type::Port:
-			for (auto unit : vrgUnits) {
-				int funds = GetCurrentPlayer().m_funds;
-				if ((unit.m_movementType == MovementTypes::Sea || unit.m_movementType == MovementTypes::Lander) && GetCOBuildCost(GetCurrentPlayer(), unit.m_type) <= funds) {
-					vecActions.emplace_back(Action::Type::Buy, x, y, unit.m_type);
-				}
-			}
-			break;
 		}
 	}
 
@@ -1237,9 +1215,7 @@ Result GameState::DoBuyAction(int x, int y, const Action& action) {
 
 	UnitProperties::Type unitType = action.m_optUnitType.value();
 
-	if ((ptile->GetTerrain().m_type == Terrain::Type::Airport && !UnitProperties::IsAirUnit(unitType)) ||
-		(ptile->GetTerrain().m_type == Terrain::Type::Base && !UnitProperties::IsGroundUnit(unitType)) ||
-		(ptile->GetTerrain().m_type == Terrain::Type::Port && !UnitProperties::IsSeaUnit(unitType))) {
+	if (!FCanProduceUnitFromTerrain(*currentPlayer, ptile->GetTerrain().m_type, unitType)) {
 		return Result::Failed;
 	}
 
@@ -1568,6 +1544,23 @@ int GameState::GetCOBuildCost(const Player& player, UnitProperties::Type unitTyp
 		return cost * 120 / 100;
 	default:
 		return cost;
+	}
+}
+
+bool GameState::FCanProduceUnitFromTerrain(const Player& player, Terrain::Type terrainType, UnitProperties::Type unitType) const noexcept {
+	switch (terrainType) {
+	case Terrain::Type::Airport:
+		return UnitProperties::IsAirUnit(unitType);
+	case Terrain::Type::Base:
+		return FStandardGroundProductionUnit(unitType);
+	case Terrain::Type::City:
+		return player.m_co.m_type == CommandingOfficier::Type::Hachi &&
+			player.PowerStatus() == 2 &&
+			FStandardGroundProductionUnit(unitType);
+	case Terrain::Type::Port:
+		return UnitProperties::IsSeaUnit(unitType);
+	default:
+		return false;
 	}
 }
 
@@ -1976,6 +1969,9 @@ Result GameState::DoCOPowerAction() {
 		case CommandingOfficier::Type::Sasha:
 			ApplySashaMarketCrash(currentPlayer);
 			return Result::Succeeded;
+		case CommandingOfficier::Type::Sensei:
+			SpawnSenseiCityUnits(currentPlayer, UnitProperties::Type::Infantry);
+			return Result::Succeeded;
 		case CommandingOfficier::Type::Sturm:
 			ApplySturmMeteor(4);
 			return Result::Succeeded;
@@ -2004,6 +2000,31 @@ void GameState::RefreshEagleLightningStrikeUnits(const Player& player) noexcept 
 			if (pUnit != nullptr &&
 				pUnit->m_owner == &player &&
 				!pUnit->IsFootsoldier()) {
+				pUnit->m_moved = false;
+			}
+		}
+	}
+}
+
+void GameState::SpawnSenseiCityUnits(const Player& player, UnitProperties::Type unitType) noexcept {
+	for (int y = 0; y < m_spmap->GetRows(); ++y) {
+		for (int x = 0; x < m_spmap->GetCols(); ++x) {
+			if (FAtUnitCap()) {
+				return;
+			}
+
+			MapTile* pTile = nullptr;
+			if (m_spmap->TryGetTile(x, y, &pTile) != Result::Succeeded ||
+				pTile->GetTerrain().m_type != Terrain::Type::City ||
+				pTile->m_spPropertyInfo == nullptr ||
+				pTile->m_spPropertyInfo->m_owner != &player ||
+				pTile->TryGetUnit() != nullptr) {
+				continue;
+			}
+
+			if (pTile->TryAddUnit(unitType, &player) == Result::Succeeded) {
+				Unit* pUnit = pTile->TryGetUnit();
+				pUnit->health = 90;
 				pUnit->m_moved = false;
 			}
 		}
@@ -2066,6 +2087,9 @@ Result GameState::DoSCOPowerAction() {
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Rachel:
 			ApplyRachelCoveringFire();
+			return Result::Succeeded;
+		case CommandingOfficier::Type::Sensei:
+			SpawnSenseiCityUnits(currentPlayer, UnitProperties::Type::Mech);
 			return Result::Succeeded;
 		case CommandingOfficier::Type::Sturm:
 			ApplySturmMeteor(8);

--- a/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-action.json
+++ b/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-action.json
@@ -1,0 +1,117 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-merchant-union-city-deployment-action",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 45000,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-merchant-union-city-deployment-action",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 6500,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-blocked.json
+++ b/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-blocked.json
@@ -1,0 +1,88 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-merchant-union-city-deployment-blocked",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    },
+    {
+      "type": "buy",
+      "source": [ 1, 0 ],
+      "unit": "tank"
+    }
+  ],
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": []
+    },
+    {
+      "source": [ 1, 0 ],
+      "expected": []
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-unit-cap.json
+++ b/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-unit-cap.json
@@ -1,0 +1,75 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-merchant-union-city-deployment-unit-cap",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 1,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "tank"
+    }
+  ],
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": []
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-valid-actions.json
+++ b/AdvanceWarsServer/test/json/co/production-effects/hachi-merchant-union-city-deployment-valid-actions.json
@@ -1,0 +1,92 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "hachi-merchant-union-city-deployment-valid-actions",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Hachi",
+        "funds": 5000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": [
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "anti-air"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "apc"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "artillery"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "infantry"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "mech"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "recon"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "tank"
+        }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/production-effects/sensei-airborne-assault-spawns-mechs-on-empty-owned-cities.json
+++ b/AdvanceWarsServer/test/json/co/production-effects/sensei-airborne-assault-spawns-mechs-on-empty-owned-cities.json
@@ -1,0 +1,188 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sensei-airborne-assault-spawns-mechs-on-empty-owned-cities",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 34
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sensei",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sensei-airborne-assault-spawns-mechs-on-empty-owned-cities",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 3,
+            "fuel": 70,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "mech"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 35
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 34
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sensei",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/production-effects/sensei-copter-command-spawns-infantry-until-unit-cap.json
+++ b/AdvanceWarsServer/test/json/co/production-effects/sensei-copter-command-spawns-infantry-until-unit-cap.json
@@ -1,0 +1,195 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sensei-copter-command-spawns-infantry-until-unit-cap",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sensei",
+        "funds": 0,
+        "power-meter": {
+          "charge": 18000,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 2,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sensei-copter-command-spawns-infantry-until-unit-cap",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 34
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sensei",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 4,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 2,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -14,6 +14,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Active weather JSON parsing/serialization, weather movement/fuel costs, and Drake/Olaf weather-changing powers.
 - Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
+- Implemented production effects: Hachi's Merchant Union allows standard ground-unit deployment from owned empty cities, and Sensei's Copter Command/Airborne Assault spawn 9 HP unwaited Infantry/Mechs on owned empty cities in top-row, left-to-right order until the unit cap is reached.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
@@ -34,7 +35,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 ## Economy Notes
 
-- Colin, Hachi, and Kanbei cost modifiers currently apply to unit construction. Hachi's Merchant Union city deployment remains part of the broader production-effects follow-up.
+- Colin, Hachi, and Kanbei cost modifiers apply to unit construction. Hachi's Merchant Union uses the simulator's existing standard ground-production list for city deployment, so Piperunners remain excluded just as they are from base production.
 - Sasha's Market Crash applies to the single opposing player in this simulator's two-player model.
 
 ## Action-State Notes
@@ -55,6 +56,5 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
 - [#25](https://github.com/ryparikh/AdvanceWarsServer/issues/25): fog, vision, hiding, and terrain-defense CO effects.
 - [#26](https://github.com/ryparikh/AdvanceWarsServer/issues/26): remaining indirect-range CO effects.


### PR DESCRIPTION
## Summary
- Add Hachi Merchant Union city deployment for standard ground units from owned empty cities.
- Add Sensei COP/SCOP city spawning for 9 HP unwaited Infantry/Mechs, respecting ownership, occupancy, top-left order, and unit cap.
- Add focused JSON regression tests and update CO support notes, including the existing Piperunner production simplification.

## Root Cause
Hachi and Sensei production-style CO effects were previously tracked as unsupported; power activation updated status/meter but did not expose Hachi city buys or spawn Sensei footsoldiers.

## Tests
- Failing first: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/production-effects` failed on missing Hachi city buy actions and missing Sensei spawned units.
- Passing: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/production-effects`
- Passing: `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- Build: `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal` succeeded with existing third-party warnings.

## Residual Risk
Hachi city deployment intentionally follows the simulator's existing base-production simplification and does not produce Piperunners.

Closes #23