### PR TITLE
Fix capture-limit counting for Labs and Comm Towers

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -209,6 +209,10 @@
     <ResourceCompile Include="AdvanceWarsServer.rc" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="test\json\captures\capture-limit-excludes-com-tower.json" />
+    <None Include="test\json\captures\capture-limit-excludes-lab.json" />
+    <None Include="test\json\captures\capture-limit-normal-property-wins.json" />
+    <None Include="test\json\captures\capture-limit-rejects-normal-property-after-win.json" />
     <None Include="test\json\captures\infantry-join-capture.json" />
     <None Include="test\json\captures\infantry-stops-capture.json" />
     <None Include="test\json\captures\infantry100FlipNeutralComTower.json" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -289,6 +289,10 @@
     <None Include="test\json\captures\infantry100FlipNeutralPort.json" />
     <None Include="test\json\captures\infantry100FlipNeutralComTower.json" />
     <None Include="test\json\captures\infantry100FlipNeutralLab.json" />
+    <None Include="test\json\captures\capture-limit-excludes-com-tower.json" />
+    <None Include="test\json\captures\capture-limit-excludes-lab.json" />
+    <None Include="test\json\captures\capture-limit-normal-property-wins.json" />
+    <None Include="test\json\captures\capture-limit-rejects-normal-property-after-win.json" />
     <None Include="test\json\captures\airport-port-capture-progress-and-transfer.json" />
     <None Include="test\json\com-tower\attack-bonus-control.json" />
     <None Include="test\json\com-tower\attack-bonus-one-owned-tower.json" />

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -582,6 +582,10 @@ void GameState::TickTemporaryWeather() noexcept {
 }
 
 Result GameState::GetValidActions(std::vector<Action>& vecActions) const noexcept {
+	if (m_fGameOver) {
+		return Result::Succeeded;
+	}
+
 	for (int x = 0; x < m_spmap->GetCols(); ++x) {
 		for (int y = 0; y < m_spmap->GetRows(); ++y) {
 			IfFailedReturn(GetValidActions(x, y, vecActions));
@@ -691,6 +695,10 @@ int GameState::GetFuelAfterMove(int xSrc, int ySrc, int xDest, int yDest) {
 }
 
 Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions) const noexcept {
+	if (m_fGameOver) {
+		return Result::Succeeded;
+	}
+
 	const MapTile* pmaptile;
 	m_spmap->TryGetTile(x, y, &pmaptile);
 	const Unit* pUnit = pmaptile->TryGetUnit();
@@ -928,6 +936,10 @@ bool GameState::AnyValidActions() const noexcept {
 }
 
 Result GameState::DoAction(const Action& action) noexcept {
+	if (m_fGameOver) {
+		return Result::Failed;
+	}
+
 	if (!action.m_optSource.has_value()) {
 		switch (action.m_type) {
 		case Action::Type::EndTurn:
@@ -1204,7 +1216,7 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 				m_spmap->TryGetTile(x, y, &pTile);
 				if (pTile->m_spPropertyInfo != nullptr &&
 					pTile->m_spPropertyInfo->m_owner == &GetCurrentPlayer() &&
-					(pTile->GetTerrain().m_type != Terrain::Type::Lab || pTile->GetTerrain().m_type != Terrain::Type::ComTower)) {
+					FProducesIncome(pTile->GetTerrain().m_type)) {
 					++totalProperties;
 				}
 			}

--- a/AdvanceWarsServer/test/json/captures/capture-limit-excludes-com-tower.json
+++ b/AdvanceWarsServer/test/json/captures/capture-limit-excludes-com-tower.json
@@ -1,0 +1,151 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": false,
+    "gameId": "capture-limit-excludes-com-tower",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": false,
+    "gameId": "capture-limit-excludes-com-tower",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 145,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/captures/capture-limit-excludes-lab.json
+++ b/AdvanceWarsServer/test/json/captures/capture-limit-excludes-lab.json
@@ -1,0 +1,151 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": false,
+    "gameId": "capture-limit-excludes-lab",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 133,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": false,
+    "gameId": "capture-limit-excludes-lab",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 133,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/captures/capture-limit-normal-property-wins.json
+++ b/AdvanceWarsServer/test/json/captures/capture-limit-normal-property-wins.json
@@ -1,0 +1,151 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": false,
+    "gameId": "capture-limit-normal-property-wins",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-capture",
+      "source": [ 1, 0 ],
+      "target": [ 1, 0 ]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": true,
+    "gameId": "capture-limit-normal-property-wins",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": 0
+  }
+}

--- a/AdvanceWarsServer/test/json/captures/capture-limit-rejects-normal-property-after-win.json
+++ b/AdvanceWarsServer/test/json/captures/capture-limit-rejects-normal-property-after-win.json
@@ -1,0 +1,87 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 2,
+    "game-over": true,
+    "gameId": "capture-limit-rejects-normal-property-after-win",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 42
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 38
+        },
+        {
+          "terrain": 34,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          },
+          "property": {
+            "capture-points": 10,
+            "owner": "neutral"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": 0
+  },
+  "failedActions": [
+    {
+      "type": "move-capture",
+      "source": [ 2, 0 ],
+      "target": [ 2, 0 ]
+    }
+  ]
+}

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -51,7 +51,7 @@ Explicitly deferred modes and options:
 | Starting funds and income | Normal income exists; Sasha income modifier exists; configurable mode presets are incomplete. | 0 starting funds and 1000/property for Standard. | Partial | #65 |
 | High Funds | No preset. | 2000/property only in High Funds modes. | Deferred | #91 |
 | Unit cap | `unit-cap` serializes and production fixtures cover under-cap and at-cap behavior. | Enforce configured unit limit. | Complete for current model | none |
-| Capture limit | Capture-limit terminal path exists, but Labs/Comm Towers are counted incorrectly. | Limit excludes Labs and Comm Towers. | Partial | #73 |
+| Capture limit | Capture-limit terminal path counts Cities, Bases, Airports, Ports, and HQs; Labs/Comm Towers are excluded. | Limit excludes Labs and Comm Towers. | Complete for current model | none |
 | Day limit | No day-limit terminal rule. | Configurable day limit with property-count winner/tie handling. | Partial | #74 |
 | Unit bans | No setup-level ban list. | Standard bans Black Bomb production. | Partial | #75 |
 | Lab units | No setup-level lab-unit requirement. | Selected lab units require owned Lab access. | Partial | #76 |
@@ -79,7 +79,7 @@ Explicitly deferred modes and options:
 | --- | --- | --- | --- | --- |
 | Movement and wait | Covered broadly by JSON fixtures. | AWBW movement/fuel/path legality. | Partial because submitted invalid actions need atomic rejection | #67 |
 | Combat actions | Direct, indirect, counterattack, ammo, HP, terrain, and many CO/power cases are covered. | AWBW combat formula and data. | Audit | #80, #81 |
-| Capture | Capture progress, interruption, HQ capture, Labs, Com Towers, Airports, Ports, and Sami capture have fixtures. | AWBW capture points and capture-limit counting. | Partial | #73 |
+| Capture | Capture progress, interruption, HQ capture, Labs, Com Towers, Airports, Ports, Sami capture, and capture-limit counting have fixtures. | AWBW capture points and capture-limit counting. | Complete for current Standard coverage | none |
 | Buy | Production fixtures cover common buy legality, unit cap, and Piperunner production from Bases/Hachi Merchant Union cities. | Add setup bans, lab units, and ghosted blockers. | Partial | #75, #76, #78 |
 | Load and unload | APC, T-Copter, Lander, Black Boat, Cruiser, Carrier, loaded-unit destruction, and many boundaries are covered. | AWBW free unload behavior and legal terrain/occupancy. | Partial because submitted invalid actions need atomic rejection | #67 |
 | Combine/join | Joining/refund/capture-preservation fixtures exist. | AWBW join/refund behavior. | Complete for current Standard coverage | none |
@@ -185,7 +185,6 @@ Standard API, settings, and terminal behavior:
 - #68: Make REST action stepping explicit and remove implicit auto-end-turn.
 - #69: Remove heuristic auto-resign from Standard engine terminal logic.
 - #70: Support AWBW map imports with all two-player country identities.
-- #73: Fix capture-limit counting to exclude Labs and Comm Towers.
 - #74: Implement day-limit victory and draw resolution.
 - #75: Add game setup support for unit bans and the Standard Black Bomb ban.
 - #76: Add lab-unit production requirements from game setup.

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -23,7 +23,7 @@ The rules/API completeness target for the initial playable environment is normal
 
 - [ ] Run the JSON subsystem tests from a current build and make failures visible in CI or local output.
 - [ ] Fix action deserialization for `unloadIndex`; it is read but not assigned to `Action::m_optUnloadIndex`. Track under submitted-action validation work in #67 if still present.
-- [ ] Fix capture-limit property counting. The current lab/com tower exclusion condition appears to use `||` where `&&` was likely intended. Tracked by #73.
+- [x] Fix capture-limit property counting. Capture-limit wins count Cities, Bases, Airports, Ports, and HQs, excluding Labs and Com Towers (#73).
 - [ ] Audit unit count caching around load/unload, clone, add, and destroy paths before relying on unit-cap logic in training.
 - [ ] Replace hardcoded local paths such as `D:/awai`, `D:/MNIST`, and local libtorch directories with config or command-line options.
 - [ ] Add a maximum turn/action limit outcome for self-play games so training cannot hang indefinitely. Coordinate with day-limit and terminal metadata work in #74 and #82.

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -171,6 +171,8 @@ When adding an action fixture, prefer copying the smallest nearby fixture that a
 | `weather/` | Rain/snow movement, temporary weather, Drake/Olaf powers. |
 | `units/` | Unit-owned movement, fuel, combat, ammo, and boundaries. |
 
+Capture-limit fixtures follow AWBW counting: Cities, Bases, Airports, Ports, and HQs count toward the configured limit; Labs and Com Towers do not.
+
 ## Debugging Failures
 
 On failure, the runner prints:


### PR DESCRIPTION
## Summary
- Count only Cities, Bases, Airports, Ports, and HQs toward capture-limit wins.
- Exclude Labs and Comm Towers from capture-limit totals while preserving normal capture ownership changes.
- Reject generated/submitted actions once a terminal capture-limit state has been reached.
- Add focused JSON fixtures and update capture-limit documentation/status notes.

## Root Cause
The capture-limit predicate used `terrain != Lab || terrain != ComTower`, which is always true for every terrain type. That caused Labs and Comm Towers to count toward the limit even though AWBW's guide says they do not.

Reference: https://awbw.fandom.com/wiki/AWBW_Guide

## Tests
- Red first: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/captures` failed on the new Lab/Comm Tower exclusion fixtures before the implementation.
- Red first: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/captures` failed on the terminal-state normal-property rejection fixture before the terminal guard.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/captures`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`
- `git diff --cached --check`

## Residual Risk
MSBuild still reports existing C4244 numeric conversion warnings in `GameState.cpp`; this change did not introduce those lines.

Closes #73