### PR TITLE
Add Anti-Air owned combat coverage

### DIFF
--- a/AdvanceWarsServer/test/json/units/README.md
+++ b/AdvanceWarsServer/test/json/units/README.md
@@ -14,7 +14,7 @@ Coverage key:
 
 | UnitProperties::Type | JSON type | Fixture home | Happy path | Boundary | Existing coverage notes |
 | --- | --- | --- | --- | --- | --- |
-| AntiAir | `anti-air` | `units/anti-air/` | partial | partial | Present as infantry combat target/opponent and production option. Owner-side attack coverage is tracked by [#104](https://github.com/ryparikh/AdvanceWarsServer/issues/104). |
+| AntiAir | `anti-air` | `units/anti-air/` | yes | yes | `units/anti-air/` covers primary anti-air attacks, lower-damage ground attacks, ammo consumption, no-ammo rejection, invalid sea targets, and direct-combat counterattack expectations. |
 | Apc | `apc` | `units/apc/` | yes | yes | `transport/apc/` covers load, unload, resupply, movement, and capacity boundaries. |
 | Artillery | `artillery` | `units/artillery/` | yes | yes | `units/artillery/` covers indirect min/max range, ammo consumption, no ammo, invalid air target, and move-fire rejection. |
 | BCopter | `bcopter` | `units/bcopter/` | yes | yes | `units/bcopter/` covers air movement over mixed terrain, begin-turn fuel drain, ammo consumption, and invalid plane targets. Existing fixtures also cover infantry combat target/opponent and cruiser cargo. |

--- a/AdvanceWarsServer/test/json/units/anti-air/air-targets-ammo-counter.json
+++ b/AdvanceWarsServer/test/json/units/anti-air/air-targets-ammo-counter.json
@@ -1,0 +1,52 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "anti-air-air-targets-ammo-counter",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 50, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "target": [0, 0], "direction": "east" },
+    { "type": "move-attack", "source": [0, 1], "target": [0, 1], "direction": "east" }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "anti-air-air-targets-ammo-counter",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 60, "health": 37, "hidden": false, "moved": true, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 5, "fuel": 99, "health": 40, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 60, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 99, "health": 35, "hidden": false, "moved": false, "owner": "blue-moon", "type": "fighter" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 9500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 17800, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/anti-air/ground-targets-ammo-counter.json
+++ b/AdvanceWarsServer/test/json/units/anti-air/ground-targets-ammo-counter.json
@@ -1,0 +1,52 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "anti-air-ground-targets-ammo-counter",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "target": [0, 0], "direction": "east" },
+    { "type": "move-attack", "source": [0, 1], "target": [0, 1], "direction": "east" }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "anti-air-ground-targets-ammo-counter",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 60, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 60, "health": 41, "hidden": false, "moved": true, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 75, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 5200, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 4400, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/anti-air/target-boundaries-no-ammo.json
+++ b/AdvanceWarsServer/test/json/units/anti-air/target-boundaries-no-ammo.json
@@ -1,0 +1,39 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "anti-air-target-boundaries-no-ammo",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "crusier" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "battleship" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bcopter" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "anti-air" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "move-attack", "source": [0, 0], "target": [0, 0], "direction": "east" },
+    { "type": "move-attack", "source": [0, 1], "target": [0, 1], "direction": "east" },
+    { "type": "move-attack", "source": [0, 2], "target": [0, 2], "direction": "east" },
+    { "type": "move-attack", "source": [0, 3], "target": [0, 3], "direction": "east" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add dedicated `units/anti-air/` JSON fixtures for owner-side Anti-Air combat.
- Cover air-target attacks, ground-target attacks, ammo consumption, no-ammo rejection, invalid sea targets, and direct-combat counterattack expectations.
- Update the unit coverage manifest to mark Anti-Air as complete.

## Why
Anti-Air appeared in combat and production fixtures mostly as a target/opponent, leaving the unit-owned coverage manifest marked partial. These fixtures document the current Standard engine behavior against the AWBW unit role: Anti-Air is a 6 move, 9 ammo, range-1 tread unit focused on air defense, with weaker legal ground attacks.

Reference checked: https://awbw.fandom.com/wiki/Units

## Tests
- Initial focused run failed in the new Anti-Air fixtures because the expected states overestimated power charge and missed B-Copter counter ammo consumption; expected JSON was corrected to the engine-serialized behavior.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/units/anti-air`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`

## Risk
Fixture-only change. No production engine behavior changed.

Closes #104