### PR TITLE
Implement Rachel property repair bonus

### DIFF
--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -65,6 +65,29 @@ bool FPropertyServicesUnit(Terrain::Type terrainType, UnitProperties::Type unitT
 	}
 }
 
+int CMaxPropertyRepairHp(const Player& player) noexcept {
+	return player.m_co.m_type == CommandingOfficier::Type::Rachel ? 30 : 20;
+}
+
+int CPropertyRepairFunds(UnitProperties::Type unitType, int repairAmount) noexcept {
+	return Unit::GetUnitCost(unitType) * (repairAmount / 10);
+}
+
+int CAffordablePropertyRepairHp(const Player& player, const Unit& unit) noexcept {
+	const int requestedRepairAmount = std::min(100 - unit.health, CMaxPropertyRepairHp(player));
+	const int requestedRepairFunds = CPropertyRepairFunds(unit.m_properties.m_type, requestedRepairAmount);
+	if (requestedRepairFunds <= player.m_funds) {
+		return requestedRepairAmount;
+	}
+
+	if (player.m_co.m_type != CommandingOfficier::Type::Rachel) {
+		return 0;
+	}
+
+	const int unitRepairCost = Unit::GetUnitCost(unit.m_properties.m_type);
+	return std::min(requestedRepairAmount, (player.m_funds / unitRepairCost) * 10);
+}
+
 bool FKindleUrbanTerrain(Terrain::Type terrainType) noexcept {
 	return MapTile::IsProperty(terrainType);
 }
@@ -204,10 +227,9 @@ Result GameState::BeginTurn() noexcept {
 					pServiceUnit->m_properties.m_fuel = GetUnitInfo(pServiceUnit->m_properties.m_type).m_fuel;
 					pServiceUnit->m_properties.m_ammo = GetUnitInfo(pServiceUnit->m_properties.m_type).m_ammo;
 					if (pServiceUnit->health < 100) {
-						int repairAmount = std::min(100 - pServiceUnit->health, 20);
-						int unitRepairFunds = Unit::GetUnitCost(pServiceUnit->m_properties.m_type) * (repairAmount/10);
-						if (unitRepairFunds <= m_arrPlayers[player].m_funds) {
-							m_arrPlayers[player].m_funds -= unitRepairFunds;
+						int repairAmount = CAffordablePropertyRepairHp(m_arrPlayers[player], *pServiceUnit);
+						if (repairAmount > 0) {
+							m_arrPlayers[player].m_funds -= CPropertyRepairFunds(pServiceUnit->m_properties.m_type, repairAmount);
 							pServiceUnit->health += repairAmount;
 						}
 					}

--- a/AdvanceWarsServer/test/json/co/rachel/property-repair-bonus.json
+++ b/AdvanceWarsServer/test/json/co/rachel/property-repair-bonus.json
@@ -1,0 +1,249 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-property-repair-bonus",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 70,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 40,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 70,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 70,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 10000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-property-repair-bonus",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 40,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 70,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 7,
+            "health": 70,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "bcopter"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 11900,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/rachel/property-repair-partial-funds.json
+++ b/AdvanceWarsServer/test/json/co/rachel/property-repair-partial-funds.json
@@ -1,0 +1,153 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-property-repair-partial-funds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 0,
+            "fuel": 9,
+            "health": 70,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 400,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "end-turn"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-property-repair-partial-funds",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38,
+          "unit": {
+            "ammo": 9,
+            "fuel": 70,
+            "health": 90,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 42,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Rachel",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -14,6 +14,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Active weather JSON parsing/serialization, weather movement/fuel costs, and Drake/Olaf weather-changing powers.
 - Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
+- Implemented Rachel day-to-day property repair: compatible owned properties repair up to 3 displayed HP instead of the normal 2, with funds charged for displayed HP actually restored.
 - Implemented production effects: Hachi's Merchant Union allows standard ground-unit deployment, including Piperunners, from owned empty cities; Sensei's Copter Command/Airborne Assault spawn 9 HP unwaited Infantry/Mechs on owned empty cities in top-row, left-to-right order until the unit cap is reached.
 - Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
 - Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
@@ -49,6 +50,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 - Colin, Hachi, and Kanbei cost modifiers apply to unit construction. Hachi's Merchant Union uses the simulator's standard ground-production list for city deployment, matching the AWBW wiki's Piperunner note that Piperunners can be built at Bases or spawned from Cities during Hachi's SCOP.
 - Sasha's Market Crash applies to the single opposing player in this simulator's two-player model.
+- Rachel's extra property repair composes with the normal owner and unit-class gates: land units repair only on owned Cities/Bases/HQs, air units on owned Airports, and sea units on owned Ports. If Rachel cannot afford the full 3 displayed HP restore, she restores the affordable displayed HP and pays only for that repair.
 
 ## Action-State Notes
 
@@ -74,7 +76,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#72](https://github.com/ryparikh/AdvanceWarsServer/issues/72): Rachel property repair bonus.
 - [#81](https://github.com/ryparikh/AdvanceWarsServer/issues/81): CO star costs and power-meter charge math audit.
 - [#83](https://github.com/ryparikh/AdvanceWarsServer/issues/83): Jess Turbo Charge COP resupply side effect.
 - [#85](https://github.com/ryparikh/AdvanceWarsServer/issues/85): Sturm all-terrain movement rules.

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -115,7 +115,7 @@ The unit fixture manifest lives at `AdvanceWarsServer/test/json/units/README.md`
 | Core terrain movement | JSON fixtures cover many terrain, weather, air, land, and sea movement cases. | AWBW movement tables. | Partial where Piperunner/Sturm/Teleport remain | #35, #85, #93 |
 | Properties and income | Cities/Bases/Airports/Ports/HQ income behavior exists; Labs/Com Towers no-income fixtures exist. | AWBW fund-producing properties only. | Complete for normal income, configurable settings partial | #65 |
 | Property repair/resupply | Begin-turn property service is gated by owner, property type, and unit class; Labs and Com Towers do not repair or resupply. | Land on City/Base/HQ, air on Airport, sea on Port; owner only. | Complete for normal property service | none |
-| Rachel property repair | Normal property repair is not Rachel-aware. | Rachel repairs +1 extra displayed HP on compatible properties. | Partial | #72 |
+| Rachel property repair | Rachel repairs +1 extra displayed HP on compatible owned properties, with affordable partial repair and no off-class service. | Rachel repairs +1 extra displayed HP on compatible properties. | Complete | none |
 | APC/Cruiser/Carrier resupply | Dedicated transport and loaded-resupply fixtures exist. | AWBW logistics order and compatible cargo. | Complete for current Standard coverage | none |
 | Labs | Lab capture/no-income/lab-victory fixtures exist. | Labs can act as no-HQ loss condition and do not produce income. | Complete for two-player Standard model | #76 for lab-unit production setting |
 | Com Towers | Capture/no-income/attack-bonus fixtures exist. | +10 attack per owned tower, no income. | Complete for standard tower attack bonus | #87 for Javier tower defense |
@@ -134,7 +134,7 @@ Detailed implementation notes live in `CO_SUPPORT.md`.
 | Power costs and meter state | Star costs and charge exist. | Audit | #81 |
 | Checked-in attack/defense charts | Normal/COP/SCOP charts exist. | Audit with combat data | #80, #81 |
 | Mass HP, weather, economy, production, range, movement, capture, and many power effects | See `CO_SUPPORT.md`. | Partial but broad support exists | focused gaps below |
-| Rachel property repair | Missing. | Partial | #72 |
+| Rachel property repair | Compatible owned property service repairs Rachel units up to 3 displayed HP and respects off-class restrictions. | Complete | none |
 | Jess COP resupply | SCOP resupply exists; COP resupply missing. | Partial | #83 |
 | Eagle air fuel upkeep | Missing. | Partial | #84 |
 | Sturm all-terrain movement | Missing/incomplete. | Partial | #85 |
@@ -208,7 +208,6 @@ Actions, units, and data:
 
 Properties, economy, and COs:
 
-- #72: Implement Rachel property repair bonus.
 - #81: Verify CO star costs and power-meter charge math against AWBW.
 - #83: Implement Jess Turbo Charge COP resupply side effect.
 - #84: Implement Eagle air-unit fuel upkeep modifier.


### PR DESCRIPTION
## Summary
- Added Rachel-aware begin-turn property repair so compatible owned properties restore up to 3 displayed HP instead of the normal 2.
- Added Rachel JSON fixtures for enough funds, partial funds, full-health units, and incompatible property/unit combinations.
- Updated CO support and Standard completeness docs to mark Rachel property repair implemented.

## Root Cause
Begin-turn property service always used the normal 20 true-HP repair cap for every CO, so Rachel's day-to-day +1 displayed HP property repair was not modeled. Issue #72 also asks for Rachel partial-funds behavior, so Rachel now restores the affordable displayed HP when she cannot afford the full 3 displayed HP restore.

## Tests
- Failing before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/rachel` failed on `property-repair-bonus.json` because Rachel repaired a 70 HP tank only to 90 HP and retained too many funds.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/rachel`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/misc`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`
- `git diff --cached --check`

## Residual Risk
- The issue's partial-funds acceptance criterion is encoded for Rachel's extra repair window while preserving existing non-Rachel property repair behavior.

Closes #72