### PR TITLE
Add black boat repair action fixtures

### DIFF
--- a/AdvanceWarsServer/test/json/transport/blackboat/repair-full-health-resupply-no-cost.json
+++ b/AdvanceWarsServer/test/json/transport/blackboat/repair-full-health-resupply-no-cost.json
@@ -1,0 +1,167 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-full-health-resupply-no-cost",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 12,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "repair",
+      "source": [ 2, 0 ],
+      "direction": "west"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-full-health-resupply-no-cost",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 2,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/transport/blackboat/repair-invalid-targets.json
+++ b/AdvanceWarsServer/test/json/transport/blackboat/repair-invalid-targets.json
@@ -1,0 +1,106 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "blackboat-repair-invalid-targets",
+    "map": [
+      [
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 12,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 3
+        },
+        {
+          "terrain": 29,
+          "unit": {
+            "ammo": 0,
+            "fuel": 50,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "blackboat"
+          }
+        },
+        {
+          "terrain": 3,
+          "unit": {
+            "ammo": 0,
+            "fuel": 12,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "repair",
+      "source": [ 2, 0 ],
+      "direction": "east"
+    },
+    {
+      "type": "repair",
+      "source": [ 2, 0 ],
+      "direction": "west"
+    },
+    {
+      "type": "repair",
+      "source": [ 2, 0 ],
+      "direction": "north"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a Black Boat direct repair fixture for a full-health allied target that still resupplies ammo/fuel without spending funds.
- Add failed-action coverage for enemy targets, non-adjacent allied targets, and off-map repair directions.

## Why
Issue #41 asked for explicit direct repair-action coverage around Black Boat repair/resupply behavior. Existing fixtures already covered damaged allied repair with HP cap/funds cost and insufficient-funds resupply-only behavior; these new fixtures fill the full-health and invalid-target gaps.

## Tests
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/transport/blackboat`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`

Both pass after rebuilding Debug x64.

## Risk
Test-only change. No gameplay code was changed.

Closes #41