### PR TITLE
Add project README and contributor docs

### DIFF
--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -43,3 +43,24 @@ You can also run a subset:
 ```powershell
 ..\x64\Debug\AdvanceWarsServer.exe -test test/json/transport
 ```
+
+## Executable Options
+
+The executable currently recognizes these development commands:
+
+| Option | Purpose | Notes |
+| --- | --- | --- |
+| `-test [path]` | Run the recursive JSON fixture suite. | Defaults to `test/json`. Run from `AdvanceWarsServer/` so relative paths resolve. |
+| `-sim-random-move-game [seed]` | Run an experimental random-action simulation. | Uses local output paths that still need cleanup before general use. |
+| `-sim-mcts-game` | Run an experimental MCTS simulation. | Uses local output paths that still need cleanup before general use. |
+| `-converter` | Regenerate the hardcoded Lefty map JSON. | Developer utility. |
+| `-torchlib` | Run a local libtorch/MNIST experiment. | Depends on local `D:/MNIST` and libtorch paths. |
+
+The usage text also advertises `-server`, and the HTTP wrapper exists in `AdvanceWarsServer/src/AdvanceWarsServer.cpp`, but `main.cpp` does not currently dispatch `-server` to `AdvanceWarsServer::run()`. The REST/server contract cleanup is tracked by #66.
+
+## Additional Docs
+
+- `README.md`: project overview and navigation.
+- `STANDARD_ENGINE_COMPLETENESS.md`: current Standard rules/API matrix.
+- `docs/API.md`: current and target API shape.
+- `docs/JSON_FIXTURES.md`: fixture authoring guide.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# AdvanceWarsServer
+
+AdvanceWarsServer is a C++ Advance Wars By Web style simulation engine. The current project goal is to make normal Global League Standard games playable through a reliable engine/API boundary, then use that same boundary for AI self-play, replay verification, and eventually a human-facing React client.
+
+The engine is intentionally treated as the source of truth for rules and legal actions. Frontends, bots, and training loops should render state, request legal actions, and submit actions instead of reimplementing gameplay rules.
+
+## Current Target
+
+The first complete rules target is normal AWBW Global League Standard:
+
+- 2 players.
+- Clear weather.
+- Fog of War off.
+- CO powers on.
+- Tags off.
+- 0 starting funds.
+- 1000 funds per fund-producing property.
+- Black Bomb production banned.
+
+Other modes such as Fog, High Funds, Tags, Random Weather, Teleport Tiles, and multiplayer/team games are intentionally deferred until the Standard engine path is reliable.
+
+See [STANDARD_ENGINE_COMPLETENESS.md](STANDARD_ENGINE_COMPLETENESS.md) for the current implementation matrix and GitHub issue index.
+
+## Repository Map
+
+| Path | Purpose |
+| --- | --- |
+| `AdvanceWarsServer/` | C++ engine, HTTP server wrapper, tests, resources, and Visual Studio project. |
+| `AdvanceWarsServer/inc/` | Public engine headers for game state, actions, units, map tiles, COs, and MCTS. |
+| `AdvanceWarsServer/src/` | Engine implementation, JSON fixture runner, map parser, HTTP routes, and platform code. |
+| `AdvanceWarsServer/test/json/` | Recursive JSON regression suite for engine behavior. |
+| `AdvanceWarsServer/res/AWBW/` | AWBW map/game source data used for development and conversion experiments. |
+| `BUILD_AND_TEST.md` | Build, executable, and test commands. |
+| `STANDARD_ENGINE_COMPLETENESS.md` | Standard-mode rules/API completeness matrix and issue index. |
+| `CO_SUPPORT.md` | Implemented CO behavior and focused CO follow-up issues. |
+| `TRAINING_LOOP_WORK_ITEMS.md` | Self-play, MCTS, tensor, model, and training-loop roadmap. |
+| `docs/API.md` | Current and target REST/API contract notes. |
+| `docs/JSON_FIXTURES.md` | JSON regression fixture format and authoring guide. |
+
+## Quick Start
+
+Build the Debug x64 configuration from the repository root:
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal
+```
+
+Run the full JSON suite from the project directory:
+
+```powershell
+Set-Location .\AdvanceWarsServer
+..\x64\Debug\AdvanceWarsServer.exe -test test/json
+```
+
+Run a focused subset:
+
+```powershell
+..\x64\Debug\AdvanceWarsServer.exe -test test/json/transport
+```
+
+More command details are in [BUILD_AND_TEST.md](BUILD_AND_TEST.md).
+
+## Development Workflow
+
+1. Check the relevant docs and issues before changing rules behavior.
+2. Use the AWBW wiki as the gameplay reference, but prefer local source and JSON tests as the source of truth for current behavior.
+3. When local behavior differs from AWBW, document the gap in a focused issue before changing code.
+4. Add or update JSON fixtures for rule changes.
+5. Run the narrowest relevant JSON subset, then the full JSON suite.
+
+The project notes in [AGENTS.md](AGENTS.md) are short but important: use the [Advance Wars By Web Wiki](https://awbw.fandom.com/wiki/Advance_Wars_By_Web_Wiki) for rules research, and call out any source-vs-wiki gap before changing implementation.
+
+## Testing Model
+
+The JSON suite is the main executable documentation for engine behavior. A fixture can:
+
+- Apply actions from an `initial-game-state` and compare with `final-game-state`.
+- Assert that actions fail.
+- Assert legal actions for a selected tile.
+- Check CO parser/chart contracts.
+- Check deterministic replay traces.
+
+See [docs/JSON_FIXTURES.md](docs/JSON_FIXTURES.md) and [AdvanceWarsServer/test/json/units/README.md](AdvanceWarsServer/test/json/units/README.md).
+
+## API And Frontend Direction
+
+The desired direction is:
+
+- C++ engine owns rules, legal actions, and state transitions.
+- REST API exposes game creation, state fetch, legal actions, explicit action stepping, errors, and terminal metadata.
+- React frontend renders board state and asks the server what actions are legal.
+- Bot replay and fixture visualizers reuse the same board renderer.
+
+The current HTTP wrapper is still early and hardcoded in places. See [docs/API.md](docs/API.md) and the related issues #66, #67, #68, #110, #111, #112, #113, #114, and #115.
+
+## Rule References
+
+Primary local/reference docs:
+
+- Local report: `C:\Users\Roshan\Downloads\advance-wars-by-web-report.md`
+- AWBW wiki hub: https://awbw.fandom.com/wiki/Advance_Wars_By_Web_Wiki
+- AWBW Metagame: https://awbw.fandom.com/wiki/Metagame
+- AWBW Guide: https://awbw.fandom.com/wiki/AWBW_Guide
+- AWBW Units: https://awbw.fandom.com/wiki/Units
+- AWBW Properties: https://awbw.fandom.com/wiki/Properties
+- AWBW Damage Formula: https://awbw.fandom.com/wiki/Damage_Formula
+- AWBW COs: https://awbw.fandom.com/wiki/CO
+
+## Known Caveats
+
+- The Standard completeness matrix is current as of its review date, not a substitute for issue triage.
+- The current REST wrapper does not yet satisfy the target API contract.
+- Several engine behaviors are intentionally documented as gaps rather than papered over in the docs.
+- Some local paths in experimental simulation/model code are still machine-specific and should be cleaned up before relying on those workflows broadly.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,100 @@
+# API Notes
+
+Last reviewed: 2026-05-18
+
+This document describes the current HTTP surface and the target API shape for the Standard engine/frontend work. The C++ engine must remain authoritative for legal actions and state transitions; API clients should not duplicate rule logic.
+
+## Current Implementation
+
+The HTTP route registration lives in `AdvanceWarsServer/src/AdvanceWarsServer.cpp`.
+
+| Method | Route | Current behavior |
+| --- | --- | --- |
+| `POST` | `/games` | Parses the request body, ignores its contents, creates one hardcoded Lefty game with Andy vs. Adder, and returns the serialized game state. |
+| `GET` | `/actions/:gameid/:x/:y` | Returns valid actions for a single board coordinate. |
+| `GET` | `/actions/:gameid` | Returns all valid actions for the active player. |
+| `POST` | `/actions/:gameid` | Parses an `Action`, applies it to cached state, may auto-end-turn if only `EndTurn` remains, and returns the serialized game state. |
+
+Important caveats:
+
+- The current `main.cpp` usage text advertises `-server`, but the command dispatcher does not currently call `AdvanceWarsServer::run()` for that option.
+- Game creation ignores map, settings, players, countries, COs, and seed.
+- Unknown game ids and invalid action responses are not a stable contract yet.
+- `POST /actions/:gameid` can apply implicit extra state change through auto-end-turn behavior.
+- Action execution and legal-action generation do not yet have a fully atomic shared validation contract.
+
+The target cleanup is tracked by:
+
+- #66: REST game lifecycle and step API contract.
+- #67: Validate and atomically reject illegal submitted actions.
+- #68: Make REST action stepping explicit and remove implicit auto-end-turn.
+- #69: Remove heuristic auto-resign from Standard terminal logic.
+- #65: Define and enforce normal Global League Standard game settings.
+
+## Target API Shape
+
+The eventual API should support both humans and AI clients with the same loop:
+
+1. Create a game from map, settings, players, COs, countries, and optional deterministic seed.
+2. Fetch the authoritative game state.
+3. Fetch legal actions for the active player or selected tile.
+4. Submit exactly one action.
+5. Receive either an atomic failure or the next authoritative state.
+6. Observe terminal status and winner/reason when the game ends.
+
+Suggested resources:
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `POST` | `/games` | Create a game from a validated setup payload. |
+| `GET` | `/games/:gameid` | Fetch current authoritative game state. |
+| `GET` | `/games/:gameid/actions` | Fetch all legal actions for the active player. |
+| `GET` | `/games/:gameid/actions?x=4&y=7` | Fetch legal actions for one selected coordinate. |
+| `POST` | `/games/:gameid/actions` | Submit exactly one action. |
+| `GET` | `/games/:gameid/trace` | Optional replay/debug trace once action history exists. |
+
+The exact route names can change, but the contract should be explicit before the React client and training loop depend on it.
+
+## Response Principles
+
+Game state responses should include:
+
+- `gameId`
+- active player and day/turn information
+- map tiles, terrain, property ownership, capture points, and units
+- player funds, CO, power meter/status, and army/country identity
+- weather and settings
+- terminal status, winner, and terminal reason when applicable
+
+Action responses should include:
+
+- submitted action
+- success/failure
+- validation errors for rejected actions
+- resulting game state on success
+- no hidden implicit action commits
+
+Legal-action responses should include:
+
+- the current active player context
+- the legal actions as server-serialized `Action` objects
+- optional selection/source metadata for tile-specific requests
+
+## Frontend And Bot Consumer Rules
+
+Clients should:
+
+- Treat server state as authoritative.
+- Render legal actions supplied by the server.
+- Submit one action at a time.
+- Resync from the server after each accepted action or rejected action.
+- Avoid inferring legality from visual state except for presentation hints.
+
+Related frontend trackers:
+
+- #110: React frontend workspace and board renderer.
+- #111: Bot replay and self-play game visualizer.
+- #112: Human-play web client using server legal actions.
+- #113: JSON fixture and scenario visualization workflow.
+- #114: Frontend API adapter and shared game-state types.
+- #115: Frontend asset pipeline.

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -1,0 +1,171 @@
+# JSON Fixture Guide
+
+Last reviewed: 2026-05-18
+
+The JSON suite under `AdvanceWarsServer/test/json` is the main executable documentation for engine behavior. The test runner recursively discovers `.json` files and runs each fixture independently.
+
+Run all fixtures from the `AdvanceWarsServer` project directory:
+
+```powershell
+..\x64\Debug\AdvanceWarsServer.exe -test test/json
+```
+
+Run a subset:
+
+```powershell
+..\x64\Debug\AdvanceWarsServer.exe -test test/json/transport
+```
+
+## Fixture Types
+
+The runner supports several top-level fixture shapes.
+
+### State Transition Fixture
+
+Use this for normal behavior: start from an initial state, apply actions, and compare the serialized result with the expected final state.
+
+```json
+{
+  "initial-game-state": {
+  },
+  "actions": [
+  ],
+  "final-game-state": {
+  }
+}
+```
+
+The runner:
+
+1. Parses `initial-game-state`.
+2. Applies each action in `actions` with `GameState::DoAction`.
+3. Serializes the result.
+4. Compares it byte-for-byte with `final-game-state` after both states are normalized through engine serialization.
+
+### Failed Actions Fixture
+
+Use `failedActions` to assert that actions are rejected from the initial state.
+
+```json
+{
+  "initial-game-state": {
+  },
+  "failedActions": [
+  ]
+}
+```
+
+Each action must return `Result::Failed`.
+
+Important: current invalid-action behavior is not fully atomic in all paths. If a fixture checks multiple `failedActions`, keep them independent from the same initial state and watch #67 for the broader validation cleanup.
+
+### Valid Actions Fixture
+
+Use `validActions` to assert the exact legal actions for a board coordinate.
+
+```json
+{
+  "initial-game-state": {
+  },
+  "validActions": [
+    {
+      "source": [4, 7],
+      "expected": [
+      ]
+    }
+  ]
+}
+```
+
+The runner calls `GetValidActions(x, y)` and compares the serialized action list to `expected`.
+
+### Deterministic Replay Fixture
+
+Use `deterministic-replay` when an action sequence should serialize to the same trace every time.
+
+```json
+{
+  "initial-game-state": {
+  },
+  "actions": [
+  ],
+  "deterministic-replay": true
+}
+```
+
+The runner applies the same action sequence twice and compares the full serialized trace.
+
+### CO Contract Fixture
+
+Use `co-contract` to check CO parser round-trip, power-meter stars, and checked-in chart values.
+
+```json
+{
+  "co-contract": {
+    "name": "Andy",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 6
+    },
+    "stats": [
+      {
+        "unit": "infantry",
+        "normal": [100, 100],
+        "cop": [110, 110],
+        "scop": [110, 110]
+      }
+    ]
+  }
+}
+```
+
+Use `invalid-co` to assert that an unknown CO string is rejected.
+
+## Action JSON
+
+Action JSON is parsed by `from_json(json&, Action&)` in `GameState.cpp`. Existing fixtures are the best source for exact spelling. Common action types include:
+
+- `attack`
+- `end-turn`
+- `move-wait`
+- `move-attack`
+- `unload`
+- `move-load`
+- `move-capture`
+- `move-combine`
+- `repair`
+- `buy`
+- `co-power`
+- `super-co-power`
+
+When adding an action fixture, prefer copying the smallest nearby fixture that already uses the same action shape.
+
+## Authoring Guidelines
+
+- Keep each fixture focused on one behavior or edge case.
+- Put new unit-owned behavior under `test/json/units/<unit-type>/` when practical.
+- Put cross-cutting rule behavior under the nearest feature folder, such as `captures`, `production`, `transport`, `weather`, `com-tower`, `lab`, or `co`.
+- Include at least one boundary/negative case for new mechanics.
+- For AWBW-specific behavior, link the corresponding GitHub issue in nearby documentation or the PR body.
+- Run the focused folder first, then the full suite.
+
+## Useful Existing Fixture Areas
+
+| Folder | Useful for |
+| --- | --- |
+| `captures/` | Capture progress, capture interruption, property transfer, airports, ports, labs, and Com Towers. |
+| `production/` | Buy actions, production terrain, unit cap, airports, and ports. |
+| `transport/` | Load/unload, cargo destruction, APC resupply, carrier/cruiser loaded resupply, Black Boat repair. |
+| `co/` | CO contract, economy, power actions, production effects, Grit/Max/Sami behavior. |
+| `weather/` | Rain/snow movement, temporary weather, Drake/Olaf powers. |
+| `units/` | Unit-owned movement, fuel, combat, ammo, and boundaries. |
+
+## Debugging Failures
+
+On failure, the runner prints:
+
+- the failing file path
+- expected serialized JSON
+- actual serialized JSON
+
+The output is often dense. For board-level regressions, the planned fixture visualizer is tracked by #113.


### PR DESCRIPTION
## Summary
- Add a top-level `README.md` with project overview, current Standard target, quick start, repo map, development workflow, testing model, API/frontend direction, and rule references.
- Add `docs/API.md` to document the current HTTP surface, current caveats, and target API principles for humans, bots, and frontends.
- Add `docs/JSON_FIXTURES.md` with fixture types, examples, authoring guidance, and debugging notes.
- Extend `BUILD_AND_TEST.md` with executable options and the current `-server` dispatcher caveat.

## Why
The repo now has several focused rule and training docs, but it was missing a welcoming entrypoint and contributor-facing guidance. These docs make it easier to build, test, understand the engine boundary, and add rule fixtures without spelunking through source first.

## Tests
- `git diff --check origin/master..HEAD`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`

## Notes
- Documentation only; no engine behavior changes.
- This PR builds on the merged Standard completeness documentation from #109.