### PR TITLE
Implement REST game lifecycle API

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -170,10 +170,12 @@
     <ClCompile Include="src\MapParser.cpp" />
     <ClCompile Include="src\MapTile.cpp" />
     <ClCompile Include="src\Player.cpp" />
+    <ClCompile Include="src\RestGameService.cpp" />
     <ClCompile Include="src\Tensor.cpp" />
     <ClCompile Include="src\TerrainInfo.cpp" />
     <ClCompile Include="src\Unit.cpp" />
     <ClCompile Include="src\UnitInfo.cpp" />
+    <ClCompile Include="src\RestApiContractTest.cpp" />
     <ClCompile Include="src\win32\Platform.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -193,6 +195,7 @@
     <ClInclude Include="inc\Platform.h" />
     <ClInclude Include="inc\Player.h" />
     <ClInclude Include="inc\Result.h" />
+    <ClInclude Include="inc\RestGameService.h" />
     <ClInclude Include="inc\Reward.h" />
     <ClInclude Include="inc\SubsystemTest.h" />
     <ClInclude Include="inc\Terrain.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -66,6 +66,12 @@
     <ClCompile Include="src\Tensor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\RestGameService.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\RestApiContractTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\Map.h">
@@ -138,6 +144,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\Reward.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\RestGameService.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AdvanceWarsServer/inc/AdvanceWarsServer.h
+++ b/AdvanceWarsServer/inc/AdvanceWarsServer.h
@@ -10,6 +10,7 @@
 #include "Map.h"
 #include "MapParser.h"
 #include "MovementTypes.h"
+#include "RestGameService.h"
 #include "Result.h"
 #include "Terrain.h"
 
@@ -37,21 +38,13 @@ public:
 
 	static AdvanceWarsServer& getInstance();
 	static tx_response post_games_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body);
+	static tx_response get_game_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body);
 	static tx_response post_game_actions(const http_request& request, const Parameters& parameters, const std::string&data, std::string&response_body);
-	static tx_response get_game_actions(const http_request& request, const Parameters& parameters, const std::string&data, std::string&response_body);
 	static tx_response get_valid_game_actions(const http_request& request, const Parameters& parameters, const std::string&data, std::string&response_body);
-
-	json create_new_game(std::string& gameId);
-	json get_valid_actions(const std::string& gameId) const;
-	Result get_valid_actions(const std::string& gameId, std::vector<Action>& vecActions) const;
-	json get_actions(const std::string& gameId, int x, int y) const;
-	json do_action(const std::string& gameId, const Action& action);
-	bool game_over(const std::string& gameId);
-
-	GameState CloneGameState(const std::string& gameId) const;
+	static tx_response options_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body);
 private:
 	static std::unique_ptr<AdvanceWarsServer> s_spServer;
 	asio::io_context m_io_context;
 	http_server_type m_http_server;
-	std::map<std::string, std::unique_ptr<GameState>> m_gameCache;
+	RestGameService m_gameService;
 };

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -107,39 +107,12 @@ struct Action {
 	Action(Type type, int xSource, int ySource, UnitProperties::Type unitType) : m_type(type), m_optSource({ xSource, ySource }), m_optUnitType(unitType) {}
 
 	bool operator==(const Action& other) const {
-		if (m_type != other.m_type) {
-			return false;
-		}
-
-		if (m_optDirection.has_value()) {
-			if (!other.m_optDirection.has_value() ||
-				(m_optDirection.value() != other.m_optDirection.value())) {
-				return false;
-			}
-		}
-
-		if (m_optSource.has_value()) {
-			if (!other.m_optSource.has_value() ||
-				(m_optSource.value() != other.m_optSource.value())) {
-				return false;
-			}
-		}
-
-		if (m_optTarget.has_value()) {
-			if (!other.m_optTarget.has_value() ||
-				(m_optTarget.value() != other.m_optTarget.value())) {
-				return false;
-			}
-		}
-
-		if (m_optUnitType.has_value()) {
-			if (!other.m_optUnitType.has_value() ||
-				(m_optUnitType.value() != other.m_optUnitType.value())) {
-				return false;
-			}
-		}
-
-		return true;
+		return m_type == other.m_type &&
+			m_optSource == other.m_optSource &&
+			m_optTarget == other.m_optTarget &&
+			m_optDirection == other.m_optDirection &&
+			m_optUnitType == other.m_optUnitType &&
+			m_optUnloadIndex == other.m_optUnloadIndex;
 	}
 
 	Type m_type{ Type::Invalid };
@@ -269,6 +242,10 @@ public:
 		return m_fGameOver;
 	}
 
+	const std::optional<std::string>& GetTerminalReason() const noexcept {
+		return m_terminalReason;
+	}
+
 	bool FEnemyHasLabs() const noexcept;
 	void SetCombatRngSeed(std::uint32_t seed);
 	void ClearCombatRngSeed() noexcept;
@@ -352,6 +329,7 @@ private:
 	bool m_isFirstPlayerTurn{ true };
 	bool m_fGameOver = false;
 	int m_winningPlayer = -1;
+	std::optional<std::string> m_terminalReason;
 	std::optional<std::uint32_t> m_combatRngSeed;
 	std::optional<std::mt19937> m_combatRng;
 	WeatherType m_weather{ WeatherType::Clear };

--- a/AdvanceWarsServer/inc/RestGameService.h
+++ b/AdvanceWarsServer/inc/RestGameService.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "GameState.h"
+
+struct ApiResponse {
+	int status{ 200 };
+	json body;
+	std::map<std::string, std::string> headers;
+};
+
+class RestGameService {
+public:
+	ApiResponse CreateGame(const std::string& requestBody);
+	ApiResponse GetGame(const std::string& gameId) const;
+	ApiResponse ListActions(const std::string& gameId, const std::string& query) const;
+	ApiResponse SubmitAction(const std::string& gameId, const std::string& requestBody);
+
+	void StoreGameForTesting(GameState gameState);
+
+private:
+	using GameCache = std::map<std::string, std::unique_ptr<GameState>>;
+
+	GameCache::iterator FindGame(const std::string& gameId);
+	GameCache::const_iterator FindGame(const std::string& gameId) const;
+
+	GameCache m_games;
+};

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -11,6 +11,8 @@
 #include "Platform.h"
 #include <torch/torch.h>
 
+int RunRestApiContractTests();
+
 int main(int argc, char* argv[]) noexcept {
 	try {
 		if (argc < 2) { // Check if the user provided exactly one argument
@@ -251,6 +253,9 @@ int main(int argc, char* argv[]) noexcept {
 
 			time_point endTime = std::chrono::steady_clock::now();
 			std::cout << "Tests took to simulate: " << std::chrono::duration<double>(endTime - startTime).count() << "s" << std::endl;
+		}
+		else if (argument == "-test-api-contract") {
+			return RunRestApiContractTests();
 		}
 		else if (argument == "-server") {
 			return AdvanceWarsServer::getInstance().run();

--- a/AdvanceWarsServer/src/AdvanceWarsServer.cpp
+++ b/AdvanceWarsServer/src/AdvanceWarsServer.cpp
@@ -1,7 +1,36 @@
 #include "AdvanceWarsServer.h"
-#include "Platform.h"
+
+#include "via/http/request_uri.hpp"
+
+namespace {
+void AddCorsHeaders(tx_response& response) {
+	response.add_header("Access-Control-Allow-Origin", "*");
+	response.add_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+	response.add_header("Access-Control-Allow-Headers", "Content-Type");
+}
+
+tx_response ToHttpResponse(const ApiResponse& apiResponse, std::string& responseBody) {
+	responseBody = apiResponse.body.dump();
+
+	tx_response response = apiResponse.status == 422
+		? tx_response("Unprocessable Entity", apiResponse.status)
+		: tx_response(static_cast<response_status::code>(apiResponse.status));
+
+	for (const auto& [name, value] : apiResponse.headers) {
+		response.add_header(name, value);
+	}
+	AddCorsHeaders(response);
+	return response;
+}
+
+std::string QueryFromRequest(const AdvanceWarsServer::http_request& request) {
+	request_uri uri(request.uri());
+	return uri.query();
+}
+}
 
 std::unique_ptr<AdvanceWarsServer> AdvanceWarsServer::s_spServer{ nullptr };
+
 /*static*/ AdvanceWarsServer& AdvanceWarsServer::getInstance() {
 	if (s_spServer == nullptr) {
 		s_spServer.reset(new AdvanceWarsServer());
@@ -11,57 +40,33 @@ std::unique_ptr<AdvanceWarsServer> AdvanceWarsServer::s_spServer{ nullptr };
 }
 
 /*static*/ tx_response AdvanceWarsServer::post_games_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {
-	json gameRequestJson = json::parse(data);
-
 	AdvanceWarsServer& server = AdvanceWarsServer::getInstance();
-	std::string guidString;
-	const json jsonResponseBody = server.create_new_game(guidString);
-	response_body = jsonResponseBody.dump();
-	tx_response resp(response_status::code::OK);
-	resp.add_header("Access-Control-Allow-Origin", "*");
-	return resp;
+	return ToHttpResponse(server.m_gameService.CreateGame(data), response_body);
 }
 
-/*static*/ tx_response AdvanceWarsServer::get_game_actions(const http_request& request, const Parameters& parameters, const std::string&data, std::string&response_body) {
-	int x = std::stoi(parameters.find("x")->second);
-	int y = std::stoi(parameters.find("y")->second);
+/*static*/ tx_response AdvanceWarsServer::get_game_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {
 	std::string gameId = parameters.find("gameid")->second;
-
 	AdvanceWarsServer& server = AdvanceWarsServer::getInstance();
-	json j = server.get_actions(gameId, x, y);
-	response_body = j.dump();
-
-	tx_response resp(response_status::code::OK);
-	resp.add_header("Access-Control-Allow-Origin", "*");
-	return resp;
+	return ToHttpResponse(server.m_gameService.GetGame(gameId), response_body);
 }
 
-/*static*/ tx_response AdvanceWarsServer::post_game_actions(const http_request& request, const Parameters& parameters, const std::string&data, std::string&response_body) {
+/*static*/ tx_response AdvanceWarsServer::post_game_actions(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {
 	std::string gameId = parameters.find("gameid")->second;
 	AdvanceWarsServer& server = AdvanceWarsServer::getInstance();
-
-	Action action;
-	std::istringstream stream(data);
-	json j;
-	stream >> j;
-	from_json(j, action);
-
-	const json jsonResponseBody = server.do_action(gameId, action);
-	response_body = jsonResponseBody.dump();
-	tx_response resp(response_status::code::OK);
-	resp.add_header("Access-Control-Allow-Origin", "*");
-	return resp;
+	return ToHttpResponse(server.m_gameService.SubmitAction(gameId, data), response_body);
 }
 
-/*static*/ tx_response AdvanceWarsServer::get_valid_game_actions(const http_request& request, const Parameters& parameters, const std::string&data, std::string&response_body) {
+/*static*/ tx_response AdvanceWarsServer::get_valid_game_actions(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {
 	std::string gameId = parameters.find("gameid")->second;
 	AdvanceWarsServer& server = AdvanceWarsServer::getInstance();
-	json j = server.get_valid_actions(gameId);
-	response_body = j.dump();
+	return ToHttpResponse(server.m_gameService.ListActions(gameId, QueryFromRequest(request)), response_body);
+}
 
-	tx_response resp(response_status::code::OK);
-	resp.add_header("Access-Control-Allow-Origin", "*");
-	return resp;
+/*static*/ tx_response AdvanceWarsServer::options_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {
+	response_body.clear();
+	tx_response response(response_status::code::NO_CONTENT);
+	AddCorsHeaders(response);
+	return response;
 }
 
 AdvanceWarsServer::AdvanceWarsServer() :
@@ -70,12 +75,17 @@ AdvanceWarsServer::AdvanceWarsServer() :
 	std::string app_name("Advance Wars AI");
 	unsigned short port_number(via::comms::tcp_adaptor::DEFAULT_HTTP_PORT);
 	std::cout << app_name << ": " << port_number << std::endl;
-	m_http_server.request_router().add_method("POST", "/games", &AdvanceWarsServer::post_games_handler);
-	m_http_server.request_router().add_method("GET", "/actions/:gameid/:x/:y", &AdvanceWarsServer::get_game_actions);
-	m_http_server.request_router().add_method("GET", "/actions/:gameid", &AdvanceWarsServer::get_valid_game_actions);
-	m_http_server.request_router().add_method("POST", "/actions/:gameid", &AdvanceWarsServer::post_game_actions);
-}
 
+	m_http_server.request_router().add_method("POST", "/games", &AdvanceWarsServer::post_games_handler);
+	m_http_server.request_router().add_method("OPTIONS", "/games", &AdvanceWarsServer::options_handler);
+
+	m_http_server.request_router().add_method("GET", "/games/:gameid", &AdvanceWarsServer::get_game_handler);
+	m_http_server.request_router().add_method("OPTIONS", "/games/:gameid", &AdvanceWarsServer::options_handler);
+
+	m_http_server.request_router().add_method("GET", "/games/:gameid/actions", &AdvanceWarsServer::get_valid_game_actions);
+	m_http_server.request_router().add_method("POST", "/games/:gameid/actions", &AdvanceWarsServer::post_game_actions);
+	m_http_server.request_router().add_method("OPTIONS", "/games/:gameid/actions", &AdvanceWarsServer::options_handler);
+}
 
 int AdvanceWarsServer::run() {
 	// Accept connections (both IPV4 and IPV6) on the default port (80)
@@ -87,67 +97,4 @@ int AdvanceWarsServer::run() {
 	m_io_context.run();
 
 	return 0;
-}
-
-json AdvanceWarsServer::create_new_game(std::string& gameId) {
-	gameId = Platform::createUuid();
-
-	Player player1(CommandingOfficier::Type::Andy, Player::ArmyType::OrangeStar);
-	Player player2(CommandingOfficier::Type::Adder, Player::ArmyType::BlueMoon);
-	std::array<Player, 2> arrPlayers{ std::move(player1), std::move(player2) };
-	GameState* gameState = new GameState(gameId, std::move(arrPlayers));
-	gameState->InitializeGame();
-	m_gameCache.emplace(gameId, gameState);
-	const auto& game = m_gameCache.find(gameId.c_str());
-	json j;
-	GameState::to_json(j, *game->second);
-	return j;
-}
-
-GameState AdvanceWarsServer::CloneGameState(const std::string& gameId) const {
-	const auto& game = m_gameCache.find(gameId.c_str());
-	return game->second->Clone();
-}
-
-json AdvanceWarsServer::get_actions(const std::string& gameId, int x, int y) const {
-	const auto& game = m_gameCache.find(gameId.c_str());
-	std::vector<Action> vecActions;
-	game->second->GetValidActions(x, y, vecActions);
-
-	json j;
-	to_json(j, vecActions);
-	return j;
-}
-
-json AdvanceWarsServer::get_valid_actions(const std::string& gameId) const {
-	std::vector<Action> vecActions;
-	get_valid_actions(gameId, vecActions);
-	json j;
-	to_json(j, vecActions);
-	return j;
-}
-
-Result AdvanceWarsServer::get_valid_actions(const std::string& gameId, std::vector<Action>& vecActions) const {
-	const auto& game = m_gameCache.find(gameId.c_str());
-	game->second->GetValidActions(vecActions);
-	return Result::Succeeded;
-}
-
-json AdvanceWarsServer::do_action(const std::string& gameId, const Action& action) {
-	const auto& game = m_gameCache.find(gameId.c_str());
-	game->second->DoAction(action);
-	std::vector<Action> vecActions;
-	// Only action left is EndTurn;
-	if (!game->second->FGameOver() && game->second->GetValidActions(vecActions) == Result::Succeeded && vecActions.size() == 1) {
-		game->second->EndTurn();
-	}
-
-	json j;
-	GameState::to_json(j, *game->second);
-	return j;
-}
-
-bool AdvanceWarsServer::game_over(const std::string& gameId) {
-	const auto& game = m_gameCache.find(gameId.c_str());
-	return game->second->FGameOver();
 }

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -255,6 +255,7 @@ Result GameState::BeginTurn() noexcept {
 					if (FPlayerRouted(GetCurrentPlayer())) {
 						m_fGameOver = true;
 						m_winningPlayer = m_isFirstPlayerTurn ? 1 : 0;
+						m_terminalReason = "fuel-rout";
 					}
 				}
 			}
@@ -1196,6 +1197,7 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 		if (fHqCapture) {
 			m_fGameOver = true;
 			m_winningPlayer = m_isFirstPlayerTurn ? 0 : 1;
+			m_terminalReason = "hq-capture";
 			return Result::Succeeded;
 		}
 		// Add logic to test if all labs are lost
@@ -1204,6 +1206,7 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 				if (!FEnemyHasLabs()) {
 					m_fGameOver = true;
 					m_winningPlayer = m_isFirstPlayerTurn ? 0 : 1;
+					m_terminalReason = "lab-capture";
 					return Result::Succeeded;
 				}
 			}
@@ -1224,6 +1227,7 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 		if (totalProperties >= m_nCaptureLimit) {
 			m_fGameOver = true;
 			m_winningPlayer = m_isFirstPlayerTurn ? 0 : 1;
+			m_terminalReason = "capture-limit";
 		}
 	}
 
@@ -1380,6 +1384,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		if (FPlayerRouted(*pdefendingplayer)) {
 			m_fGameOver = true;
 			m_winningPlayer = m_isFirstPlayerTurn ? 0 : 1;
+			m_terminalReason = "rout";
 		}
 		return Result::Succeeded;
 	}
@@ -1415,6 +1420,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		if (FPlayerRouted(*pattackingplayer)) {
 			m_fGameOver = true;
 			m_winningPlayer = m_isFirstPlayerTurn ? 1 : 0;
+			m_terminalReason = "rout";
 		}
 		return Result::Succeeded;
 	}
@@ -2245,6 +2251,7 @@ bool GameState::CheckPlayerResigns() noexcept {
 		//std::cout << "Forfeit by player" << (m_isFirstPlayerTurn ? 0 : 1) << std::endl;
 		//std::cout << "Winning player" << m_winningPlayer << std::endl;
 		m_fGameOver = true;
+		m_terminalReason = "heuristic-resign";
 	}
 
 	return true;
@@ -2261,6 +2268,7 @@ GameState::GameState(const GameState& other) noexcept :
 	m_isFirstPlayerTurn = other.m_isFirstPlayerTurn;
 	m_fGameOver = other.m_fGameOver;
 	m_winningPlayer = other.m_winningPlayer;
+	m_terminalReason = other.m_terminalReason;
 	m_combatRngSeed = other.m_combatRngSeed;
 	m_combatRng = other.m_combatRng;
 	m_weather = other.m_weather;
@@ -2286,6 +2294,7 @@ GameState& GameState::operator=(const GameState& other) noexcept {
 		m_isFirstPlayerTurn = other.m_isFirstPlayerTurn;
 		m_fGameOver = other.m_fGameOver;
 		m_winningPlayer = other.m_winningPlayer;
+		m_terminalReason = other.m_terminalReason;
 		m_combatRngSeed = other.m_combatRngSeed;
 		m_combatRng = other.m_combatRng;
 		m_weather = other.m_weather;
@@ -2464,6 +2473,12 @@ void GameState::from_json(json& j, GameState& gameState) {
 	j.at("turn-count").get_to(gameState.m_nTurnCount);
 	j.at("game-over").get_to(gameState.m_fGameOver);
 	j.at("winner").get_to(gameState.m_winningPlayer);
+	if (j.contains("terminalReason") && !j.at("terminalReason").is_null()) {
+		gameState.m_terminalReason = j.at("terminalReason").get<std::string>();
+	}
+	else {
+		gameState.m_terminalReason.reset();
+	}
 	int activePlayer;
 	j.at("activePlayer").get_to(activePlayer);
 	gameState.m_isFirstPlayerTurn = activePlayer == 0;

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -1,0 +1,241 @@
+#include "RestGameService.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+bool Expect(bool condition, const std::string& message) {
+	if (!condition) {
+		std::cerr << "REST API contract test failed: " << message << std::endl;
+	}
+	return condition;
+}
+
+json StandardCreatePayload(const std::string& mapId = "lefty") {
+	return {
+		{ "mapId", mapId },
+		{ "players", json::array({
+			{
+				{ "co", "andy" },
+				{ "armyType", "orange-star" },
+			},
+			{
+				{ "co", "adder" },
+				{ "armyType", "blue-moon" },
+			},
+		}) },
+		{ "seed", 8675309 },
+	};
+}
+
+bool RunCreateGetAndLegalActionContract() {
+	RestGameService service;
+	ApiResponse create = service.CreateGame(StandardCreatePayload("mcts").dump());
+	if (!Expect(create.status == 201, "create should return 201")) {
+		return false;
+	}
+	if (!Expect(create.headers.at("Location") == "/games/" + create.body.at("gameId").get<std::string>(), "create should set Location")) {
+		return false;
+	}
+	if (!Expect(create.body.contains("settings"), "create should return resolved settings")) {
+		return false;
+	}
+	if (!Expect(create.body.at("settings").at("mode") == "standard", "settings mode should be standard")) {
+		return false;
+	}
+	if (!Expect(!create.body.contains("combat-rng-seed"), "create should not expose combat RNG seed")) {
+		return false;
+	}
+	if (!Expect(create.body.contains("terminalReason") && create.body.at("terminalReason").is_null(), "active game should have null terminalReason")) {
+		return false;
+	}
+
+	const std::string gameId = create.body.at("gameId").get<std::string>();
+	ApiResponse get = service.GetGame(gameId);
+	if (!Expect(get.status == 200, "get should return 200")) {
+		return false;
+	}
+	if (!Expect(get.body.at("gameId") == gameId, "get should return requested game")) {
+		return false;
+	}
+
+	ApiResponse allActions = service.ListActions(gameId, "");
+	if (!Expect(allActions.status == 200, "all legal actions should return 200")) {
+		return false;
+	}
+	if (!Expect(allActions.body.at("gameId") == gameId, "legal action envelope should include gameId")) {
+		return false;
+	}
+	if (!Expect(allActions.body.contains("activePlayer"), "legal action envelope should include activePlayer")) {
+		return false;
+	}
+	if (!Expect(!allActions.body.contains("source"), "all legal actions should not include source")) {
+		return false;
+	}
+	if (!Expect(allActions.body.at("actions").is_array() && !allActions.body.at("actions").empty(), "all legal actions should include actions")) {
+		return false;
+	}
+
+	json sourceAction;
+	for (const json& action : allActions.body.at("actions")) {
+		if (action.contains("source")) {
+			sourceAction = action;
+			break;
+		}
+	}
+	if (!Expect(!sourceAction.is_null(), "expected at least one source action")) {
+		return false;
+	}
+
+	const int x = sourceAction.at("source").at(0).get<int>();
+	const int y = sourceAction.at("source").at(1).get<int>();
+	ApiResponse tileActions = service.ListActions(gameId, "x=" + std::to_string(x) + "&y=" + std::to_string(y));
+	if (!Expect(tileActions.status == 200, "tile legal actions should return 200")) {
+		return false;
+	}
+	if (!Expect(tileActions.body.at("source").at(0) == x && tileActions.body.at("source").at(1) == y, "tile legal action envelope should include source")) {
+		return false;
+	}
+
+	return true;
+}
+
+bool RunStepAndErrorContract() {
+	RestGameService service;
+	ApiResponse create = service.CreateGame(StandardCreatePayload("mcts").dump());
+	if (!Expect(create.status == 201, "create for step contract should return 201")) {
+		return false;
+	}
+	const std::string gameId = create.body.at("gameId").get<std::string>();
+
+	ApiResponse allActions = service.ListActions(gameId, "");
+	json legalAction = allActions.body.at("actions").front();
+	ApiResponse step = service.SubmitAction(gameId, legalAction.dump());
+	if (!Expect(step.status == 200, "legal step should return 200")) {
+		return false;
+	}
+	if (!Expect(step.body.at("gameId") == gameId, "legal step should return updated game")) {
+		return false;
+	}
+
+	json illegalAction = {
+		{ "type", "move-wait" },
+		{ "source", json::array({ 999, 999 }) },
+		{ "target", json::array({ 999, 999 }) },
+	};
+	ApiResponse illegal = service.SubmitAction(gameId, illegalAction.dump());
+	if (!Expect(illegal.status == 422, "illegal action should return 422")) {
+		return false;
+	}
+	if (!Expect(illegal.body.at("error").at("code") == "illegal-action", "illegal action should use stable error code")) {
+		return false;
+	}
+	if (!Expect(illegal.body.contains("game"), "illegal action should return current game")) {
+		return false;
+	}
+
+	ApiResponse unknown = service.GetGame("missing-game");
+	if (!Expect(unknown.status == 404, "unknown game should return 404")) {
+		return false;
+	}
+
+	ApiResponse invalidPayload = service.SubmitAction(gameId, R"({"type":"end-turn","unexpected":true})");
+	if (!Expect(invalidPayload.status == 400, "unknown action field should return 400")) {
+		return false;
+	}
+
+	return true;
+}
+
+bool RunTerminalContract() {
+	RestGameService service;
+
+	std::fstream filestream("test/json/misc/end-game-hqcap-player0.json", std::ios::in);
+	if (!Expect(!filestream.fail(), "terminal fixture should be readable")) {
+		return false;
+	}
+
+	json fixture;
+	filestream >> fixture;
+	GameState gameState;
+	GameState::from_json(fixture.at("initial-game-state"), gameState);
+	service.StoreGameForTesting(std::move(gameState));
+
+	const std::string gameId = fixture.at("initial-game-state").at("gameId").get<std::string>();
+	ApiResponse terminalStep = service.SubmitAction(gameId, fixture.at("actions").front().dump());
+	if (!Expect(terminalStep.status == 200, "terminal-producing legal step should return 200")) {
+		return false;
+	}
+	if (!Expect(terminalStep.body.at("game-over") == true, "terminal step should return terminal game")) {
+		return false;
+	}
+	if (!Expect(terminalStep.body.at("terminalReason") == "hq-capture", "terminal step should include terminal reason")) {
+		return false;
+	}
+
+	ApiResponse afterTerminal = service.SubmitAction(gameId, R"({"type":"end-turn"})");
+	if (!Expect(afterTerminal.status == 409, "post-terminal action should return 409")) {
+		return false;
+	}
+	if (!Expect(afterTerminal.body.at("error").at("code") == "terminal-state", "post-terminal action should use terminal-state code")) {
+		return false;
+	}
+	if (!Expect(afterTerminal.body.contains("game"), "post-terminal action should return current game")) {
+		return false;
+	}
+
+	return true;
+}
+
+bool RunCreateValidationContract() {
+	RestGameService service;
+
+	json unsupported = StandardCreatePayload();
+	unsupported["settings"] = { { "fog", true } };
+	ApiResponse unsupportedResponse = service.CreateGame(unsupported.dump());
+	if (!Expect(unsupportedResponse.status == 422, "unsupported setting should return 422")) {
+		return false;
+	}
+	if (!Expect(unsupportedResponse.body.at("error").at("code") == "unsupported-setting", "unsupported setting should use stable error code")) {
+		return false;
+	}
+
+	json unknownMap = StandardCreatePayload();
+	unknownMap["mapId"] = "not-a-map";
+	ApiResponse unknownMapResponse = service.CreateGame(unknownMap.dump());
+	if (!Expect(unknownMapResponse.status == 422, "unknown map should return 422")) {
+		return false;
+	}
+	if (!Expect(unknownMapResponse.body.at("error").at("details").at("supportedMapIds").is_array(), "unknown map should list supported map ids")) {
+		return false;
+	}
+
+	json unknownField = StandardCreatePayload();
+	unknownField["mode"] = "standard";
+	ApiResponse unknownFieldResponse = service.CreateGame(unknownField.dump());
+	if (!Expect(unknownFieldResponse.status == 400, "unknown top-level field should return 400")) {
+		return false;
+	}
+
+	return true;
+}
+}
+
+int RunRestApiContractTests() {
+	if (!RunCreateGetAndLegalActionContract()) {
+		return 1;
+	}
+	if (!RunStepAndErrorContract()) {
+		return 1;
+	}
+	if (!RunTerminalContract()) {
+		return 1;
+	}
+	if (!RunCreateValidationContract()) {
+		return 1;
+	}
+
+	std::cout << "REST API contract tests passed" << std::endl;
+	return 0;
+}

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -1,0 +1,519 @@
+#include "RestGameService.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include "Platform.h"
+
+namespace {
+constexpr int HttpOk = 200;
+constexpr int HttpCreated = 201;
+constexpr int HttpBadRequest = 400;
+constexpr int HttpNotFound = 404;
+constexpr int HttpConflict = 409;
+constexpr int HttpUnprocessableEntity = 422;
+constexpr int HttpInternalServerError = 500;
+
+struct MapTemplate {
+	const char* id;
+	const char* path;
+};
+
+constexpr std::array<MapTemplate, 2> MapTemplates{ {
+	{ "lefty", "res/AWBW/MapSources/Lefty.json" },
+	{ "mcts", "res/AWBW/MapSources/MCTS.json" },
+} };
+
+json StandardSettingsJson() {
+	return {
+		{ "mode", "standard" },
+		{ "fog", false },
+		{ "weather", "clear" },
+		{ "coPowers", true },
+		{ "tags", false },
+		{ "startingFunds", 0 },
+		{ "incomePerProperty", 1000 },
+		{ "unitCap", 50 },
+		{ "captureLimit", 21 },
+		{ "bannedUnits", json::array({ "blackbomb" }) },
+	};
+}
+
+json SupportedMapIds() {
+	json supported = json::array();
+	for (const MapTemplate& mapTemplate : MapTemplates) {
+		supported.push_back(mapTemplate.id);
+	}
+	return supported;
+}
+
+const MapTemplate* FindMapTemplate(const std::string& mapId) {
+	for (const MapTemplate& mapTemplate : MapTemplates) {
+		if (mapId == mapTemplate.id) {
+			return &mapTemplate;
+		}
+	}
+	return nullptr;
+}
+
+ApiResponse JsonResponse(int status, json body) {
+	ApiResponse response;
+	response.status = status;
+	response.body = std::move(body);
+	response.headers.emplace("Content-Type", "application/json");
+	return response;
+}
+
+ApiResponse ErrorResponse(int status, const std::string& code, const std::string& message, json details = json::object()) {
+	json body = {
+		{ "error", {
+			{ "code", code },
+			{ "message", message },
+		} },
+	};
+	if (!details.empty()) {
+		body["error"]["details"] = std::move(details);
+	}
+	return JsonResponse(status, std::move(body));
+}
+
+ApiResponse ErrorResponseWithGame(int status, const std::string& code, const std::string& message, const json& game) {
+	json body = {
+		{ "error", {
+			{ "code", code },
+			{ "message", message },
+		} },
+		{ "game", game },
+	};
+	return JsonResponse(status, std::move(body));
+}
+
+bool ContainsOnlyFields(const json& object, const std::vector<std::string>& allowedFields, std::string& invalidField) {
+	if (!object.is_object()) {
+		invalidField.clear();
+		return false;
+	}
+
+	for (auto it = object.begin(); it != object.end(); ++it) {
+		if (std::find(allowedFields.begin(), allowedFields.end(), it.key()) == allowedFields.end()) {
+			invalidField = it.key();
+			return false;
+		}
+	}
+
+	return true;
+}
+
+std::string ToPascalNoHyphen(std::string value) {
+	std::string converted;
+	bool capitalizeNext = true;
+	for (char ch : value) {
+		if (ch == '-') {
+			capitalizeNext = true;
+			continue;
+		}
+
+		if (capitalizeNext) {
+			converted.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+			capitalizeNext = false;
+		}
+		else {
+			converted.push_back(ch);
+		}
+	}
+	return converted;
+}
+
+bool TryParseCoId(const std::string& coId, CommandingOfficier& co, std::string& coJsonName) {
+	coJsonName = ToPascalNoHyphen(coId);
+	json coJson = coJsonName;
+	try {
+		from_json(coJson, co);
+		return co.m_type != CommandingOfficier::Type::Invalid;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool IsStandardBannedUnits(const json& bannedUnits) {
+	return bannedUnits.is_array() &&
+		bannedUnits.size() == 1 &&
+		bannedUnits.at(0).is_string() &&
+		bannedUnits.at(0).get<std::string>() == "blackbomb";
+}
+
+ApiResponse ValidateSettings(const json& request) {
+	if (!request.contains("settings")) {
+		return JsonResponse(HttpOk, StandardSettingsJson());
+	}
+
+	const json& settings = request.at("settings");
+	if (!settings.is_object()) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "settings must be an object.", { { "field", "settings" } });
+	}
+
+	std::string invalidField;
+	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "bannedUnits" }, invalidField)) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown settings field.", { { "field", "settings." + invalidField } });
+	}
+
+	try {
+		if (settings.contains("mode") && (!settings.at("mode").is_string() || settings.at("mode").get<std::string>() != "standard")) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only standard mode is supported.", { { "field", "settings.mode" }, { "value", settings.at("mode") } });
+		}
+		if (settings.contains("fog") && (!settings.at("fog").is_boolean() || settings.at("fog").get<bool>() != false)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Fog of War is not supported for standard games yet.", { { "field", "settings.fog" }, { "value", settings.at("fog") } });
+		}
+		if (settings.contains("weather") && (!settings.at("weather").is_string() || settings.at("weather").get<std::string>() != "clear")) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only clear weather is supported for standard games.", { { "field", "settings.weather" }, { "value", settings.at("weather") } });
+		}
+		if (settings.contains("coPowers") && (!settings.at("coPowers").is_boolean() || settings.at("coPowers").get<bool>() != true)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "CO powers must remain enabled for standard games.", { { "field", "settings.coPowers" }, { "value", settings.at("coPowers") } });
+		}
+		if (settings.contains("tags") && (!settings.at("tags").is_boolean() || settings.at("tags").get<bool>() != false)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Tag powers are not supported for standard games yet.", { { "field", "settings.tags" }, { "value", settings.at("tags") } });
+		}
+		if (settings.contains("startingFunds") && (!settings.at("startingFunds").is_number_integer() || settings.at("startingFunds").get<int>() != 0)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only 0 starting funds are supported for standard games.", { { "field", "settings.startingFunds" }, { "value", settings.at("startingFunds") } });
+		}
+		if (settings.contains("incomePerProperty") && (!settings.at("incomePerProperty").is_number_integer() || settings.at("incomePerProperty").get<int>() != 1000)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only 1000 income per property is supported for standard games.", { { "field", "settings.incomePerProperty" }, { "value", settings.at("incomePerProperty") } });
+		}
+		if (settings.contains("unitCap") && (!settings.at("unitCap").is_number_integer() || settings.at("unitCap").get<int>() != 50)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only unit cap 50 is supported for standard games.", { { "field", "settings.unitCap" }, { "value", settings.at("unitCap") } });
+		}
+		if (settings.contains("captureLimit") && (!settings.at("captureLimit").is_number_integer() || settings.at("captureLimit").get<int>() != 21)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only capture limit 21 is supported for standard games.", { { "field", "settings.captureLimit" }, { "value", settings.at("captureLimit") } });
+		}
+		if (settings.contains("bannedUnits") && !IsStandardBannedUnits(settings.at("bannedUnits"))) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only the standard blackbomb ban is supported.", { { "field", "settings.bannedUnits" }, { "value", settings.at("bannedUnits") } });
+		}
+	}
+	catch (const std::exception&) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "settings contains a value with the wrong type.", { { "field", "settings" } });
+	}
+
+	return JsonResponse(HttpOk, StandardSettingsJson());
+}
+
+json SerializeGameForApi(const GameState& gameState) {
+	json game;
+	GameState::to_json(game, gameState);
+	game.erase("combat-rng-seed");
+	game["settings"] = StandardSettingsJson();
+	if (gameState.GetTerminalReason().has_value()) {
+		game["terminalReason"] = gameState.GetTerminalReason().value();
+	}
+	else {
+		game["terminalReason"] = nullptr;
+	}
+	return game;
+}
+
+ApiResponse UnknownGameResponse() {
+	return ErrorResponse(HttpNotFound, "unknown-game-id", "Game id was not found.");
+}
+
+bool TryGetInteger(const std::string& value, int& parsed) {
+	try {
+		size_t processed = 0;
+		parsed = std::stoi(value, &processed);
+		return processed == value.size();
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+std::map<std::string, std::string> ParseQueryString(const std::string& query, bool& valid) {
+	valid = true;
+	std::map<std::string, std::string> parsed;
+	if (query.empty()) {
+		return parsed;
+	}
+
+	std::stringstream stream(query);
+	std::string part;
+	while (std::getline(stream, part, '&')) {
+		const size_t equals = part.find('=');
+		if (equals == std::string::npos) {
+			valid = false;
+			return parsed;
+		}
+
+		std::string key = part.substr(0, equals);
+		std::string value = part.substr(equals + 1);
+		if ((key != "x" && key != "y") || parsed.find(key) != parsed.end()) {
+			valid = false;
+			return parsed;
+		}
+
+		parsed.emplace(std::move(key), std::move(value));
+	}
+
+	return parsed;
+}
+
+json LegalActionsEnvelope(const GameState& gameState, const std::string& gameId, const std::vector<Action>& actions) {
+	json envelope = {
+		{ "gameId", gameId },
+		{ "activePlayer", gameState.getCurrentPlayer() },
+		{ "actions", actions },
+	};
+	return envelope;
+}
+
+ApiResponse ParseActionBody(const std::string& requestBody, Action& action) {
+	json request;
+	try {
+		request = json::parse(requestBody);
+	}
+	catch (const std::exception&) {
+		return ErrorResponse(HttpBadRequest, "malformed-json", "Request body is not valid JSON.");
+	}
+
+	if (!request.is_object()) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Action payload must be an object.");
+	}
+
+	std::string invalidField;
+	if (!ContainsOnlyFields(request, { "type", "source", "target", "direction", "unit", "unloadIndex" }, invalidField)) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown action field.", { { "field", invalidField } });
+	}
+
+	if (!request.contains("type") || !request.at("type").is_string()) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Action type is required.", { { "field", "type" } });
+	}
+
+	try {
+		from_json(request, action);
+	}
+	catch (const std::exception&) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Action payload has an invalid field shape.");
+	}
+
+	if (action.m_type == Action::Type::Invalid) {
+		return ErrorResponse(HttpBadRequest, "unknown-action-id", "Action type is not recognized.", { { "field", "type" }, { "value", request.at("type") } });
+	}
+
+	if (request.contains("unit") && (!action.m_optUnitType.has_value() || action.m_optUnitType.value() == UnitProperties::Type::Invalid)) {
+		return ErrorResponse(HttpBadRequest, "unknown-unit-id", "Unit id is not recognized.", { { "field", "unit" }, { "value", request.at("unit") } });
+	}
+
+	if (request.contains("direction") && !action.m_optDirection.has_value()) {
+		return ErrorResponse(HttpBadRequest, "unknown-direction", "Direction is not recognized.", { { "field", "direction" }, { "value", request.at("direction") } });
+	}
+
+	return JsonResponse(HttpOk, json::object());
+}
+}
+
+RestGameService::GameCache::iterator RestGameService::FindGame(const std::string& gameId) {
+	return m_games.find(gameId);
+}
+
+RestGameService::GameCache::const_iterator RestGameService::FindGame(const std::string& gameId) const {
+	return m_games.find(gameId);
+}
+
+ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
+	json request;
+	try {
+		request = json::parse(requestBody.empty() ? "{}" : requestBody);
+	}
+	catch (const std::exception&) {
+		return ErrorResponse(HttpBadRequest, "malformed-json", "Request body is not valid JSON.");
+	}
+
+	if (!request.is_object()) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Create game payload must be an object.");
+	}
+
+	std::string invalidField;
+	if (!ContainsOnlyFields(request, { "mapId", "players", "settings", "seed" }, invalidField)) {
+		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown create-game field.", { { "field", invalidField } });
+	}
+
+	if (!request.contains("mapId") || !request.at("mapId").is_string()) {
+		return ErrorResponse(HttpBadRequest, "missing-required-field", "mapId is required.", { { "field", "mapId" } });
+	}
+
+	const std::string mapId = request.at("mapId").get<std::string>();
+	const MapTemplate* mapTemplate = FindMapTemplate(mapId);
+	if (mapTemplate == nullptr) {
+		return ErrorResponse(HttpUnprocessableEntity, "unknown-map-id", "Map id is not supported.", { { "field", "mapId" }, { "value", mapId }, { "supportedMapIds", SupportedMapIds() } });
+	}
+
+	if (!request.contains("players") || !request.at("players").is_array() || request.at("players").size() != 2) {
+		return ErrorResponse(HttpBadRequest, "missing-required-field", "players must contain exactly two players.", { { "field", "players" } });
+	}
+
+	ApiResponse settingsValidation = ValidateSettings(request);
+	if (settingsValidation.status != HttpOk) {
+		return settingsValidation;
+	}
+
+	std::fstream filestream(mapTemplate->path, std::ios::in);
+	if (filestream.fail() || filestream.eof()) {
+		return ErrorResponse(HttpInternalServerError, "map-template-unavailable", "Map template could not be loaded.", { { "mapId", mapId } });
+	}
+
+	json templateJson;
+	filestream >> templateJson;
+	templateJson["gameId"] = Platform::createUuid();
+	templateJson["unit-cap"] = 50;
+	templateJson["cap-limit"] = 21;
+	templateJson.erase("combat-rng-seed");
+
+	for (int i = 0; i < 2; ++i) {
+		const json& requestedPlayer = request.at("players").at(i);
+		if (!requestedPlayer.is_object()) {
+			return ErrorResponse(HttpBadRequest, "invalid-field", "Player setup must be an object.", { { "field", "players[" + std::to_string(i) + "]" } });
+		}
+
+		if (!ContainsOnlyFields(requestedPlayer, { "co", "armyType" }, invalidField)) {
+			return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown player field.", { { "field", "players[" + std::to_string(i) + "]." + invalidField } });
+		}
+
+		if (!requestedPlayer.contains("co") || !requestedPlayer.at("co").is_string()) {
+			return ErrorResponse(HttpBadRequest, "missing-required-field", "Player co is required.", { { "field", "players[" + std::to_string(i) + "].co" } });
+		}
+
+		if (!requestedPlayer.contains("armyType") || !requestedPlayer.at("armyType").is_string()) {
+			return ErrorResponse(HttpBadRequest, "missing-required-field", "Player armyType is required.", { { "field", "players[" + std::to_string(i) + "].armyType" } });
+		}
+
+		const std::string armyType = requestedPlayer.at("armyType").get<std::string>();
+		const std::string templateArmyType = templateJson.at("players").at(i).at("armyType").get<std::string>();
+		if (armyType != templateArmyType || Player::armyTypefromString(armyType) == Player::ArmyType::Invalid) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-army", "Requested armyType must match the map template player slot.", {
+				{ "field", "players[" + std::to_string(i) + "].armyType" },
+				{ "value", armyType },
+				{ "templateArmyType", templateArmyType },
+			});
+		}
+
+		CommandingOfficier co;
+		std::string coJsonName;
+		if (!TryParseCoId(requestedPlayer.at("co").get<std::string>(), co, coJsonName)) {
+			return ErrorResponse(HttpUnprocessableEntity, "unsupported-co", "Commanding officer is not supported.", { { "field", "players[" + std::to_string(i) + "].co" }, { "value", requestedPlayer.at("co") } });
+		}
+
+		Player player(co.m_type, Player::armyTypefromString(armyType));
+		player.m_funds = 0;
+		json playerJson;
+		to_json(playerJson, player);
+		templateJson["players"][i] = std::move(playerJson);
+	}
+
+	GameState gameState;
+	try {
+		GameState::from_json(templateJson, gameState);
+	}
+	catch (const std::exception& err) {
+		return ErrorResponse(HttpInternalServerError, "map-template-invalid", err.what(), { { "mapId", mapId } });
+	}
+
+	if (request.contains("seed")) {
+		if (!request.at("seed").is_number_unsigned() &&
+			(!request.at("seed").is_number_integer() || request.at("seed").get<std::int64_t>() < 0)) {
+			return ErrorResponse(HttpBadRequest, "invalid-field", "seed must be an integer.", { { "field", "seed" } });
+		}
+		gameState.SetCombatRngSeed(request.at("seed").get<std::uint32_t>());
+	}
+
+	const std::string gameId = gameState.GetId();
+	m_games.emplace(gameId, std::unique_ptr<GameState>(new GameState(gameState)));
+
+	ApiResponse response = JsonResponse(HttpCreated, SerializeGameForApi(*m_games.at(gameId)));
+	response.headers.emplace("Location", "/games/" + gameId);
+	return response;
+}
+
+ApiResponse RestGameService::GetGame(const std::string& gameId) const {
+	const auto game = FindGame(gameId);
+	if (game == m_games.end()) {
+		return UnknownGameResponse();
+	}
+
+	return JsonResponse(HttpOk, SerializeGameForApi(*game->second));
+}
+
+ApiResponse RestGameService::ListActions(const std::string& gameId, const std::string& query) const {
+	const auto game = FindGame(gameId);
+	if (game == m_games.end()) {
+		return UnknownGameResponse();
+	}
+
+	bool validQuery = true;
+	std::map<std::string, std::string> queryParams = ParseQueryString(query, validQuery);
+	if (!validQuery || queryParams.size() == 1) {
+		return ErrorResponse(HttpBadRequest, "invalid-query", "Legal action query must include both x and y, or neither.");
+	}
+
+	std::vector<Action> actions;
+	json envelope;
+	if (queryParams.empty()) {
+		game->second->GetValidActions(actions);
+		envelope = LegalActionsEnvelope(*game->second, gameId, actions);
+	}
+	else {
+		int x = 0;
+		int y = 0;
+		if (!TryGetInteger(queryParams["x"], x) || !TryGetInteger(queryParams["y"], y)) {
+			return ErrorResponse(HttpUnprocessableEntity, "invalid-coordinate", "x and y must be integer board coordinates.", { { "x", queryParams["x"] }, { "y", queryParams["y"] } });
+		}
+
+		if (game->second->GetValidActions(x, y, actions) == Result::Failed) {
+			return ErrorResponse(HttpUnprocessableEntity, "invalid-coordinate", "x and y must be in bounds.", { { "x", x }, { "y", y } });
+		}
+
+		envelope = LegalActionsEnvelope(*game->second, gameId, actions);
+		envelope["source"] = json::array({ x, y });
+	}
+
+	return JsonResponse(HttpOk, std::move(envelope));
+}
+
+ApiResponse RestGameService::SubmitAction(const std::string& gameId, const std::string& requestBody) {
+	const auto game = FindGame(gameId);
+	if (game == m_games.end()) {
+		return UnknownGameResponse();
+	}
+
+	json currentGame = SerializeGameForApi(*game->second);
+	if (game->second->FGameOver()) {
+		return ErrorResponseWithGame(HttpConflict, "terminal-state", "Cannot apply an action to a terminal game.", currentGame);
+	}
+
+	Action action;
+	ApiResponse actionParse = ParseActionBody(requestBody, action);
+	if (actionParse.status != HttpOk) {
+		return actionParse;
+	}
+
+	std::vector<Action> legalActions;
+	game->second->GetValidActions(legalActions);
+	if (std::find(legalActions.begin(), legalActions.end(), action) == legalActions.end()) {
+		return ErrorResponseWithGame(HttpUnprocessableEntity, "illegal-action", "Action is not legal for the current player.", currentGame);
+	}
+
+	if (game->second->DoAction(action) == Result::Failed) {
+		return ErrorResponseWithGame(HttpUnprocessableEntity, "illegal-action", "Action failed during execution.", currentGame);
+	}
+
+	game->second->CheckPlayerResigns();
+	return JsonResponse(HttpOk, SerializeGameForApi(*game->second));
+}
+
+void RestGameService::StoreGameForTesting(GameState gameState) {
+	const std::string gameId = gameState.GetId();
+	m_games[gameId] = std::unique_ptr<GameState>(new GameState(gameState));
+}

--- a/AdvanceWarsServer/test/json/transport/apc/move-unload-infantry.json
+++ b/AdvanceWarsServer/test/json/transport/apc/move-unload-infantry.json
@@ -119,7 +119,8 @@
     {
       "type": "unload",
       "source": [ 1, 0 ],
-      "direction": "east"
+      "direction": "east",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/apc/multiple-loads-unloads.json
+++ b/AdvanceWarsServer/test/json/transport/apc/multiple-loads-unloads.json
@@ -196,7 +196,8 @@
     {
       "type": "unload",
       "source": [ 2, 1 ],
-      "direction": "south"
+      "direction": "south",
+      "unloadIndex": 0
     },
     {
       "type": "move-load",
@@ -206,7 +207,8 @@
     {
       "type": "unload",
       "source": [ 2, 1 ],
-      "direction": "east"
+      "direction": "east",
+      "unloadIndex": 0
     },
     {
       "type": "move-wait",
@@ -221,7 +223,8 @@
     {
       "type": "unload",
       "source": [ 5, 1 ],
-      "direction": "north"
+      "direction": "north",
+      "unloadIndex": 0
     },
     {
       "type": "move-load",
@@ -231,7 +234,8 @@
     {
       "type": "unload",
       "source": [ 5, 1 ],
-      "direction": "west"
+      "direction": "west",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/apc/unload-infantry.json
+++ b/AdvanceWarsServer/test/json/transport/apc/unload-infantry.json
@@ -114,7 +114,8 @@
     {
       "type": "unload",
       "source": [ 2, 0 ],
-      "direction":  "west"
+      "direction":  "west",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/apc/unload-mech.json
+++ b/AdvanceWarsServer/test/json/transport/apc/unload-mech.json
@@ -114,7 +114,8 @@
     {
       "type": "unload",
       "source": [ 2, 0 ],
-      "direction":  "west"
+      "direction":  "west",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/blackboat/no-unload-at-sea.json
+++ b/AdvanceWarsServer/test/json/transport/blackboat/no-unload-at-sea.json
@@ -123,7 +123,8 @@
     {
       "type": "unload",
       "source": [ 2, 0 ],
-      "direction":  "west"
+      "direction":  "west",
+      "unloadIndex": 0
     }
   ]
 }

--- a/AdvanceWarsServer/test/json/transport/lander/no-unload-at-sea.json
+++ b/AdvanceWarsServer/test/json/transport/lander/no-unload-at-sea.json
@@ -87,7 +87,8 @@
     {
       "type": "unload",
       "source": [ 2, 0 ],
-      "direction": "west"
+      "direction": "west",
+      "unloadIndex": 0
     }
   ]
 }

--- a/AdvanceWarsServer/test/json/transport/tcopter/move-unload-infantry.json
+++ b/AdvanceWarsServer/test/json/transport/tcopter/move-unload-infantry.json
@@ -119,7 +119,8 @@
     {
       "type": "unload",
       "source": [ 1, 0 ],
-      "direction": "east"
+      "direction": "east",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/tcopter/multiple-loads-unloads.json
+++ b/AdvanceWarsServer/test/json/transport/tcopter/multiple-loads-unloads.json
@@ -196,7 +196,8 @@
     {
       "type": "unload",
       "source": [ 2, 1 ],
-      "direction": "south"
+      "direction": "south",
+      "unloadIndex": 0
     },
     {
       "type": "move-load",
@@ -206,7 +207,8 @@
     {
       "type": "unload",
       "source": [ 2, 1 ],
-      "direction": "east"
+      "direction": "east",
+      "unloadIndex": 0
     },
     {
       "type": "move-wait",
@@ -221,7 +223,8 @@
     {
       "type": "unload",
       "source": [ 5, 1 ],
-      "direction": "north"
+      "direction": "north",
+      "unloadIndex": 0
     },
     {
       "type": "move-load",
@@ -231,7 +234,8 @@
     {
       "type": "unload",
       "source": [ 5, 1 ],
-      "direction": "west"
+      "direction": "west",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/tcopter/unload-infantry.json
+++ b/AdvanceWarsServer/test/json/transport/tcopter/unload-infantry.json
@@ -114,7 +114,8 @@
     {
       "type": "unload",
       "source": [ 2, 0 ],
-      "direction":  "west"
+      "direction":  "west",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/transport/tcopter/unload-mech.json
+++ b/AdvanceWarsServer/test/json/transport/tcopter/unload-mech.json
@@ -114,7 +114,8 @@
     {
       "type": "unload",
       "source": [ 2, 0 ],
-      "direction":  "west"
+      "direction":  "west",
+      "unloadIndex": 0
     }
   ],
   "final-game-state": {

--- a/AdvanceWarsServer/test/json/units/lander/boundaries.json
+++ b/AdvanceWarsServer/test/json/units/lander/boundaries.json
@@ -31,7 +31,7 @@
     "winner": -1
   },
   "failedActions": [
-    { "type": "unload", "source": [1, 0], "direction": "west" },
+    { "type": "unload", "source": [1, 0], "direction": "west", "unloadIndex": 0 },
     { "type": "move-wait", "source": [0, 1], "target": [1, 1] },
     { "type": "move-attack", "source": [0, 2], "target": [0, 2], "direction": "east" },
     { "type": "move-load", "source": [0, 3], "target": [1, 3] }

--- a/AdvanceWarsServer/test/json/units/lander/load-unload-movement.json
+++ b/AdvanceWarsServer/test/json/units/lander/load-unload-movement.json
@@ -34,7 +34,7 @@
   },
   "actions": [
     { "type": "move-load", "source": [0, 0], "target": [1, 0] },
-    { "type": "unload", "source": [1, 1], "direction": "east" },
+    { "type": "unload", "source": [1, 1], "direction": "east", "unloadIndex": 0 },
     { "type": "move-wait", "source": [0, 2], "target": [3, 2] }
   ],
   "final-game-state": {

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -30,6 +30,7 @@ Run tests from the `AdvanceWarsServer` project directory so the relative `test/j
 ```powershell
 Set-Location .\AdvanceWarsServer
 ..\x64\Debug\AdvanceWarsServer.exe -test test/json
+..\x64\Debug\AdvanceWarsServer.exe -test-api-contract
 ```
 
 Release:
@@ -52,9 +53,10 @@ The executable currently recognizes these development commands:
 | Option | Purpose | Notes |
 | --- | --- | --- |
 | `-test [path]` | Run the recursive JSON fixture suite. | Defaults to `test/json`. Run from `AdvanceWarsServer/` so relative paths resolve. |
+| `-test-api-contract` | Run focused REST lifecycle/action contract tests. | Run from `AdvanceWarsServer/` so map templates and fixtures resolve. |
 | `-sim-random-move-game [seed]` | Run an experimental random-action simulation. | Uses local output paths that still need cleanup before general use. |
 | `-sim-mcts-game` | Run an experimental MCTS simulation. | Uses local output paths that still need cleanup before general use. |
-| `-server` | Run the current HTTP server on port 80. | Serves the legacy routes documented in `docs/API.md`; route cleanup is tracked by #66. |
+| `-server` | Run the current HTTP server on port 80. | Serves the canonical REST routes documented in `docs/API.md`. |
 | `-converter` | Regenerate the hardcoded Lefty map JSON. | Developer utility. |
 | `-torchlib` | Run a local libtorch/MNIST experiment. | Depends on local `D:/MNIST` and libtorch paths. |
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The desired direction is:
 - React frontend renders board state and asks the server what actions are legal.
 - Bot replay and fixture visualizers reuse the same board renderer.
 
-The current HTTP wrapper is still early and hardcoded in places. See [docs/API.md](docs/API.md) and the related issues #66, #67, #68, #110, #111, #112, #113, #114, and #115.
+The HTTP wrapper exposes the canonical lifecycle/action contract documented in [docs/API.md](docs/API.md). Related follow-up work lives in #67, #68, #110, #111, #112, #113, #114, and #115.
 
 The React board viewer lives in [frontend/](frontend/). It can render checked-in sample JSON, pasted serialized `GameState` JSON, or a game created from the current HTTP server.
 
@@ -112,6 +112,6 @@ Primary local/reference docs:
 ## Known Caveats
 
 - The Standard completeness matrix is current as of its review date, not a substitute for issue triage.
-- The current REST wrapper does not yet satisfy the target API contract.
+- The REST wrapper is intentionally v1: games are process-local, Standard-only, and use a small curated map id catalog.
 - Several engine behaviors are intentionally documented as gaps rather than papered over in the docs.
 - Some local paths in experimental simulation/model code are still machine-specific and should be cleaned up before relying on those workflows broadly.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,100 +1,97 @@
 # API Notes
 
-Last reviewed: 2026-05-18
+Last reviewed: 2026-05-24
 
-This document describes the current HTTP surface and the target API shape for the Standard engine/frontend work. The C++ engine must remain authoritative for legal actions and state transitions; API clients should not duplicate rule logic.
+The C++ engine is authoritative for legal actions and state transitions. REST clients should create games, fetch state, request legal actions, and submit exactly one server-validated action at a time.
 
-## Current Implementation
-
-The HTTP route registration lives in `AdvanceWarsServer/src/AdvanceWarsServer.cpp`.
-
-| Method | Route | Current behavior |
-| --- | --- | --- |
-| `POST` | `/games` | Parses the request body, ignores its contents, creates one hardcoded Lefty game with Andy vs. Adder, and returns the serialized game state. |
-| `GET` | `/actions/:gameid/:x/:y` | Returns valid actions for a single board coordinate. |
-| `GET` | `/actions/:gameid` | Returns all valid actions for the active player. |
-| `POST` | `/actions/:gameid` | Parses an `Action`, applies it to cached state, may auto-end-turn if only `EndTurn` remains, and returns the serialized game state. |
-
-Important caveats:
-
-- The executable supports `-server`, which starts the current HTTP wrapper on port 80.
-- Game creation ignores map, settings, players, countries, COs, and seed.
-- Unknown game ids and invalid action responses are not a stable contract yet.
-- `POST /actions/:gameid` can apply implicit extra state change through auto-end-turn behavior.
-- Action execution and legal-action generation do not yet have a fully atomic shared validation contract.
-
-The target cleanup is tracked by:
-
-- #66: REST game lifecycle and step API contract.
-- #67: Validate and atomically reject illegal submitted actions.
-- #68: Make REST action stepping explicit and remove implicit auto-end-turn.
-- #69: Remove heuristic auto-resign from Standard terminal logic.
-- #65: Define and enforce normal Global League Standard game settings.
-
-## Target API Shape
-
-The eventual API should support both humans and AI clients with the same loop:
-
-1. Create a game from map, settings, players, COs, countries, and optional deterministic seed.
-2. Fetch the authoritative game state.
-3. Fetch legal actions for the active player or selected tile.
-4. Submit exactly one action.
-5. Receive either an atomic failure or the next authoritative state.
-6. Observe terminal status and winner/reason when the game ends.
-
-Suggested resources:
+## Routes
 
 | Method | Route | Purpose |
 | --- | --- | --- |
-| `POST` | `/games` | Create a game from a validated setup payload. |
-| `GET` | `/games/:gameid` | Fetch current authoritative game state. |
+| `POST` | `/games` | Create a Standard game from a setup payload. |
+| `GET` | `/games/:gameid` | Fetch the current authoritative game state. |
 | `GET` | `/games/:gameid/actions` | Fetch all legal actions for the active player. |
 | `GET` | `/games/:gameid/actions?x=4&y=7` | Fetch legal actions for one selected coordinate. |
 | `POST` | `/games/:gameid/actions` | Submit exactly one action. |
-| `GET` | `/games/:gameid/trace` | Optional replay/debug trace once action history exists. |
+| `OPTIONS` | canonical routes above | Browser CORS preflight. |
 
-The exact route names can change, but the contract should be explicit before the React client and training loop depend on it.
+Legacy `/actions/:gameid` and `/actions/:gameid/:x/:y` routes are not part of the supported contract.
 
-## Response Principles
+## Create Game
 
-Game state responses should include:
+Minimal request:
 
-- `gameId`
-- active player and day/turn information
-- map tiles, terrain, property ownership, capture points, and units
-- player funds, CO, power meter/status, and army/country identity
-- weather and settings
-- terminal status, winner, and terminal reason when applicable
+```json
+{
+  "mapId": "lefty",
+  "players": [
+    { "co": "andy", "armyType": "orange-star" },
+    { "co": "adder", "armyType": "blue-moon" }
+  ],
+  "seed": 8675309
+}
+```
 
-Action responses should include:
+`settings` is optional. If present, `mode` belongs inside `settings`; v1 accepts only strict Standard values. `seed` is optional and request-only: it enables deterministic combat RNG but is not returned in normal API game-state responses.
 
-- submitted action
-- success/failure
-- validation errors for rejected actions
-- resulting game state on success
-- no hidden implicit action commits
+Supported v1 map ids are `lefty` and `mcts`.
 
-Legal-action responses should include:
+## Responses
 
-- the current active player context
-- the legal actions as server-serialized `Action` objects
-- optional selection/source metadata for tile-specific requests
+Successful create returns `201 Created`, a full game-state JSON body, and `Location: /games/:gameId`. Successful get and step responses return `200 OK` with the full current game state. Game-state responses include resolved `settings` and `terminalReason`; active games use `null` for `terminalReason`.
 
-## Frontend And Bot Consumer Rules
+Legal-action responses use an envelope:
 
-Clients should:
+```json
+{
+  "gameId": "abc",
+  "activePlayer": 0,
+  "source": [4, 7],
+  "actions": [
+    { "type": "move-wait", "source": [1, 2], "target": [1, 3] },
+    { "type": "end-turn" }
+  ]
+}
+```
 
-- Treat server state as authoritative.
-- Render legal actions supplied by the server.
-- Submit one action at a time.
-- Resync from the server after each accepted action or rejected action.
-- Avoid inferring legality from visual state except for presentation hints.
+For all legal actions, `source` is omitted.
 
-Related frontend trackers:
+## Errors
 
-- #110: React frontend workspace and board renderer.
-- #111: Bot replay and self-play game visualizer.
-- #112: Human-play web client using server legal actions.
-- #113: JSON fixture and scenario visualization workflow.
-- #114: Frontend API adapter and shared game-state types.
-- #115: Frontend asset pipeline.
+Errors use HTTP status codes plus a stable JSON error code:
+
+```json
+{
+  "error": {
+    "code": "unsupported-setting",
+    "message": "Fog of War is not supported for standard games yet.",
+    "details": {
+      "field": "settings.fog",
+      "value": true
+    }
+  }
+}
+```
+
+Invalid actions against an existing game include the current authoritative game state:
+
+```json
+{
+  "error": {
+    "code": "illegal-action",
+    "message": "Action is not legal for the current player."
+  },
+  "game": { "...current unchanged GameState...": true }
+}
+```
+
+Status mapping:
+
+- `400 Bad Request`: malformed JSON, wrong field type, invalid query shape, unknown JSON field, unknown action/unit id.
+- `404 Not Found`: unknown `gameId`.
+- `409 Conflict`: action submitted after terminal state.
+- `422 Unprocessable Entity`: valid JSON but invalid setup/action, such as unknown `mapId`, unsupported setting, unsupported CO/army, illegal action, or invalid coordinate.
+
+## Lifecycle
+
+Games are process-local and retained in memory until server restart, including terminal games. There is no delete, list, reset, persistence, TTL, or optimistic concurrency token in v1.

--- a/docs/ISSUE_66_REST_CONTRACT_PLAN.md
+++ b/docs/ISSUE_66_REST_CONTRACT_PLAN.md
@@ -1,0 +1,150 @@
+# Issue #66 REST Contract Plan
+
+This file captures the issue #66 REST contract decisions from the design interview so they can be tracked verbatim.
+
+## Settled Design
+
+- `POST /games` takes setup payload, not full state.
+- Create request uses `mapId`; v1 supports `lefty` and `mcts`.
+- Map id resolves to curated backend JSON templates, not raw `.txt` terrain.
+- `players` is required, exactly two players, v1 armies must match template armies.
+- `players[0]` maps to template player slot 0 and `players[1]` maps to template player slot 1.
+- No `startingPlayer` override in v1; use the template/default initial active player.
+- Create CO ids use lowercase kebab-case, while existing state/action serialization stays as-is for now.
+- V1 accepts any CO id the engine can parse; remaining CO mechanic gaps stay tracked in focused follow-up issues.
+- Settings may be omitted; server fills strict Standard defaults and rejects unsupported non-Standard settings.
+- Resolved settings are serialized inside every returned `GameState`, including create, get, and step responses.
+- Optional `seed` is accepted for reproducible combat RNG; when omitted, combat RNG may be nondeterministic.
+- `seed` is request-only/debug metadata and is not serialized in normal state responses.
+- No reset endpoint; recreate from same setup.
+- Server-generated `gameId` only.
+- Games are process-local and retained in memory until server restart, including terminal games.
+- No delete/list/persistence/TTL behavior in v1.
+- No optimistic concurrency/version token or state-version field in v1; action legality is checked against current server state at mutation time.
+- New canonical routes:
+  - `POST /games`
+  - `GET /games/:gameId`
+  - `GET /games/:gameId/actions`
+  - `GET /games/:gameId/actions?x=4&y=7`
+  - `POST /games/:gameId/actions`
+- Do not keep legacy `/actions/:gameid` or `/actions/:gameid/:x/:y` routes as supported aliases.
+- Successful create/get/step returns full raw `GameState`.
+- Legal action list returns an envelope with `gameId`, `activePlayer`, optional `source`, and `actions`:
+  ```json
+  {
+    "gameId": "abc",
+    "activePlayer": 0,
+    "source": [4, 7],
+    "actions": [
+      { "type": "move-wait", "source": [1, 2], "target": [1, 3] },
+      { "type": "end-turn" }
+    ]
+  }
+  ```
+  For all legal actions, omit `source`.
+- Action post body is a raw action object.
+- Illegal action returns non-2xx error plus current authoritative game state.
+- Error responses use status codes plus stable `error.code`.
+- REST step validates against generated legal actions before mutation and applies exactly one action.
+- Add `terminalReason`, including `heuristic-resign` for current heuristic behavior.
+- Fix `Action::operator==` to include `unloadIndex`.
+- Unknown ids and unknown JSON fields are parse/validation errors, not silent `Invalid` enums or ignored extras.
+- Opened #138 for configurable heuristic resign.
+- Opened #139 for full map catalog expansion.
+- Opened #140 for explicit or randomized starting player setup.
+- Opened #141 for game cache persistence, cleanup, or TTL policy.
+
+## Create Payload Direction
+
+Minimal v1 request:
+
+```json
+{
+  "mapId": "lefty",
+  "players": [
+    { "co": "andy", "armyType": "orange-star" },
+    { "co": "adder", "armyType": "blue-moon" }
+  ],
+  "seed": 8675309
+}
+```
+
+Settings may be omitted. If provided, `mode` belongs inside `settings`, not at the top level. The server resolves strict Standard defaults and serializes the resolved settings in returned game state.
+
+Resolved v1 settings:
+
+```json
+{
+  "settings": {
+    "mode": "standard",
+    "fog": false,
+    "weather": "clear",
+    "coPowers": true,
+    "tags": false,
+    "startingFunds": 0,
+    "incomePerProperty": 1000,
+    "unitCap": 50,
+    "captureLimit": 21,
+    "bannedUnits": ["blackbomb"]
+  }
+}
+```
+
+Do not include day limit, timer/live settings, lab units, High Funds, tag COs, random weather, or fog metadata in v1. Reject those if submitted.
+
+Deferred settings are already tracked by follow-up issues:
+
+- Day-limit terminal rules: #74.
+- Lab-unit production requirements: #76.
+- Timer/live enforcement and timeout metadata: #82.
+- Fog of War, visibility, and fog-only metadata: #90.
+- High Funds mode: #91.
+- Random weather mode/settings: #92.
+- Tag powers and tag-team modes: #96.
+
+## Error Direction
+
+Use HTTP status codes plus a stable JSON error envelope:
+
+```json
+{
+  "error": {
+    "code": "unsupported-setting",
+    "message": "Fog of War is not supported for standard games yet.",
+    "details": {
+      "field": "settings.fog",
+      "value": true
+    }
+  }
+}
+```
+
+For invalid actions against an existing game, include the current authoritative game state:
+
+```json
+{
+  "error": {
+    "code": "illegal-action",
+    "message": "Action is not legal for the current player."
+  },
+  "game": { "...current unchanged GameState...": true }
+}
+```
+
+Recommended status mapping:
+
+- `400 Bad Request`: malformed JSON, wrong field type, invalid query shape, unknown action/unit id in an action payload.
+- `404 Not Found`: unknown `gameId`.
+- `409 Conflict`: action submitted after terminal state.
+- `422 Unprocessable Entity`: valid JSON but invalid setup/action, such as unknown `mapId`, unsupported setting, unsupported CO/army, illegal action, or out-of-bounds coordinate.
+- `201 Created`: successful `POST /games`.
+- `200 OK`: successful get/list/step.
+
+`POST /games` should also set `Location: /games/:gameId` while returning the full `GameState` body.
+
+Canonical REST routes should set `Content-Type: application/json` on JSON responses and support browser CORS preflight:
+
+- Keep `Access-Control-Allow-Origin: *` for v1.
+- Support `OPTIONS` for the canonical routes.
+- Allow `GET`, `POST`, and `OPTIONS`.
+- Allow `Content-Type` so browser clients can submit JSON setup/action payloads.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,7 +41,7 @@ Set-Location .\AdvanceWarsServer
 ..\x64\Debug\AdvanceWarsServer.exe -server
 ```
 
-The current server uses the legacy routes documented in `docs/API.md`, including `POST /games` and `GET /actions/:gameid/:x/:y`, and listens on port 80. The frontend defaults to `http://localhost:80`, but the base URL is editable and saved in browser local storage.
+The current server uses the canonical routes documented in `docs/API.md`, including `POST /games` and `GET /games/:gameid/actions?x=4&y=7`, and listens on port 80. The frontend defaults to `http://localhost:80`, but the base URL is editable and saved in browser local storage.
 
 ## Verification
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BoardCanvas } from "./components/BoardCanvas";
 import { actionHighlightsForSource } from "./rendering/actions";
-import { coordinateKey, parseGameStatePayload, type Action, actionListSchema, type Coordinate, type GameState, type ValidActionGroup } from "./gameState/schema";
+import { coordinateKey, parseGameStatePayload, type Action, legalActionEnvelopeSchema, type Coordinate, type GameState, type ValidActionGroup } from "./gameState/schema";
 import { normalizeServerBaseUrl, serverApiUrl } from "./api/url";
 import { terrainDisplayName } from "./rendering/terrain";
 import "./styles.css";
@@ -145,7 +145,16 @@ export default function App() {
       const response = await fetch(serverApiUrl(baseUrl, "games"), {
         method: "POST",
         credentials: "omit",
-        body: "{}"
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          mapId: "lefty",
+          players: [
+            { co: "andy", armyType: "orange-star" },
+            { co: "adder", armyType: "blue-moon" }
+          ]
+        })
       });
       if (!response.ok) {
         throw new Error(`${response.status} ${response.statusText}`);
@@ -213,13 +222,16 @@ export default function App() {
 
     setError(undefined);
     try {
-      const response = await fetch(serverApiUrl(serverBaseUrl, "actions", loaded.gameState.gameId, coordinate[0], coordinate[1]), {
+      const actionsUrl = new URL(serverApiUrl(serverBaseUrl, "games", loaded.gameState.gameId, "actions"));
+      actionsUrl.searchParams.set("x", String(coordinate[0]));
+      actionsUrl.searchParams.set("y", String(coordinate[1]));
+      const response = await fetch(actionsUrl.toString(), {
         credentials: "omit"
       });
       if (!response.ok) {
         throw new Error(`${response.status} ${response.statusText}`);
       }
-      const actions = actionListSchema.parse(await response.json());
+      const actions = legalActionEnvelopeSchema.parse(await response.json()).actions;
       if (actionRequestId.current === requestId) {
         setSelectedActions(actions);
       }

--- a/frontend/src/api/url.test.ts
+++ b/frontend/src/api/url.test.ts
@@ -15,8 +15,8 @@ describe("normalizeServerBaseUrl", () => {
 
 describe("serverApiUrl", () => {
   it("encodes dynamic path segments instead of interpolating them", () => {
-    expect(serverApiUrl("http://localhost:8080/api", "actions", "game/../id", 1, 2)).toBe(
-      "http://localhost:8080/api/actions/game%2F..%2Fid/1/2"
+    expect(serverApiUrl("http://localhost:8080/api", "games", "game/../id", "actions")).toBe(
+      "http://localhost:8080/api/games/game%2F..%2Fid/actions"
     );
   });
 });

--- a/frontend/src/gameState/schema.ts
+++ b/frontend/src/gameState/schema.ts
@@ -24,6 +24,12 @@ export const actionSchema = z.object({
 export type Action = z.infer<typeof actionSchema>;
 export type Coordinate = z.infer<typeof coordinateSchema>;
 export const actionListSchema = z.array(actionSchema).max(maxActionCount);
+export const legalActionEnvelopeSchema = z.object({
+  gameId: shortText,
+  activePlayer: finiteInteger.min(0).max(7),
+  source: coordinateSchema.optional(),
+  actions: actionListSchema
+});
 
 const powerMeterSchema = z.object({
   "cop-stars": finiteInteger.min(0).max(20),
@@ -111,6 +117,8 @@ export const gameStateSchema = z.object({
   activePlayer: finiteInteger.min(0).max(7),
   "game-over": z.boolean(),
   winner: finiteInteger.min(-1).max(7),
+  terminalReason: shortText.nullable().optional(),
+  settings: z.record(z.unknown()).optional(),
   weather: z.enum(["clear", "rain", "snow"]).optional(),
   "weather-turns-remaining": finiteInteger.min(0).max(100).optional(),
   "combat-rng-seed": finiteInteger.min(0).max(4_294_967_295).optional()


### PR DESCRIPTION
Closes #66.

## Summary
- Adds a `RestGameService` behind the HTTP server for the canonical game lifecycle routes: create game, fetch game, list legal actions, and submit one raw legal action.
- Changes `POST /games` to accept a setup payload with backend `mapId` templates (`lefty`, `mcts`), required ordered players, optional Standard settings, and an optional request-only seed.
- Returns API envelopes with resolved settings, active player, legal actions, and full updated game state after action submission; strips the combat RNG seed from normal API state responses.
- Adds terminal reasons to game state for API consumers while preserving heuristic resign behavior.
- Updates frontend calls/schema, REST docs, build docs, and captures the agreed design decisions in `docs/ISSUE_66_REST_CONTRACT_PLAN.md`.
- Tightens raw action matching by making `Action::operator==` exact, including `unloadIndex`, and updates affected transport fixtures.

## Verification
- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `yarn test`
- `yarn typecheck`
- `yarn build`
- Live HTTP smoke against localhost: create game, list actions, submit action route surface
- `git diff --check`

## Deferred / tracked separately
- Configurable heuristic resign: #138
- Expand mapId catalog: #139
- Starting player controls: #140
- Cache persistence / cleanup / TTL: #141
- Other army/game-option expansion remains tracked by existing follow-up issues referenced from the design plan.