### PR TITLE
Implement Eagle air fuel upkeep

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -325,6 +325,7 @@ private:
 	int RollCombatLuck(int min, int max);
 	int GetCOMovementBonus(const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
 	int GetWeatherMovementCost(const Terrain& terrain, const Player& player, const Unit& unit) const noexcept;
+	int GetFuelCostPerDay(const Player& player, const Unit& unit) const noexcept;
 	void SetTemporaryWeather(WeatherType weather) noexcept;
 	void TickTemporaryWeather() noexcept;
 	void HealUnits(const Player& player, int health);

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -209,8 +209,7 @@ Result GameState::BeginTurn() noexcept {
 			if (pUnit != nullptr &&
 				pUnit->m_owner == &GetCurrentPlayer() &&
 				(pUnit->IsAirUnit() || pUnit->IsSeaUnit())) {
-				bool isHidden = pUnit->IsHidden();
-				pUnit->m_properties.m_fuel -= isHidden ? pUnit->m_properties.m_fuelCostPerDay.second : pUnit->m_properties.m_fuelCostPerDay.first;
+				pUnit->m_properties.m_fuel -= GetFuelCostPerDay(GetCurrentPlayer(), *pUnit);
 				if (pUnit->m_properties.m_fuel <= 0) {
 					m_spmap->TryDestroyUnit(x, y);
 					if (FPlayerRouted(GetCurrentPlayer())) {
@@ -514,6 +513,15 @@ int GameState::GetWeatherMovementCost(const Terrain& terrain, const Player& play
 	}
 
 	return baseCost;
+}
+
+int GameState::GetFuelCostPerDay(const Player& player, const Unit& unit) const noexcept {
+	int fuelCost = unit.IsHidden() ? unit.m_properties.m_fuelCostPerDay.second : unit.m_properties.m_fuelCostPerDay.first;
+	if (player.m_co.m_type == CommandingOfficier::Type::Eagle && unit.IsAirUnit()) {
+		fuelCost += 2;
+	}
+
+	return fuelCost;
 }
 
 void GameState::SetTemporaryWeather(WeatherType weather) noexcept {

--- a/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-after-power-weather-expire.json
+++ b/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-after-power-weather-expire.json
@@ -1,0 +1,139 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-air-fuel-upkeep-after-power-weather-expire",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 10,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bomber"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "weather-turns-remaining": 1,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-air-fuel-upkeep-after-power-weather-expire",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 3,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "bomber"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-crash.json
+++ b/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-crash.json
@@ -1,0 +1,152 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-air-fuel-upkeep-crash",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 4,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 0,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-air-fuel-upkeep-crash",
+    "map": [
+      [
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 0,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep.json
+++ b/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep.json
@@ -1,0 +1,233 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-air-fuel-upkeep",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "fighter"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 20,
+            "health": 100,
+            "hidden": true,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "stealth"
+          }
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "battleship"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "eagle-air-fuel-upkeep",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 5,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 2,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "fighter"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 6,
+            "fuel": 10,
+            "health": 100,
+            "hidden": true,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "stealth"
+          }
+        },
+        {
+          "terrain": 28,
+          "unit": {
+            "ammo": 9,
+            "fuel": 8,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "battleship"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Eagle",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 6,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -16,6 +16,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
 - Implemented production effects: Hachi's Merchant Union allows standard ground-unit deployment from owned empty cities, and Sensei's Copter Command/Airborne Assault spawn 9 HP unwaited Infantry/Mechs on owned empty cities in top-row, left-to-right order until the unit cap is reached.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
+- Implemented fuel-upkeep modifiers: Eagle air units consume 2 additional fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
@@ -50,6 +51,12 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Loaded units are not refreshed while they are cargo because they are not map occupants. If a transport unloads after Lightning Strike, the unloaded unit still becomes `"moved": true` under the simulator's existing unload rule.
 - Lightning Strike is not a `BeginTurn`: it does not grant income, property repairs, property resupply, APC resupply, fuel-day processing, or capture-point changes. Black Boat repair is a normal action, so a Black Boat that repaired before Lightning Strike can repair again after being refreshed.
 
+## Fuel Upkeep Notes
+
+- Eagle air units consume 2 additional fuel per day on top of their normal visible or hidden air-unit upkeep. This applies to B-Copters, Black Bombs, Bombers, Fighters, Stealths, and T-Copters.
+- Non-air units keep their normal daily fuel upkeep under Eagle, including sea units with base upkeep and ground units with no daily upkeep.
+- Begin-turn temporary power and weather expiration still runs before daily fuel upkeep; Eagle's air upkeep modifier remains a day-to-day CO effect after those statuses expire.
+
 ## Capture Notes
 
 - Capture progress uses the simulator's displayed-HP calculation, where partial true-health values round up to the current displayed HP before applying capture modifiers.
@@ -63,7 +70,6 @@ These AWBW mechanics are not implemented yet. They are tracked as GitHub issues 
 - [#72](https://github.com/ryparikh/AdvanceWarsServer/issues/72): Rachel property repair bonus.
 - [#81](https://github.com/ryparikh/AdvanceWarsServer/issues/81): CO star costs and power-meter charge math audit.
 - [#83](https://github.com/ryparikh/AdvanceWarsServer/issues/83): Jess Turbo Charge COP resupply side effect.
-- [#84](https://github.com/ryparikh/AdvanceWarsServer/issues/84): Eagle air-unit fuel upkeep modifier.
 - [#85](https://github.com/ryparikh/AdvanceWarsServer/issues/85): Sturm all-terrain movement rules.
 - [#86](https://github.com/ryparikh/AdvanceWarsServer/issues/86): Lash terrain-star attack and movement effects.
 - [#87](https://github.com/ryparikh/AdvanceWarsServer/issues/87): Javier indirect-defense and Comm Tower defense bonuses.


### PR DESCRIPTION
## Summary
- Add CO-aware daily fuel upkeep so Eagle air units consume 2 less fuel per day, clamped at 0, on top of visible/hidden base upkeep.
- Add Eagle regression fixtures for air/non-air upkeep, exact-zero air-unit crash behavior, and begin-turn power/weather expiration ordering.
- Update `CO_SUPPORT.md` to mark #84 implemented and document Eagle reduced fuel upkeep behavior.

## Root Cause
Begin-turn fuel drain used only each unit's base `m_fuelCostPerDay`, so Eagle's AWBW air-unit `-2 fuel/day` modifier was missing for B-Copters, Black Bombs, Bombers, Fighters, Stealths, and T-Copters. The issue text described this as additional fuel drain, but the AWBW Eagle page records it as reduced daily fuel consumption.

Reference checked: https://awbw.fandom.com/wiki/Eagle

## Tests
- Failing before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/eagle` failed the new Eagle upkeep fixtures because air units used only base upkeep.
- Failing before correction: the same focused command failed corrected expectations because the first implementation treated `-2 fuel/day` as extra drain.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/eagle`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

## Risk
Low; the production change is limited to begin-turn daily fuel cost calculation and only reduces the modifier for Eagle-owned air units. Existing sea, ground, weather movement, repair/resupply, and crash behavior remain covered by the full JSON suite.

Closes #84