### PR TITLE
Restrict property repair by unit class

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -349,6 +349,7 @@
     <None Include="test\json\misc\begin-turn-fuel.json" />
     <None Include="test\json\misc\begin-turn-funds.json" />
     <None Include="test\json\misc\begin-turn-no-repair-enemy-property.json" />
+    <None Include="test\json\misc\begin-turn-property-repair-class-compatibility.json" />
     <None Include="test\json\misc\begin-turn-repair-enough-funds.json" />
     <None Include="test\json\misc\end-game-capturelimit-player0.json" />
     <None Include="test\json\misc\end-game-hqcap-player0.json" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -310,6 +310,7 @@
     <None Include="test\json\misc\begin-turn-fuel-out_of_fuel.json" />
     <None Include="test\json\misc\begin-turn-funds.json" />
     <None Include="test\json\misc\begin-turn-repair-enough-funds.json" />
+    <None Include="test\json\misc\begin-turn-property-repair-class-compatibility.json" />
     <None Include="test\json\captures\infantry-join-capture.json" />
     <None Include="test\json\captures\infantry-stops-capture.json" />
     <None Include="test\json\misc\end-game-rout-indirect-attack.json" />

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -50,6 +50,21 @@ bool FProducesIncome(Terrain::Type terrainType) noexcept {
 		terrainType != Terrain::Type::Lab;
 }
 
+bool FPropertyServicesUnit(Terrain::Type terrainType, UnitProperties::Type unitType) noexcept {
+	switch (terrainType) {
+	case Terrain::Type::City:
+	case Terrain::Type::Base:
+	case Terrain::Type::Headquarters:
+		return UnitProperties::IsGroundUnit(unitType);
+	case Terrain::Type::Airport:
+		return UnitProperties::IsAirUnit(unitType);
+	case Terrain::Type::Port:
+		return UnitProperties::IsSeaUnit(unitType);
+	default:
+		return false;
+	}
+}
+
 bool FKindleUrbanTerrain(Terrain::Type terrainType) noexcept {
 	return MapTile::IsProperty(terrainType);
 }
@@ -181,16 +196,20 @@ Result GameState::BeginTurn() noexcept {
 					}
 				}
 
-				if (MapTile::IsProperty(terrain.m_type) && pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[player] && terrain.m_type != Terrain::Type::ComTower && terrain.m_type != Terrain::Type::Lab && pUnit->m_owner == &m_arrPlayers[player]) {
-					Unit* pUnit = pTile->TryGetUnit();
-					pUnit->m_properties.m_fuel = GetUnitInfo(pUnit->m_properties.m_type).m_fuel;
-					pUnit->m_properties.m_ammo = GetUnitInfo(pUnit->m_properties.m_type).m_ammo;
-					if (pUnit != nullptr && pUnit->health < 100) {
-						int repairAmount = std::min(100 - pUnit->health, 20);
-						int unitRepairFunds = Unit::GetUnitCost(pUnit->m_properties.m_type) * (repairAmount/10);
+				if (pTile->m_spPropertyInfo != nullptr && pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[player] && pUnit->m_owner == &m_arrPlayers[player] && FPropertyServicesUnit(terrain.m_type, pUnit->m_properties.m_type)) {
+					Unit* pServiceUnit = pTile->TryGetUnit();
+					if (pServiceUnit == nullptr) {
+						continue;
+					}
+
+					pServiceUnit->m_properties.m_fuel = GetUnitInfo(pServiceUnit->m_properties.m_type).m_fuel;
+					pServiceUnit->m_properties.m_ammo = GetUnitInfo(pServiceUnit->m_properties.m_type).m_ammo;
+					if (pServiceUnit->health < 100) {
+						int repairAmount = std::min(100 - pServiceUnit->health, 20);
+						int unitRepairFunds = Unit::GetUnitCost(pServiceUnit->m_properties.m_type) * (repairAmount/10);
 						if (unitRepairFunds <= m_arrPlayers[player].m_funds) {
 							m_arrPlayers[player].m_funds -= unitRepairFunds;
-							pUnit->health += repairAmount;
+							pServiceUnit->health += repairAmount;
 						}
 					}
 				}

--- a/AdvanceWarsServer/test/json/misc/begin-turn-property-repair-class-compatibility.json
+++ b/AdvanceWarsServer/test/json/misc/begin-turn-property-repair-class-compatibility.json
@@ -1,0 +1,391 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "begin-turn-property-repair-class-compatibility",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 40,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 40,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 41,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "battleship"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "battleship"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 134,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        { "terrain": 1 },
+        { "terrain": 1 },
+        { "terrain": 1 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "begin-turn-property-repair-class-compatibility",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 40,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 40,
+          "unit": {
+            "ammo": 6,
+            "fuel": 97,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 7,
+            "health": 80,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 41,
+          "unit": {
+            "ammo": 9,
+            "fuel": 98,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "battleship"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 8,
+            "health": 80,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "battleship"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 146,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 80,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 134,
+          "unit": {
+            "ammo": 0,
+            "fuel": 7,
+            "health": 80,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        }
+      ],
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        { "terrain": 1 },
+        { "terrain": 1 },
+        { "terrain": 1 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 7200,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -114,7 +114,7 @@ The unit fixture manifest lives at `AdvanceWarsServer/test/json/units/README.md`
 | --- | --- | --- | --- | --- |
 | Core terrain movement | JSON fixtures cover many terrain, weather, air, land, and sea movement cases. | AWBW movement tables. | Partial where Piperunner/Sturm/Teleport remain | #35, #85, #93 |
 | Properties and income | Cities/Bases/Airports/Ports/HQ income behavior exists; Labs/Com Towers no-income fixtures exist. | AWBW fund-producing properties only. | Complete for normal income, configurable settings partial | #65 |
-| Property repair/resupply | Begin-turn repair currently applies too broadly by property type. | Land on City/Base/HQ, air on Airport, sea on Port; owner only. | Partial | #71 |
+| Property repair/resupply | Begin-turn property service is gated by owner, property type, and unit class; Labs and Com Towers do not repair or resupply. | Land on City/Base/HQ, air on Airport, sea on Port; owner only. | Complete for normal property service | none |
 | Rachel property repair | Normal property repair is not Rachel-aware. | Rachel repairs +1 extra displayed HP on compatible properties. | Partial | #72 |
 | APC/Cruiser/Carrier resupply | Dedicated transport and loaded-resupply fixtures exist. | AWBW logistics order and compatible cargo. | Complete for current Standard coverage | none |
 | Labs | Lab capture/no-income/lab-victory fixtures exist. | Labs can act as no-HQ loss condition and do not produce income. | Complete for two-player Standard model | #76 for lab-unit production setting |
@@ -208,7 +208,6 @@ Actions, units, and data:
 
 Properties, economy, and COs:
 
-- #71: Restrict property repair and resupply by property type and unit class.
 - #72: Implement Rachel property repair bonus.
 - #81: Verify CO star costs and power-meter charge math against AWBW.
 - #83: Implement Jess Turbo Charge COP resupply side effect.


### PR DESCRIPTION
## Summary
- Gate begin-turn property repair/resupply by property type and unit class: land on City/Base/HQ, air on Airport, sea on Port.
- Keep Labs and Com Towers as no-service properties and charge funds only for compatible HP repairs.
- Add a regression fixture covering compatible/incompatible land, air, and sea property service, and update the Standard coverage doc.

## Root Cause
Begin-turn property service previously allowed any owned property except Lab/Com Tower to refuel, rearm, and repair any owned unit standing on it. That let off-class units such as tanks on Airports, copters on Cities, and ships on HQs receive service and spend repair funds.

## Tests
- Failing before fix: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/misc` failed on `begin-turn-property-repair-class-compatibility.json` because off-class units were serviced and funds dropped to 200 instead of 7200.
- Passing after fix: MSBuild Debug x64 succeeded; `..\x64\Debug\AdvanceWarsServer.exe -test test/json` passed.

## Residual Risk
- Rachel's +1 displayed HP property repair bonus remains tracked separately in #72.

Closes #71