### PR TITLE
Add deterministic Sonja luck combat fixtures

### DIFF
--- a/AdvanceWarsServer/inc/Player.h
+++ b/AdvanceWarsServer/inc/Player.h
@@ -42,6 +42,7 @@ enum class LuckPolicy {
 	None = 0,
 	AlwaysLowestValue,
 	AlwaysHighestValue,
+	AlwaysMiddleValue,
 };
 
 class Player final {

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1445,6 +1445,9 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 	else if (pattackingplayer->m_luckPolicy == LuckPolicy::AlwaysHighestValue) {
 		goodLuckRoll = goodLuckDistribution.max();
 	}
+	else if (pattackingplayer->m_luckPolicy == LuckPolicy::AlwaysMiddleValue) {
+		goodLuckRoll = (goodLuckDistribution.min() + goodLuckDistribution.max()) / 2;
+	}
 	else {
 		goodLuckRoll = RollCombatLuck(goodLuckDistribution.min(), goodLuckDistribution.max());
 	}
@@ -1456,6 +1459,9 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 	}
 	else if (pattackingplayer->m_luckPolicy == LuckPolicy::AlwaysHighestValue) {
 		badLuckRoll = badLuckDistribution.min();
+	}
+	else if (pattackingplayer->m_luckPolicy == LuckPolicy::AlwaysMiddleValue) {
+		badLuckRoll = (badLuckDistribution.min() + badLuckDistribution.max()) / 2;
 	}
 	else {
 		badLuckRoll = RollCombatLuck(badLuckDistribution.min(), badLuckDistribution.max());

--- a/AdvanceWarsServer/test/json/co/sonja/luck-cop-low-roll.json
+++ b/AdvanceWarsServer/test/json/co/sonja/luck-cop-low-roll.json
@@ -1,0 +1,143 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-cop-low-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    },
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-cop-low-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 72,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 49,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 600,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/luck-d2d-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/sonja/luck-d2d-high-roll.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-d2d-high-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-d2d-high-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 78,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 36,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 500,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 700,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/luck-d2d-low-roll.json
+++ b/AdvanceWarsServer/test/json/co/sonja/luck-d2d-low-roll.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-d2d-low-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-d2d-low-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 62,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 54,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 500,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 550,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/luck-d2d-middle-roll.json
+++ b/AdvanceWarsServer/test/json/co/sonja/luck-d2d-middle-roll.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-d2d-middle-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 3
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 3
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-d2d-middle-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 71,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 45,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 450,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 3
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 600,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 3
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/luck-scop-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/sonja/luck-scop-high-roll.json
@@ -1,0 +1,143 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-scop-high-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 45000,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-luck-scop-high-roll",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 81,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 31,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sonja",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 2,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 2
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 650,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -21,6 +21,13 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
 - Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
+## Luck Notes
+
+- JSON combat fixtures can force deterministic luck with `"luck-policy"`: `0` uses normal RNG or `"combat-rng-seed"`, `1` forces the lowest total luck outcome, `2` forces the highest total luck outcome, and `3` forces the middle value of each luck range.
+- For bad-luck COs, the lowest total outcome uses minimum good luck and maximum bad luck; the highest total outcome uses maximum good luck and minimum bad luck.
+- Sonja's AWBW combat luck is covered separately from her information and counterattack effects: she keeps +0..+9 good luck and 0..9 bad luck in day-to-day, Enhanced Vision, and Counter Break, while COP/SCOP still use the universal AWBW +10 attack/+10 defense chart bonus.
+- Sonja's hidden HP, fog vision, day-to-day counterattack multiplier, and Counter Break first-strike edge cases remain tracked by [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89) and [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90), rather than by the combat-luck fixtures.
+
 ## Weather Notes
 
 - Weather JSON uses `"weather": "rain"` or `"weather": "snow"`. CO-created weather also writes `"weather-turns-remaining"` and expires on a later `BeginTurn`.
@@ -76,4 +83,4 @@ These AWBW mechanics are not implemented yet. They are tracked as GitHub issues 
 - [#88](https://github.com/ryparikh/AdvanceWarsServer/issues/88): Kanbei Samurai Spirit counterattack bonus.
 - [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89): Sonja counterattack bonus and hidden-HP API redaction.
 - [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90): fog, vision, hiding visibility, and fog-only CO effects.
-- [#99](https://github.com/ryparikh/AdvanceWarsServer/issues/99), [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100), [#101](https://github.com/ryparikh/AdvanceWarsServer/issues/101), [#102](https://github.com/ryparikh/AdvanceWarsServer/issues/102), and [#103](https://github.com/ryparikh/AdvanceWarsServer/issues/103): deterministic luck CO combat fixtures for Nell, Rachel, Flak, Jugger, and Sonja.
+- [#99](https://github.com/ryparikh/AdvanceWarsServer/issues/99), [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100), [#101](https://github.com/ryparikh/AdvanceWarsServer/issues/101), and [#102](https://github.com/ryparikh/AdvanceWarsServer/issues/102): deterministic luck CO combat fixtures for Nell, Rachel, Flak, and Jugger.

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -142,7 +142,8 @@ Detailed implementation notes live in `CO_SUPPORT.md`.
 | Javier indirect and Comm Tower defense | Missing/incomplete. | Partial | #87 |
 | Kanbei Samurai Spirit counterattack | Missing/incomplete. | Partial | #88 |
 | Sonja counterattack and hidden HP API view | Missing/incomplete. | Partial | #89 |
-| Luck CO deterministic fixtures | Luck bounds exist; exact deterministic fixtures split per CO. | Partial | #99, #100, #101, #102, #103 |
+| Sonja luck deterministic fixtures | D2D/COP/SCOP low, high, and middle combat fixtures cover luck separately from visibility and counterattack effects. | Complete | #103 |
+| Other luck CO deterministic fixtures | Luck bounds exist; exact deterministic fixtures split per CO. | Partial | #99, #100, #101, #102 |
 | Fog/vision-only CO effects | Not needed for Standard fog-off target. | Deferred | #90 |
 
 ## Weather And Fog
@@ -220,7 +221,6 @@ Properties, economy, and COs:
 - #100: Implement and test Rachel luck combat modifiers.
 - #101: Implement and test Flak luck combat modifiers.
 - #102: Implement and test Jugger luck combat modifiers.
-- #103: Implement and test Sonja luck combat modifiers.
 
 Deferred modes and map features:
 

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -95,6 +95,17 @@ Use `deterministic-replay` when an action sequence should serialize to the same 
 
 The runner applies the same action sequence twice and compares the full serialized trace.
 
+### Deterministic Luck Fixtures
+
+Player JSON supports `"luck-policy"` for combat fixtures:
+
+- `0`: normal combat luck, using `"combat-rng-seed"` when present.
+- `1`: force the lowest total luck outcome.
+- `2`: force the highest total luck outcome.
+- `3`: force the middle value of each luck range.
+
+For COs with bad luck, "lowest" means minimum good luck and maximum bad luck. "Highest" means maximum good luck and minimum bad luck.
+
 ### CO Contract Fixture
 
 Use `co-contract` to check CO parser round-trip, power-meter stars, and checked-in chart values.


### PR DESCRIPTION
## Summary
- Add deterministic Sonja combat fixtures for D2D low, D2D high, D2D middle, COP low, and SCOP high luck outcomes.
- Add `LuckPolicy::AlwaysMiddleValue` so JSON fixtures can assert representative middle luck without relying on seeded RNG implementation details.
- Document Sonja combat luck separately from hidden HP, fog vision, and counterattack follow-ups.

## Why
AWBW documents Sonja as having bad luck from -9% to +9% while her COP/SCOP retain the universal +10 attack/+10 defense power chart bonus. The engine already had low/high deterministic luck controls, but not a stable middle-roll fixture policy, and Sonja's combat luck coverage was still tracked with the broader luck fixture gap.

## Tests
- Before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/sonja` failed on `luck-d2d-middle-roll.json` because `luck-policy: 3` still used random combat luck.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/sonja`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --cached --check`

## Residual Risk
- This intentionally does not implement or expand Sonja hidden HP, fog vision, day-to-day counterattack multiplier, or Counter Break defender-first edge cases; those remain tracked by #89/#90.

Closes #103