### PR TITLE
Implement indirect range CO effects

### DIFF
--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1493,15 +1493,23 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 
 
 int GameState::GetCOIndirectRangeModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit) const noexcept {
+	if (!UnitProperties::IsIndirectAttack(unit.m_properties.m_type)) {
+		return 0;
+	}
+
 	switch (co) {
 	default:
 		break;
+	case CommandingOfficier::Type::Grit:
+		return 1 + player.PowerStatus();
 	case CommandingOfficier::Type::Jake:
 		if (player.PowerStatus() != 0 && unit.IsVehicle()) {
 			return 1;
 		}
 
 		break;
+	case CommandingOfficier::Type::Max:
+		return -1;
 	}
 
 	return 0;

--- a/AdvanceWarsServer/test/json/co/grit/indirect-range-valid-actions.json
+++ b/AdvanceWarsServer/test/json/co/grit/indirect-range-valid-actions.json
@@ -1,0 +1,39 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "grit-indirect-range-valid-actions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 0, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Grit", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [1, 0] },
+    { "type": "attack", "source": [0, 0], "target": [5, 0] }
+  ],
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "attack", "source": [0, 0], "target": [2, 0] },
+        { "type": "attack", "source": [0, 0], "target": [4, 0] }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/grit/super-snipe-executes-at-six-range.json
+++ b/AdvanceWarsServer/test/json/co/grit/super-snipe-executes-at-six-range.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "grit-super-snipe-executes-at-six-range",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 0, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "medium-tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Grit", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [6, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "grit-super-snipe-executes-at-six-range",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 0, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 33, "hidden": false, "moved": false, "owner": "blue-moon", "type": "medium-tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Grit", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 9600, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/max/direct-range-valid-actions.json
+++ b/AdvanceWarsServer/test/json/co/max/direct-range-valid-actions.json
@@ -1,0 +1,31 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "max-direct-range-valid-actions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 0, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Max", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-attack", "source": [0, 0], "target": [0, 0], "direction": "east" }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/max/indirect-range-valid-actions.json
+++ b/AdvanceWarsServer/test/json/co/max/indirect-range-valid-actions.json
@@ -1,0 +1,35 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "max-indirect-range-valid-actions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 0, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Max", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "attack", "source": [0, 0], "target": [3, 0] }
+  ],
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "attack", "source": [0, 0], "target": [2, 0] }
+      ]
+    }
+  ]
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -17,7 +17,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
-- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Jake COP/SCOP indirect range for vehicles, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
 ## Weather Notes
 
@@ -31,6 +31,10 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Drake's Tsunami and Typhoon halve enemy fuel with integer truncation, then apply their HP damage. Typhoon also keeps the existing rain side effect.
 - Rachel, Sturm, and Von Bolt missile-style powers use a 2-range diamond area. Target scoring follows the AWBW wiki criteria using the simulator's two-player friendly/enemy model, unit HP, unit cost, and property capture state. Loaded units are excluded because they are not represented as map occupants.
 - Rachel's three Covering Fire target centers are selected before damage is applied, then each missile applies damage. Von Bolt's stun is represented internally until the affected player's next `BeginTurn`, where stunned units remain `"moved": true` for that turn.
+
+## Range Notes
+
+- Indirect range modifiers adjust maximum range only; minimum range is unchanged. Grit applies to all indirect units, Jake applies to vehicle indirects during COP/SCOP, and Max applies his -1 maximum-range penalty to indirect units without changing adjacent direct attacks.
 
 ## Economy Notes
 
@@ -57,4 +61,3 @@ These AWBW mechanics are not implemented yet. They are tracked as GitHub issues 
 
 - [#23](https://github.com/ryparikh/AdvanceWarsServer/issues/23): CO production effects.
 - [#25](https://github.com/ryparikh/AdvanceWarsServer/issues/25): fog, vision, hiding, and terrain-defense CO effects.
-- [#26](https://github.com/ryparikh/AdvanceWarsServer/issues/26): remaining indirect-range CO effects.


### PR DESCRIPTION
## Summary
- Add Grit day-to-day/COP/SCOP indirect maximum-range modifiers.
- Add Max's indirect maximum-range penalty while leaving direct attacks unchanged.
- Document the supported range behavior and remove #26 from the open CO follow-up list.

## Root Cause
The simulator only applied Jake's indirect range helper, so Grit's AWBW range bonuses and Max's indirect penalty were missing from valid action generation and attack execution validation.

## Tests
- Initially observed focused failures in `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/grit` and `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/max` before implementation.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/grit`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/max`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --cached --check`

## Notes
- Indirect CO range modifiers intentionally adjust max range only; minimum range remains unchanged.
- AWBW-relevant range COs covered here are Grit, Jake, and Max.

Closes #26