### PR TITLE
Correct Eagle air fuel upkeep direction

### DIFF
--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -537,7 +537,7 @@ int GameState::GetWeatherMovementCost(const Terrain& terrain, const Player& play
 int GameState::GetFuelCostPerDay(const Player& player, const Unit& unit) const noexcept {
 	int fuelCost = unit.IsHidden() ? unit.m_properties.m_fuelCostPerDay.second : unit.m_properties.m_fuelCostPerDay.first;
 	if (player.m_co.m_type == CommandingOfficier::Type::Eagle && unit.IsAirUnit()) {
-		fuelCost += 2;
+		fuelCost = std::max(0, fuelCost - 2);
 	}
 
 	return fuelCost;

--- a/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-after-power-weather-expire.json
+++ b/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-after-power-weather-expire.json
@@ -82,7 +82,7 @@
           "terrain": 15,
           "unit": {
             "ammo": 9,
-            "fuel": 3,
+            "fuel": 7,
             "health": 100,
             "hidden": false,
             "moved": false,

--- a/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-crash.json
+++ b/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep-crash.json
@@ -9,13 +9,13 @@
         {
           "terrain": 15,
           "unit": {
-            "ammo": 6,
-            "fuel": 4,
+            "ammo": 9,
+            "fuel": 3,
             "health": 100,
             "hidden": false,
             "moved": true,
             "owner": "orange-star",
-            "type": "bcopter"
+            "type": "fighter"
           }
         },
         {

--- a/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep.json
+++ b/AdvanceWarsServer/test/json/co/eagle/air-fuel-upkeep.json
@@ -128,7 +128,7 @@
           "terrain": 15,
           "unit": {
             "ammo": 6,
-            "fuel": 5,
+            "fuel": 9,
             "health": 100,
             "hidden": false,
             "moved": false,
@@ -140,7 +140,7 @@
           "terrain": 15,
           "unit": {
             "ammo": 9,
-            "fuel": 2,
+            "fuel": 6,
             "health": 100,
             "hidden": false,
             "moved": false,
@@ -152,7 +152,7 @@
           "terrain": 15,
           "unit": {
             "ammo": 6,
-            "fuel": 10,
+            "fuel": 14,
             "health": 100,
             "hidden": true,
             "moved": false,

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -16,7 +16,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
 - Implemented production effects: Hachi's Merchant Union allows standard ground-unit deployment from owned empty cities, and Sensei's Copter Command/Airborne Assault spawn 9 HP unwaited Infantry/Mechs on owned empty cities in top-row, left-to-right order until the unit cap is reached.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
-- Implemented fuel-upkeep modifiers: Eagle air units consume 2 additional fuel per day.
+- Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
@@ -53,9 +53,9 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 ## Fuel Upkeep Notes
 
-- Eagle air units consume 2 additional fuel per day on top of their normal visible or hidden air-unit upkeep. This applies to B-Copters, Black Bombs, Bombers, Fighters, Stealths, and T-Copters.
+- Eagle air units reduce daily upkeep by 2 fuel, to a minimum of 0. This applies to B-Copters, Black Bombs, Bombers, Fighters, Stealths, and T-Copters, including hidden Stealth upkeep.
 - Non-air units keep their normal daily fuel upkeep under Eagle, including sea units with base upkeep and ground units with no daily upkeep.
-- Begin-turn temporary power and weather expiration still runs before daily fuel upkeep; Eagle's air upkeep modifier remains a day-to-day CO effect after those statuses expire.
+- Begin-turn temporary power and weather expiration still runs before daily fuel upkeep; Eagle's reduced air upkeep remains a day-to-day CO effect after those statuses expire.
 
 ## Capture Notes
 


### PR DESCRIPTION
## Summary
- Correct Eagle's air fuel modifier from extra daily drain to reduced daily upkeep.
- Clamp Eagle air upkeep at 0 so B-Copters and T-Copters consume no day-to-day fuel, while Fighters/Bombers/Black Bombs consume 3 and hidden Stealths consume 6.
- Update the Eagle fuel fixtures and `CO_SUPPORT.md` wording to match AWBW.

## Root Cause
The first #84 implementation misread AWBW's `-2 fuel/day` modifier as an additional drain. The AWBW Eagle page says air units consume `-2 fuel per day`, so the modifier should reduce daily upkeep by 2 instead.

Reference checked: https://awbw.fandom.com/wiki/Eagle

## Tests
- Failing before correction: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/eagle` failed the corrected expectations because the previous implementation drained too much fuel.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/eagle`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check HEAD~1..HEAD`

## Risk
Low; this follow-up only reverses the direction of the Eagle air fuel modifier and adjusts the new fixtures/docs accordingly. Non-air upkeep remains unchanged.

Follow-up to #118.