### PR TITLE
Expand lab capture and victory-condition tests

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -218,6 +218,12 @@
     <None Include="test\json\com-tower\attack-bonus-two-owned-towers.json" />
     <None Include="test\json\com-tower\begin-turn-no-income.json" />
     <None Include="test\json\com-tower\capture-progress-and-transfer.json" />
+    <None Include="test\json\lab\begin-turn-no-income.json" />
+    <None Include="test\json\lab\capture-interrupted-resets.json" />
+    <None Include="test\json\lab\capture-progress-and-transfer.json" />
+    <None Include="test\json\lab\multiple-enemy-labs-capturing-all-wins.json" />
+    <None Include="test\json\lab\multiple-enemy-labs-capturing-one-does-not-win.json" />
+    <None Include="test\json\lab\victory-player1.json" />
     <None Include="test\json\combat\infantry\forest\city\infantry-infantry.json" />
     <None Include="test\json\combat\infantry\infantryCity0-infantryCity0.json" />
     <None Include="test\json\combat\infantry\infantryMountain0-infantryMountain0.json" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -295,6 +295,12 @@
     <None Include="test\json\com-tower\attack-bonus-two-owned-towers.json" />
     <None Include="test\json\com-tower\begin-turn-no-income.json" />
     <None Include="test\json\com-tower\capture-progress-and-transfer.json" />
+    <None Include="test\json\lab\begin-turn-no-income.json" />
+    <None Include="test\json\lab\capture-interrupted-resets.json" />
+    <None Include="test\json\lab\capture-progress-and-transfer.json" />
+    <None Include="test\json\lab\multiple-enemy-labs-capturing-all-wins.json" />
+    <None Include="test\json\lab\multiple-enemy-labs-capturing-one-does-not-win.json" />
+    <None Include="test\json\lab\victory-player1.json" />
     <None Include="test\json\joining\full-health-join-hurt.json" />
     <None Include="test\json\joining\hurt-join-full-health-fail.json" />
     <None Include="test\json\joining\basic-supply.json" />

--- a/AdvanceWarsServer/test/json/lab/begin-turn-no-income.json
+++ b/AdvanceWarsServer/test/json/lab/begin-turn-no-income.json
@@ -1,0 +1,163 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-begin-turn-no-income",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-begin-turn-no-income",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 4000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/lab/capture-interrupted-resets.json
+++ b/AdvanceWarsServer/test/json/lab/capture-interrupted-resets.json
@@ -1,0 +1,183 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-capture-interrupted-resets",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 91,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 15,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-wait",
+      "source": [ 1, 0 ],
+      "target": [ 0, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-capture-interrupted-resets",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 98,
+            "health": 91,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 145,
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 2000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/lab/capture-progress-and-transfer.json
+++ b/AdvanceWarsServer/test/json/lab/capture-progress-and-transfer.json
@@ -1,0 +1,262 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-capture-progress-and-transfer",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 91,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 44,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 140,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "blue-moon"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 2, 0 ],
+      "target": [ 2, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 3, 0 ],
+      "target": [ 3, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 4, 0 ],
+      "target": [ 4, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-capture-progress-and-transfer",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 91,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 44,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 15,
+            "owner": "neutral"
+          }
+        },
+        {
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/lab/multiple-enemy-labs-capturing-all-wins.json
+++ b/AdvanceWarsServer/test/json/lab/multiple-enemy-labs-capturing-all-wins.json
@@ -1,0 +1,174 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-multiple-enemy-labs-capturing-all-wins",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        },
+        {
+          "terrain": 140,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "blue-moon"
+          }
+        },
+        {
+          "terrain": 140,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "blue-moon"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    },
+    {
+      "type": "move-capture",
+      "source": [ 2, 0 ],
+      "target": [ 2, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": true,
+    "gameId": "lab-multiple-enemy-labs-capturing-all-wins",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        },
+        {
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": 0
+  }
+}

--- a/AdvanceWarsServer/test/json/lab/multiple-enemy-labs-capturing-one-does-not-win.json
+++ b/AdvanceWarsServer/test/json/lab/multiple-enemy-labs-capturing-one-does-not-win.json
@@ -1,0 +1,151 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-multiple-enemy-labs-capturing-one-does-not-win",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        },
+        {
+          "terrain": 140,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "blue-moon"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 140
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-multiple-enemy-labs-capturing-one-does-not-win",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146
+        },
+        {
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 140
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/lab/victory-player1.json
+++ b/AdvanceWarsServer/test/json/lab/victory-player1.json
@@ -1,0 +1,137 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lab-victory-player1",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 140
+        },
+        {
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "orange-star"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": true,
+    "gameId": "lab-victory-player1",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 140
+        },
+        {
+          "terrain": 140,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "blue-moon",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": 1
+  }
+}


### PR DESCRIPTION
## Summary
- Add a dedicated `test/json/lab` suite for lab income, capture progress, ownership transfer, interruption/reset, player-1 lab victory, and multi-lab victory/non-victory behavior.
- Include the new lab fixtures in the Visual Studio project metadata.

## Why
Issue #44 asks for lab behavior coverage beyond the existing capture-victory smoke test. The AWBW lab rules being pinned here are that labs do not provide income, only act as HQ substitutes on no-HQ maps, and require every enemy-owned lab to be captured before lab victory.

## Tests
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/lab` passed immediately after adding the fixtures, confirming the current implementation already matches the expected lab behavior.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --cached --check`

## Risk
Low. This is test-only coverage plus project-file includes; no production logic changed.

Closes #44