### PR TITLE
[codex] Enable playable local games

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -227,6 +227,7 @@ public:
 
 	GameState Clone();
 	Result InitializeGame() noexcept;
+	Result StartFirstTurn() noexcept;
 	Result DoAction(const Action& action) noexcept;
 	Map* TryGetMap() const noexcept;
 	const std::string& GetId() const noexcept;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -169,6 +169,14 @@ Result GameState::EndTurn() noexcept {
 	return Result::Succeeded;
 }
 
+Result GameState::StartFirstTurn() noexcept {
+	if (m_nTurnCount != 0 || !m_isFirstPlayerTurn || m_fGameOver) {
+		return Result::Failed;
+	}
+
+	return BeginTurn();
+}
+
 Result GameState::BeginTurn() noexcept {
 	// TODO Refactor to get rid of 4O(n^2)
 	if (m_isFirstPlayerTurn) {

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -50,6 +50,15 @@ bool RunCreateGetAndLegalActionContract() {
 	if (!Expect(create.body.contains("terminalReason") && create.body.at("terminalReason").is_null(), "active game should have null terminalReason")) {
 		return false;
 	}
+	if (!Expect(create.body.at("turn-count") == 1, "create should run the opening turn start")) {
+		return false;
+	}
+	if (!Expect(create.body.at("players").at(0).at("funds") == 2000, "opening turn start should pay player 1 income")) {
+		return false;
+	}
+	if (!Expect(create.body.at("players").at(1).at("funds") == 0, "opening turn start should not pay player 2 income yet")) {
+		return false;
+	}
 
 	const std::string gameId = create.body.at("gameId").get<std::string>();
 	ApiResponse get = service.GetGame(gameId);
@@ -74,6 +83,16 @@ bool RunCreateGetAndLegalActionContract() {
 		return false;
 	}
 	if (!Expect(allActions.body.at("actions").is_array() && !allActions.body.at("actions").empty(), "all legal actions should include actions")) {
+		return false;
+	}
+	bool hasEndTurn = false;
+	for (const json& action : allActions.body.at("actions")) {
+		if (action.at("type") == "end-turn") {
+			hasEndTurn = true;
+			break;
+		}
+	}
+	if (!Expect(hasEndTurn, "all legal actions should include end-turn")) {
 		return false;
 	}
 

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -370,6 +370,8 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 	templateJson["gameId"] = Platform::createUuid();
 	templateJson["unit-cap"] = 50;
 	templateJson["cap-limit"] = 21;
+	templateJson["activePlayer"] = 0;
+	templateJson["turn-count"] = 0;
 	templateJson.erase("combat-rng-seed");
 
 	for (int i = 0; i < 2; ++i) {
@@ -427,6 +429,10 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 			return ErrorResponse(HttpBadRequest, "invalid-field", "seed must be an integer.", { { "field", "seed" } });
 		}
 		gameState.SetCombatRngSeed(request.at("seed").get<std::uint32_t>());
+	}
+
+	if (gameState.StartFirstTurn() == Result::Failed) {
+		return ErrorResponse(HttpInternalServerError, "game-initialization-failed", "Game could not run the opening turn start.", { { "mapId", mapId } });
 	}
 
 	const std::string gameId = gameState.GetId();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BoardCanvas } from "./components/BoardCanvas";
 import { actionHighlightsForSource } from "./rendering/actions";
+import { actionToSubmitFromBoardTarget, actionsVisibleInInspector, buyMenuItems, globalActionsFromLegalActions, labelForAction } from "./gameState/actionDisplay";
 import { coordinateKey, parseGameStatePayload, type Action, legalActionEnvelopeSchema, type Coordinate, type GameState, type ValidActionGroup } from "./gameState/schema";
 import { normalizeServerBaseUrl, serverApiUrl } from "./api/url";
 import { terrainDisplayName } from "./rendering/terrain";
+import { unitAssetPath, unitFallbackLabel } from "./rendering/unitAssets";
 import "./styles.css";
 
 const defaultServerBaseUrl = "http://localhost:80";
@@ -14,6 +16,7 @@ type LoadSource = "sample" | "server" | "pasted";
 
 type LoadedState = {
   gameState: GameState;
+  globalActions: Action[];
   legalActionGroups: ValidActionGroup[];
   source: LoadSource;
   label: string;
@@ -47,6 +50,18 @@ async function fetchJson(path: string): Promise<unknown> {
     throw new Error(`${response.status} ${response.statusText}`);
   }
   return response.json();
+}
+
+async function fetchServerGlobalActions(baseUrl: string, gameId: string): Promise<Action[]> {
+  const response = await fetch(serverApiUrl(baseUrl, "games", gameId, "actions"), {
+    credentials: "omit"
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
+  const envelope = legalActionEnvelopeSchema.parse(await response.json());
+  return globalActionsFromLegalActions(envelope.actions);
 }
 
 function actionGroupForSelection(groups: ValidActionGroup[], selected?: Coordinate): Action[] {
@@ -106,7 +121,7 @@ export default function App() {
         return;
       }
       actionRequestId.current += 1;
-      setLoaded({ ...parsed, source: "sample", label });
+      setLoaded({ ...parsed, globalActions: [], source: "sample", label });
       setSelected(undefined);
       setInspectedCoordinate(undefined);
       setSelectedActions([]);
@@ -160,11 +175,12 @@ export default function App() {
         throw new Error(`${response.status} ${response.statusText}`);
       }
       const parsed = parseGameStatePayload(await response.json());
+      const globalActions = await fetchServerGlobalActions(baseUrl, parsed.gameState.gameId);
       if (loadRequestId.current !== requestId) {
         return;
       }
       actionRequestId.current += 1;
-      setLoaded({ ...parsed, source: "server", label: "Server game" });
+      setLoaded({ ...parsed, globalActions, source: "server", label: "Server game" });
       setSelected(undefined);
       setInspectedCoordinate(undefined);
       setSelectedActions([]);
@@ -190,7 +206,7 @@ export default function App() {
       }
       const parsed = parseGameStatePayload(JSON.parse(pasteValue));
       actionRequestId.current += 1;
-      setLoaded({ ...parsed, source: "pasted", label: "Pasted JSON" });
+      setLoaded({ ...parsed, globalActions: [], source: "pasted", label: "Pasted JSON" });
       setSelected(undefined);
       setInspectedCoordinate(undefined);
       setSelectedActions([]);
@@ -202,7 +218,15 @@ export default function App() {
 
   async function selectTile(coordinate: Coordinate) {
     const targetActions = highlights?.actionsByTile.get(coordinateKey(coordinate));
-    if (selected && targetActions && (coordinate[0] !== selected[0] || coordinate[1] !== selected[1])) {
+    if (selected && targetActions) {
+      const actionToSubmit = loaded?.source === "server" && loaded.gameState["game-over"] === false
+        ? actionToSubmitFromBoardTarget(targetActions)
+        : undefined;
+      if (actionToSubmit) {
+        await submitServerAction(actionToSubmit);
+        return;
+      }
+
       setInspectedCoordinate(coordinate);
       setInspectedActions(targetActions);
       return;
@@ -242,13 +266,70 @@ export default function App() {
     }
   }
 
+  async function submitServerAction(action: Action) {
+    if (!loaded || loaded.source !== "server") {
+      return;
+    }
+
+    const requestId = loadRequestId.current + 1;
+    loadRequestId.current = requestId;
+    actionRequestId.current += 1;
+    setIsLoading(true);
+    setError(undefined);
+    try {
+      const baseUrl = normalizeServerBaseUrl(serverBaseUrl);
+      rememberServerBaseUrl(baseUrl);
+      setServerBaseUrl(baseUrl);
+      const response = await fetch(serverApiUrl(baseUrl, "games", loaded.gameState.gameId, "actions"), {
+        method: "POST",
+        credentials: "omit",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(action)
+      });
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+
+      const parsed = parseGameStatePayload(await response.json());
+      const globalActions = await fetchServerGlobalActions(baseUrl, parsed.gameState.gameId);
+      if (loadRequestId.current !== requestId) {
+        return;
+      }
+
+      setLoaded({ ...parsed, globalActions, source: "server", label: loaded.label });
+      setSelected(undefined);
+      setInspectedCoordinate(undefined);
+      setSelectedActions([]);
+      setInspectedActions([]);
+    } catch (err) {
+      if (loadRequestId.current === requestId) {
+        setError(err instanceof Error ? err.message : "Unable to submit action");
+      }
+    } finally {
+      if (loadRequestId.current === requestId) {
+        setIsLoading(false);
+      }
+    }
+  }
+
   function toggle(key: keyof Toggles) {
     setToggles((current) => ({ ...current, [key]: !current[key] }));
   }
 
   const displayCoordinate = inspectedCoordinate ?? selected;
   const tile = loaded ? selectedTile(loaded.gameState, displayCoordinate) : undefined;
-  const displayedActions = inspectedActions.length > 0 ? inspectedActions : selectedActions;
+  const displayedActions = actionsVisibleInInspector({
+    globalActions: loaded?.globalActions ?? [],
+    inspectedActions,
+    selectedActions
+  });
+  const activePlayer = loaded?.gameState.players[loaded.gameState.activePlayer];
+  const buyItems = inspectedActions.length > 0 ? [] : buyMenuItems(selectedActions, activePlayer);
+  const buyActionSet = new Set(buyItems.map((item) => item.action));
+  const commandActions = displayedActions.filter((action) => !buyActionSet.has(action));
+  const canSubmitDisplayedActions = loaded?.source === "server" && loaded.gameState["game-over"] === false;
   const mapRows = loaded?.gameState.map.length ?? 0;
   const mapCols = loaded?.gameState.map[0]?.length ?? 0;
 
@@ -411,14 +492,44 @@ export default function App() {
 
           <div className="inspector-block">
             <h2>Actions</h2>
-            {displayedActions.length > 0 ? (
+            {buyItems.length > 0 || commandActions.length > 0 ? (
               <div className="action-list">
-                {displayedActions.map((action, index) => (
-                  <pre key={`${coordinateKey(action.source ?? [0, 0])}-${action.type}-${index}`}>{JSON.stringify(action)}</pre>
+                {buyItems.length > 0 && activePlayer && (
+                  <div className="buy-menu" aria-label="Deployment menu">
+                    {buyItems.map((item) => {
+                      const assetPath = unitAssetPath(activePlayer.armyType, item.unit, false);
+                      return (
+                        <button
+                          type="button"
+                          className="buy-menu-row"
+                          key={`${coordinateKey(item.action.source ?? [0, 0])}-${item.unit}`}
+                          onClick={() => submitServerAction(item.action)}
+                          disabled={!canSubmitDisplayedActions || isLoading}
+                          aria-label={`Buy ${item.label} for ${formatMoney(item.cost)}`}
+                        >
+                          <span className="buy-unit-icon" aria-hidden="true">
+                            {assetPath ? <img src={assetPath} alt="" /> : unitFallbackLabel(item.unit)}
+                          </span>
+                          <span className="buy-unit-name">{item.label}</span>
+                          <span className="buy-unit-cost">{formatMoney(item.cost)}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+                {commandActions.map((action, index) => (
+                  <div className={canSubmitDisplayedActions ? "action-row" : "action-row action-row-readonly"} key={`${coordinateKey(action.source ?? [0, 0])}-${action.type}-${index}`}>
+                    {canSubmitDisplayedActions && (
+                      <button type="button" onClick={() => submitServerAction(action)} disabled={isLoading}>
+                        {labelForAction(action)}
+                      </button>
+                    )}
+                    <pre>{JSON.stringify(action)}</pre>
+                  </div>
                 ))}
               </div>
             ) : (
-              <p className="muted">No server or sample actions for this tile.</p>
+              <p className="muted">No actions available.</p>
             )}
           </div>
 

--- a/frontend/src/components/BoardCanvas.tsx
+++ b/frontend/src/components/BoardCanvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { ActionHighlights } from "../rendering/actions";
+import { movementTrailAfterHover, type ActionHighlights } from "../rendering/actions";
 import { boardTileSize, type BoardImages, renderBoard } from "../rendering/renderBoard";
 import { unitAssetPath } from "../rendering/unitAssets";
 import type { Coordinate, GameState } from "../gameState/schema";
@@ -52,6 +52,7 @@ export function BoardCanvas({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [images, setImages] = useState<BoardImages>({ units: new Map() });
   const [hover, setHover] = useState<Coordinate | undefined>();
+  const [movementTrail, setMovementTrail] = useState<Coordinate[] | undefined>();
   const assetPaths = useMemo(() => unitAssetPaths(gameState), [gameState]);
   const cols = gameState.map[0]?.length ?? 0;
   const rows = gameState.map.length;
@@ -89,6 +90,10 @@ export function BoardCanvas({
   }, [assetPaths]);
 
   useEffect(() => {
+    setMovementTrail(selected ? [selected] : undefined);
+  }, [highlights, selected]);
+
+  useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) {
       return;
@@ -110,12 +115,13 @@ export function BoardCanvas({
       images,
       selected,
       hover,
+      movementTrail,
       highlights,
       showCoordinates,
       showGrid,
       showTerrainIds
     });
-  }, [cssHeight, cssWidth, gameState, highlights, hover, images, selected, showCoordinates, showGrid, showTerrainIds, zoom]);
+  }, [cssHeight, cssWidth, gameState, highlights, hover, images, movementTrail, selected, showCoordinates, showGrid, showTerrainIds, zoom]);
 
   function eventToCoordinate(event: React.MouseEvent<HTMLCanvasElement>): Coordinate | undefined {
     const rect = event.currentTarget.getBoundingClientRect();
@@ -132,10 +138,16 @@ export function BoardCanvas({
       ref={canvasRef}
       className="board-canvas"
       onPointerLeave={() => setHover(undefined)}
-      onPointerMove={(event) => setHover(eventToCoordinate(event))}
+      onPointerMove={(event) => {
+        const coordinate = eventToCoordinate(event);
+        setHover(coordinate);
+        setMovementTrail((current) => movementTrailAfterHover(current, selected, coordinate, highlights));
+      }}
       onClick={(event) => {
         const coordinate = eventToCoordinate(event);
         if (coordinate) {
+          setHover(coordinate);
+          setMovementTrail((current) => movementTrailAfterHover(current, selected, coordinate, highlights));
           onSelectTile(coordinate);
         }
       }}

--- a/frontend/src/gameState/actionDisplay.test.ts
+++ b/frontend/src/gameState/actionDisplay.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { Action, Player } from "./schema";
+import { actionToSubmitFromBoardTarget, actionsVisibleInInspector, buyMenuItems, globalActionsFromLegalActions, labelForAction } from "./actionDisplay";
+
+const activePlayer: Player = {
+  armyType: "orange-star",
+  co: "Andy",
+  funds: 50_000,
+  "power-meter": {
+    charge: 0,
+    "cop-stars": 3,
+    "scop-stars": 3,
+    "star-value": 9000
+  },
+  "power-status": 0,
+  "luck-policy": 1
+};
+
+describe("globalActionsFromLegalActions", () => {
+  it("keeps source-less actions available apart from tile actions", () => {
+    const endTurn: Action = { type: "end-turn" };
+    const tileAction: Action = { type: "move-wait", source: [1, 1], target: [1, 1] };
+
+    expect(globalActionsFromLegalActions([tileAction, endTurn])).toEqual([endTurn]);
+  });
+});
+
+describe("actionsVisibleInInspector", () => {
+  it("shows global actions when the selected tile has none", () => {
+    const endTurn: Action = { type: "end-turn" };
+
+    expect(
+      actionsVisibleInInspector({
+        globalActions: [endTurn],
+        inspectedActions: [],
+        selectedActions: []
+      })
+    ).toEqual([endTurn]);
+  });
+
+  it("uses inspected target actions while hovering a highlighted target", () => {
+    const endTurn: Action = { type: "end-turn" };
+    const attack: Action = { type: "attack", source: [1, 1], target: [2, 1] };
+
+    expect(
+      actionsVisibleInInspector({
+        globalActions: [endTurn],
+        inspectedActions: [attack],
+        selectedActions: []
+      })
+    ).toEqual([attack]);
+  });
+});
+
+describe("actionToSubmitFromBoardTarget", () => {
+  it("confirms a single movement action from a board target click", () => {
+    const move: Action = { type: "move-wait", source: [1, 1], target: [2, 1] };
+
+    expect(actionToSubmitFromBoardTarget([move])).toBe(move);
+  });
+
+  it("leaves attack target clicks for the inspector", () => {
+    const attack: Action = { type: "attack", source: [1, 1], target: [3, 1] };
+
+    expect(actionToSubmitFromBoardTarget([attack])).toBeUndefined();
+  });
+
+  it("does not choose from ambiguous target actions", () => {
+    expect(
+      actionToSubmitFromBoardTarget([
+        { type: "move-wait", source: [1, 1], target: [2, 1] },
+        { type: "move-load", source: [1, 1], target: [2, 1] }
+      ])
+    ).toBeUndefined();
+  });
+});
+
+describe("labelForAction", () => {
+  it("uses a readable command label for ending the turn", () => {
+    expect(labelForAction({ type: "end-turn" })).toBe("End turn");
+  });
+});
+
+describe("buyMenuItems", () => {
+  it("turns buy actions into sorted deployment menu rows", () => {
+    const tank: Action = { type: "buy", source: [1, 1], unit: "tank" };
+    const infantry: Action = { type: "buy", source: [1, 1], unit: "infantry" };
+    const mediumTank: Action = { type: "buy", source: [1, 1], unit: "medium-tank" };
+
+    expect(buyMenuItems([tank, mediumTank, infantry], activePlayer)).toEqual([
+      { action: infantry, unit: "infantry", label: "Infantry", cost: 1000 },
+      { action: tank, unit: "tank", label: "Tank", cost: 7000 },
+      { action: mediumTank, unit: "medium-tank", label: "Md.Tank", cost: 16000 }
+    ]);
+  });
+
+  it("uses active CO build costs", () => {
+    const hachi: Player = {
+      ...activePlayer,
+      co: "Hachi",
+      "power-status": 2
+    };
+
+    expect(buyMenuItems([{ type: "buy", source: [1, 1], unit: "mech" }], hachi)[0].cost).toBe(1500);
+  });
+});

--- a/frontend/src/gameState/actionDisplay.ts
+++ b/frontend/src/gameState/actionDisplay.ts
@@ -1,0 +1,214 @@
+import type { Action, Player } from "./schema";
+
+type InspectorActionSets = {
+  globalActions: Action[];
+  inspectedActions: Action[];
+  selectedActions: Action[];
+};
+
+export type BuyMenuItem = {
+  action: Action;
+  unit: string;
+  label: string;
+  cost: number;
+};
+
+const unitBaseCosts: Record<string, number> = {
+  "anti-air": 8000,
+  apc: 5000,
+  artillery: 6000,
+  battleship: 28000,
+  bcopter: 9000,
+  blackboat: 7500,
+  blackbomb: 25000,
+  bomber: 22000,
+  carrier: 30000,
+  crusier: 18000,
+  fighter: 20000,
+  infantry: 1000,
+  lander: 12000,
+  "medium-tank": 16000,
+  mech: 3000,
+  megatank: 28000,
+  missile: 12000,
+  neotank: 22000,
+  piperunner: 20000,
+  recon: 4000,
+  rocket: 15000,
+  stealth: 24000,
+  sub: 20000,
+  tank: 7000,
+  tcopter: 5000
+};
+
+const unitLabels: Record<string, string> = {
+  "anti-air": "Anti-Air",
+  apc: "APC",
+  artillery: "Artillery",
+  battleship: "Battleship",
+  bcopter: "B-Copter",
+  blackboat: "Black Boat",
+  blackbomb: "Black Bomb",
+  bomber: "Bomber",
+  carrier: "Carrier",
+  crusier: "Cruiser",
+  fighter: "Fighter",
+  infantry: "Infantry",
+  lander: "Lander",
+  "medium-tank": "Md.Tank",
+  mech: "Mech",
+  megatank: "Mega Tank",
+  missile: "Missile",
+  neotank: "Neotank",
+  piperunner: "Piperunner",
+  recon: "Recon",
+  rocket: "Rocket",
+  stealth: "Stealth",
+  sub: "Sub",
+  tank: "Tank",
+  tcopter: "T-Copter"
+};
+
+const unitDisplayOrder = [
+  "infantry",
+  "mech",
+  "recon",
+  "apc",
+  "artillery",
+  "tank",
+  "anti-air",
+  "missile",
+  "rocket",
+  "medium-tank",
+  "piperunner",
+  "neotank",
+  "megatank",
+  "tcopter",
+  "bcopter",
+  "fighter",
+  "bomber",
+  "stealth",
+  "blackbomb",
+  "lander",
+  "blackboat",
+  "crusier",
+  "sub",
+  "battleship",
+  "carrier"
+];
+
+const unitOrderIndex = new Map(unitDisplayOrder.map((unit, index) => [unit, index]));
+
+const boardClickConfirmActionTypes = new Set([
+  "move-wait",
+  "move-capture",
+  "move-load",
+  "move-combine"
+]);
+
+function labelFromType(type: string): string {
+  return type
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function normalizedCoName(player: Player): string {
+  return player.co.toLowerCase().replace(/[^a-z]/g, "");
+}
+
+function buildCostForPlayer(unit: string, player: Player): number | undefined {
+  const baseCost = unitBaseCosts[unit];
+  if (baseCost === undefined) {
+    return undefined;
+  }
+
+  const co = normalizedCoName(player);
+  if (co === "colin") {
+    return Math.trunc((baseCost * 80) / 100);
+  }
+
+  if (co === "hachi") {
+    return Math.trunc((baseCost * (player["power-status"] === 0 ? 90 : 50)) / 100);
+  }
+
+  if (co === "kanbei") {
+    return Math.trunc((baseCost * 120) / 100);
+  }
+
+  return baseCost;
+}
+
+export function globalActionsFromLegalActions(actions: Action[]): Action[] {
+  return actions.filter((action) => action.source === undefined);
+}
+
+export function actionsVisibleInInspector({
+  globalActions,
+  inspectedActions,
+  selectedActions
+}: InspectorActionSets): Action[] {
+  if (inspectedActions.length > 0) {
+    return inspectedActions;
+  }
+
+  return [...globalActions, ...selectedActions];
+}
+
+export function actionToSubmitFromBoardTarget(actions: Action[]): Action | undefined {
+  if (actions.length !== 1) {
+    return undefined;
+  }
+
+  const [action] = actions;
+  return boardClickConfirmActionTypes.has(action.type) ? action : undefined;
+}
+
+export function labelForAction(action: Action): string {
+  if (action.type === "end-turn") {
+    return "End turn";
+  }
+
+  if (action.type === "co-power") {
+    return "CO power";
+  }
+
+  if (action.type === "super-co-power") {
+    return "Super CO power";
+  }
+
+  return labelFromType(action.type);
+}
+
+export function buyMenuItems(actions: Action[], player: Player | undefined): BuyMenuItem[] {
+  if (!player) {
+    return [];
+  }
+
+  return actions
+    .filter((action) => action.type === "buy" && action.unit !== undefined)
+    .map((action) => {
+      const unit = action.unit ?? "";
+      const cost = buildCostForPlayer(unit, player);
+      if (cost === undefined) {
+        return undefined;
+      }
+
+      return {
+        action,
+        unit,
+        label: unitLabels[unit] ?? labelFromType(unit),
+        cost
+      };
+    })
+    .filter((item): item is BuyMenuItem => item !== undefined)
+    .sort((a, b) => {
+      const orderA = unitOrderIndex.get(a.unit) ?? Number.MAX_SAFE_INTEGER;
+      const orderB = unitOrderIndex.get(b.unit) ?? Number.MAX_SAFE_INTEGER;
+      if (orderA !== orderB) {
+        return orderA - orderB;
+      }
+
+      return a.label.localeCompare(b.label);
+    });
+}

--- a/frontend/src/rendering/actions.test.ts
+++ b/frontend/src/rendering/actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { actionHighlightsForSource } from "./actions";
+import { actionHighlightsForSource, actionPreviewForTile, movementTrailAfterHover, orthogonalPath } from "./actions";
 import { unitAssetName, unitAssetPath } from "./unitAssets";
+import type { Coordinate } from "../gameState/schema";
 
 describe("unitAssetName", () => {
   it("normalizes server unit names to reference asset filenames", () => {
@@ -15,6 +16,182 @@ describe("unitAssetName", () => {
     expect(unitAssetName("../tank")).toBeUndefined();
     expect(unitAssetPath("../orange-star", "tank", false)).toBeUndefined();
     expect(unitAssetPath("orange-star", "../tank", false)).toBeUndefined();
+  });
+});
+
+describe("orthogonalPath", () => {
+  it("builds a board-space movement route with one bend", () => {
+    expect(orthogonalPath([1, 4], [4, 2])).toEqual([
+      [1, 4],
+      [1, 2],
+      [4, 2]
+    ]);
+  });
+
+  it("omits duplicate bend points for straight movement", () => {
+    expect(orthogonalPath([1, 4], [1, 2])).toEqual([
+      [1, 4],
+      [1, 2]
+    ]);
+  });
+});
+
+describe("actionPreviewForTile", () => {
+  it("uses the cursor movement trail for move targets", () => {
+    const trail: Coordinate[] = [
+      [1, 4],
+      [2, 4],
+      [3, 4],
+      [3, 3],
+      [4, 3],
+      [4, 2]
+    ];
+
+    expect(
+      actionPreviewForTile(
+        [{ type: "move-wait", source: [1, 4], target: [4, 2] }],
+        [1, 4],
+        [4, 2],
+        [...trail]
+      )
+    ).toEqual({
+      kind: "move",
+      path: [...trail]
+    });
+  });
+
+  it("prefers a movement route for move targets", () => {
+    expect(
+      actionPreviewForTile(
+        [{ type: "move-wait", source: [1, 4], target: [4, 2] }],
+        [1, 4],
+        [4, 2]
+      )
+    ).toEqual({
+      kind: "move",
+      path: [
+        [1, 4],
+        [1, 2],
+        [4, 2]
+      ]
+    });
+  });
+
+  it("creates an attack preview for direct attacks", () => {
+    expect(
+      actionPreviewForTile(
+        [{ type: "attack", source: [3, 2], target: [4, 2] }],
+        [3, 2],
+        [4, 2]
+      )
+    ).toEqual({
+      kind: "attack",
+      attacker: [3, 2],
+      attackerUnit: [3, 2],
+      defender: [4, 2],
+      route: undefined
+    });
+  });
+
+  it("creates a moved attack preview from the move destination", () => {
+    expect(
+      actionPreviewForTile(
+        [{ type: "move-attack", source: [1, 4], target: [3, 2], direction: "east" }],
+        [1, 4],
+        [4, 2]
+      )
+    ).toEqual({
+      kind: "attack",
+      attacker: [3, 2],
+      attackerUnit: [1, 4],
+      defender: [4, 2],
+      route: [
+        [1, 4],
+        [1, 2],
+        [3, 2]
+      ]
+    });
+  });
+
+  it("uses the cursor movement trail for moved attacks", () => {
+    const trail: Coordinate[] = [
+      [1, 4],
+      [2, 4],
+      [3, 4],
+      [3, 3],
+      [3, 2]
+    ];
+
+    expect(
+      actionPreviewForTile(
+        [{ type: "move-attack", source: [1, 4], target: [3, 2], direction: "east" }],
+        [1, 4],
+        [4, 2],
+        [...trail]
+      )
+    ).toEqual({
+      kind: "attack",
+      attacker: [3, 2],
+      attackerUnit: [1, 4],
+      defender: [4, 2],
+      route: [...trail]
+    });
+  });
+});
+
+describe("movementTrailAfterHover", () => {
+  const source: Coordinate = [0, 0];
+  const highlights = actionHighlightsForSource(
+    [
+      { type: "move-wait", source: [0, 0], target: [1, 0] },
+      { type: "move-wait", source: [0, 0], target: [2, 0] },
+      { type: "move-wait", source: [0, 0], target: [2, 1] },
+      { type: "move-wait", source: [0, 0], target: [2, 2] },
+      { type: "attack", source: [0, 0], target: [3, 0] }
+    ],
+    [0, 0]
+  );
+
+  it("extends through adjacent valid movement hovers", () => {
+    let trail = movementTrailAfterHover(undefined, [...source], [1, 0], highlights);
+    trail = movementTrailAfterHover(trail, [...source], [2, 0], highlights);
+    trail = movementTrailAfterHover(trail, [...source], [2, 1], highlights);
+
+    expect(trail).toEqual([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [2, 1]
+    ]);
+  });
+
+  it("truncates when hovering an earlier point in the trail", () => {
+    expect(
+      movementTrailAfterHover(
+        [
+          [0, 0],
+          [1, 0],
+          [2, 0],
+          [2, 1]
+        ],
+        [...source],
+        [1, 0],
+        highlights
+      )
+    ).toEqual([
+      [0, 0],
+      [1, 0]
+    ]);
+  });
+
+  it("keeps the route while hovering non-move targets", () => {
+    const trail: Coordinate[] = [
+      [0, 0],
+      [1, 0],
+      [2, 0]
+    ];
+
+    expect(movementTrailAfterHover(trail, [...source], [3, 0], highlights)).toBe(trail);
   });
 });
 

--- a/frontend/src/rendering/actions.ts
+++ b/frontend/src/rendering/actions.ts
@@ -13,6 +13,19 @@ export type ActionHighlights = {
   actionsByTile: Map<string, Action[]>;
 };
 
+export type ActionPreview =
+  | {
+      kind: "move";
+      path: Coordinate[];
+    }
+  | {
+      kind: "attack";
+      attacker: Coordinate;
+      attackerUnit: Coordinate;
+      defender: Coordinate;
+      route?: Coordinate[];
+    };
+
 const moveActionTypes = new Set([
   "move-wait",
   "move-capture",
@@ -20,6 +33,20 @@ const moveActionTypes = new Set([
   "move-combine",
   "move-attack"
 ]);
+
+const movementPreviewTypes = new Set([
+  "move-wait",
+  "move-capture",
+  "move-load",
+  "move-combine"
+]);
+
+const movementDirections: Coordinate[] = [
+  [0, -1],
+  [1, 0],
+  [0, 1],
+  [-1, 0]
+];
 
 function directionalTarget(origin: Coordinate, direction: Action["direction"]): Coordinate | undefined {
   if (direction === "north") {
@@ -35,6 +62,118 @@ function directionalTarget(origin: Coordinate, direction: Action["direction"]): 
     return [origin[0] - 1, origin[1]];
   }
   return undefined;
+}
+
+export function orthogonalPath(source: Coordinate, target: Coordinate): Coordinate[] {
+  if (sameCoordinate(source, target)) {
+    return [source];
+  }
+
+  const path: Coordinate[] = [source];
+  const bend: Coordinate = [source[0], target[1]];
+  if (!sameCoordinate(source, bend) && !sameCoordinate(bend, target)) {
+    path.push(bend);
+  }
+  path.push(target);
+  return path;
+}
+
+function isAdjacent(a: Coordinate, b: Coordinate): boolean {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]) === 1;
+}
+
+function routeForTarget(
+  source: Coordinate,
+  target: Coordinate,
+  movementTrail?: Coordinate[]
+): Coordinate[] {
+  if (movementTrail?.length && sameCoordinate(movementTrail[0], source)) {
+    const targetIndex = movementTrail.findIndex((coordinate) => sameCoordinate(coordinate, target));
+    if (targetIndex >= 0) {
+      return movementTrail.slice(0, targetIndex + 1);
+    }
+  }
+
+  return orthogonalPath(source, target);
+}
+
+function moveTargetKeys(highlights: ActionHighlights, source: Coordinate): Set<string> {
+  return new Set([
+    coordinateKey(source),
+    ...highlights.moves.map((move) => move.key)
+  ]);
+}
+
+function shortestPathWithin(validKeys: Set<string>, source: Coordinate, target: Coordinate): Coordinate[] | undefined {
+  const sourceKey = coordinateKey(source);
+  const targetKey = coordinateKey(target);
+  const queue: Coordinate[] = [source];
+  const previous = new Map<string, string | undefined>([[sourceKey, undefined]]);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      break;
+    }
+
+    if (sameCoordinate(current, target)) {
+      const path: Coordinate[] = [];
+      let key: string | undefined = targetKey;
+      while (key) {
+        const [x, y] = key.split(",").map(Number);
+        path.push([x, y]);
+        key = previous.get(key);
+      }
+      return path.reverse();
+    }
+
+    for (const [dx, dy] of movementDirections) {
+      const neighbor: Coordinate = [current[0] + dx, current[1] + dy];
+      const neighborKey = coordinateKey(neighbor);
+      if (!validKeys.has(neighborKey) || previous.has(neighborKey)) {
+        continue;
+      }
+
+      previous.set(neighborKey, coordinateKey(current));
+      queue.push(neighbor);
+    }
+  }
+
+  return undefined;
+}
+
+export function movementTrailAfterHover(
+  currentTrail: Coordinate[] | undefined,
+  source: Coordinate | undefined,
+  hover: Coordinate | undefined,
+  highlights: ActionHighlights | undefined
+): Coordinate[] | undefined {
+  if (!source || !highlights) {
+    return undefined;
+  }
+
+  const validKeys = moveTargetKeys(highlights, source);
+  const trail = currentTrail?.length && sameCoordinate(currentTrail[0], source) ? currentTrail : [source];
+  if (!hover || !validKeys.has(coordinateKey(hover))) {
+    return trail;
+  }
+
+  const existingIndex = trail.findIndex((coordinate) => sameCoordinate(coordinate, hover));
+  if (existingIndex >= 0) {
+    return trail.slice(0, existingIndex + 1);
+  }
+
+  const last = trail[trail.length - 1];
+  if (isAdjacent(last, hover)) {
+    return [...trail, hover];
+  }
+
+  const trailingPath = shortestPathWithin(validKeys, last, hover);
+  if (trailingPath && trailingPath.length > 1) {
+    return [...trail, ...trailingPath.slice(1)];
+  }
+
+  return shortestPathWithin(validKeys, source, hover) ?? trail;
 }
 
 function pushHighlight(
@@ -75,4 +214,67 @@ export function actionHighlightsForSource(actions: Action[], source: Coordinate)
   }
 
   return { moves, attacks, actionsByTile };
+}
+
+export function actionPreviewForTile(
+  actions: Action[],
+  source: Coordinate,
+  tile: Coordinate,
+  movementTrail?: Coordinate[]
+): ActionPreview | undefined {
+  const attack = actions.find((action) => {
+    if (!sameCoordinate(action.source, source)) {
+      return false;
+    }
+
+    if (action.type === "attack") {
+      return sameCoordinate(action.target, tile);
+    }
+
+    if (action.type === "move-attack" && action.target && action.direction) {
+      const defender = directionalTarget(action.target, action.direction);
+      return sameCoordinate(defender, tile);
+    }
+
+    return false;
+  });
+
+  if (attack?.type === "attack" && attack.target) {
+    return {
+      kind: "attack",
+      attacker: source,
+      attackerUnit: source,
+      defender: attack.target,
+      route: undefined
+    };
+  }
+
+  if (attack?.type === "move-attack" && attack.target && attack.direction) {
+    const defender = directionalTarget(attack.target, attack.direction);
+    if (defender) {
+      return {
+        kind: "attack",
+        attacker: attack.target,
+        attackerUnit: source,
+        defender,
+        route: routeForTarget(source, attack.target, movementTrail)
+      };
+    }
+  }
+
+  const move = actions.find((action) =>
+    sameCoordinate(action.source, source) &&
+    action.target !== undefined &&
+    sameCoordinate(action.target, tile) &&
+    movementPreviewTypes.has(action.type)
+  );
+
+  if (move?.target) {
+    return {
+      kind: "move",
+      path: routeForTarget(source, move.target, movementTrail)
+    };
+  }
+
+  return undefined;
 }

--- a/frontend/src/rendering/renderBoard.test.ts
+++ b/frontend/src/rendering/renderBoard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { boardTileSize, routeStrokeForPath } from "./renderBoard";
+
+describe("routeStrokeForPath", () => {
+  it("backs the line endpoint away from the arrow tip", () => {
+    const center = boardTileSize / 2;
+
+    expect(routeStrokeForPath([[0, 0], [2, 0]], true)).toEqual({
+      linePoints: [
+        { x: center, y: center },
+        { x: center + boardTileSize * 2 - 6, y: center }
+      ],
+      arrowFrom: { x: center, y: center },
+      arrowTo: { x: center + boardTileSize * 2, y: center }
+    });
+  });
+});

--- a/frontend/src/rendering/renderBoard.ts
+++ b/frontend/src/rendering/renderBoard.ts
@@ -1,8 +1,8 @@
-import type { ActionHighlights } from "./actions";
+import { actionPreviewForTile, type ActionHighlights, type ActionPreview } from "./actions";
 import { spriteLocations } from "./spriteLocations";
 import { terrainSpriteName } from "./terrain";
 import { unitAssetPath, unitFallbackLabel } from "./unitAssets";
-import type { Coordinate, GameState, MapTile } from "../gameState/schema";
+import { coordinateKey, type Coordinate, type GameState, type MapTile, type Unit } from "../gameState/schema";
 
 const tileSize = 16;
 const plainSprite = spriteLocations.clear.plain;
@@ -17,6 +17,7 @@ export type RenderBoardOptions = {
   images: BoardImages;
   selected?: Coordinate;
   hover?: Coordinate;
+  movementTrail?: Coordinate[];
   highlights?: ActionHighlights;
   showCoordinates: boolean;
   showGrid: boolean;
@@ -29,6 +30,19 @@ type SpriteInfo = {
   w: number;
   h: number;
 };
+
+type CanvasPoint = {
+  x: number;
+  y: number;
+};
+
+type RouteStroke = {
+  linePoints: CanvasPoint[];
+  arrowFrom?: CanvasPoint;
+  arrowTo?: CanvasPoint;
+};
+
+const routeArrowInset = 6;
 
 function drawTextBadge(
   ctx: CanvasRenderingContext2D,
@@ -49,6 +63,106 @@ function drawTextBadge(
   ctx.fillRect(left, y, width, 9);
   ctx.fillStyle = color;
   ctx.fillText(text, x + (align === "right" ? -2 : 2), y + 1);
+  ctx.restore();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function tileCenter(coordinate: Coordinate): CanvasPoint {
+  return {
+    x: coordinate[0] * tileSize + tileSize / 2,
+    y: coordinate[1] * tileSize + tileSize / 2
+  };
+}
+
+function drawArrowHead(ctx: CanvasRenderingContext2D, from: CanvasPoint, to: CanvasPoint, color: string, size = 6) {
+  const angle = Math.atan2(to.y - from.y, to.x - from.x);
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(to.x, to.y);
+  ctx.lineTo(to.x - Math.cos(angle - Math.PI / 6) * size, to.y - Math.sin(angle - Math.PI / 6) * size);
+  ctx.lineTo(to.x - Math.cos(angle + Math.PI / 6) * size, to.y - Math.sin(angle + Math.PI / 6) * size);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawOutlinedArrowHead(ctx: CanvasRenderingContext2D, from: CanvasPoint, to: CanvasPoint) {
+  drawArrowHead(ctx, from, to, "#ffd74a", 8);
+  drawArrowHead(ctx, from, to, "#ed271d", 6);
+}
+
+function strokeRoutePath(ctx: CanvasRenderingContext2D, points: CanvasPoint[]) {
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
+}
+
+export function routeStrokeForPath(path: Coordinate[], withArrow = true): RouteStroke | undefined {
+  if (path.length < 2) {
+    return undefined;
+  }
+
+  const points = path.map(tileCenter);
+  if (!withArrow) {
+    return { linePoints: points };
+  }
+
+  const arrowFrom = points[points.length - 2];
+  const arrowTo = points[points.length - 1];
+  const dx = arrowTo.x - arrowFrom.x;
+  const dy = arrowTo.y - arrowFrom.y;
+  const length = Math.hypot(dx, dy);
+  if (length <= 0) {
+    return { linePoints: points, arrowFrom, arrowTo };
+  }
+
+  const inset = Math.min(routeArrowInset, Math.max(0, length - 1));
+  const linePoints = [...points];
+  linePoints[linePoints.length - 1] = {
+    x: arrowTo.x - (dx / length) * inset,
+    y: arrowTo.y - (dy / length) * inset
+  };
+
+  return { linePoints, arrowFrom, arrowTo };
+}
+
+function drawRoute(ctx: CanvasRenderingContext2D, path: Coordinate[], withArrow = true) {
+  const routeStroke = routeStrokeForPath(path, withArrow);
+  if (!routeStroke) {
+    return;
+  }
+
+  ctx.save();
+  ctx.lineJoin = "miter";
+  ctx.lineCap = "butt";
+
+  ctx.translate(1, 1);
+  ctx.strokeStyle = "rgba(97, 21, 17, 0.58)";
+  ctx.lineWidth = 8;
+  strokeRoutePath(ctx, routeStroke.linePoints);
+  ctx.translate(-1, -1);
+
+  ctx.strokeStyle = "#ffd63a";
+  ctx.lineWidth = 7;
+  strokeRoutePath(ctx, routeStroke.linePoints);
+
+  ctx.strokeStyle = "#ed271d";
+  ctx.lineWidth = 5;
+  strokeRoutePath(ctx, routeStroke.linePoints);
+
+  if (routeStroke.arrowFrom && routeStroke.arrowTo) {
+    drawOutlinedArrowHead(ctx, routeStroke.arrowFrom, routeStroke.arrowTo);
+  }
   ctx.restore();
 }
 
@@ -219,6 +333,35 @@ function drawTerrain(ctx: CanvasRenderingContext2D, state: GameState, images: Bo
   }
 }
 
+function unitAt(state: GameState, coordinate: Coordinate): Unit | undefined {
+  return state.map[coordinate[1]]?.[coordinate[0]]?.unit;
+}
+
+function drawUnitIcon(
+  ctx: CanvasRenderingContext2D,
+  images: BoardImages,
+  unit: Unit | undefined,
+  x: number,
+  y: number
+) {
+  if (!unit) {
+    ctx.fillStyle = "#d8e0e8";
+    ctx.fillRect(x, y, tileSize, tileSize);
+    return;
+  }
+
+  const assetPath = unitAssetPath(unit.owner, unit.type, false);
+  const image = assetPath ? images.units.get(assetPath) : undefined;
+  if (image) {
+    ctx.drawImage(image, x, y, tileSize, tileSize);
+    return;
+  }
+
+  ctx.fillStyle = unit.owner === "blue-moon" ? "#2b67d1" : "#d86f1f";
+  ctx.fillRect(x + 1, y + 1, tileSize - 2, tileSize - 2);
+  drawTextBadge(ctx, unitFallbackLabel(unit.type), x + 1, y + 4, "#fff");
+}
+
 function drawUnits(ctx: CanvasRenderingContext2D, state: GameState, images: BoardImages) {
   for (let row = 0; row < state.map.length; row += 1) {
     for (let col = 0; col < state.map[row].length; col += 1) {
@@ -296,6 +439,119 @@ function drawHighlights(ctx: CanvasRenderingContext2D, options: RenderBoardOptio
   ctx.restore();
 }
 
+function drawAttackArrow(ctx: CanvasRenderingContext2D, attacker: Coordinate, defender: Coordinate) {
+  const start = tileCenter(attacker);
+  const end = tileCenter(defender);
+  const angle = Math.atan2(end.y - start.y, end.x - start.x);
+  const from = {
+    x: start.x + Math.cos(angle) * 5,
+    y: start.y + Math.sin(angle) * 5
+  };
+  const to = {
+    x: end.x - Math.cos(angle) * 5,
+    y: end.y - Math.sin(angle) * 5
+  };
+
+  ctx.save();
+  ctx.strokeStyle = "#ffd63a";
+  ctx.lineWidth = 6;
+  ctx.beginPath();
+  ctx.moveTo(from.x, from.y);
+  ctx.lineTo(to.x, to.y);
+  ctx.stroke();
+
+  ctx.strokeStyle = "#ed271d";
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.moveTo(from.x, from.y);
+  ctx.lineTo(to.x, to.y);
+  ctx.stroke();
+  drawArrowHead(ctx, from, to, "#ed271d", 7);
+  ctx.restore();
+}
+
+function drawAttackCard(ctx: CanvasRenderingContext2D, state: GameState, images: BoardImages, preview: Extract<ActionPreview, { kind: "attack" }>) {
+  const attackerPoint = tileCenter(preview.attacker);
+  const defenderPoint = tileCenter(preview.defender);
+  const width = 78;
+  const height = 31;
+  const boardWidth = (state.map[0]?.length ?? 0) * tileSize;
+  const boardHeight = state.map.length * tileSize;
+  const centerX = (attackerPoint.x + defenderPoint.x) / 2;
+  let x = clamp(Math.round(centerX - width / 2), 2, Math.max(2, boardWidth - width - 2));
+  let y = Math.min(attackerPoint.y, defenderPoint.y) - height - 10;
+  if (y < 2) {
+    y = Math.max(attackerPoint.y, defenderPoint.y) + 10;
+  }
+  y = clamp(Math.round(y), 2, Math.max(2, boardHeight - height - 2));
+
+  const attackerUnit = unitAt(state, preview.attackerUnit);
+  const defenderUnit = unitAt(state, preview.defender);
+
+  ctx.save();
+  ctx.fillStyle = "rgba(16, 22, 30, 0.28)";
+  ctx.fillRect(x + 2, y + 2, width, height);
+  ctx.fillStyle = "rgba(255, 255, 248, 0.94)";
+  ctx.fillRect(x, y, width, height);
+  ctx.strokeStyle = "#f2362d";
+  ctx.lineWidth = 1.5;
+  ctx.strokeRect(x + 0.5, y + 0.5, width - 1, height - 1);
+
+  drawUnitIcon(ctx, images, attackerUnit, x + 4, y + 7);
+  drawUnitIcon(ctx, images, defenderUnit, x + width - 20, y + 7);
+
+  ctx.fillStyle = "#101832";
+  ctx.font = "8px 'Trebuchet MS', Arial, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("Attack", x + width / 2, y + 10);
+  ctx.fillText("Counter", x + width / 2, y + 22);
+
+  const arrowLeft = x + 24;
+  const arrowRight = x + width - 24;
+  drawArrowHead(ctx, { x: arrowLeft, y: y + 10 }, { x: arrowRight, y: y + 10 }, "#ed271d", 4);
+  drawArrowHead(ctx, { x: arrowRight, y: y + 22 }, { x: arrowLeft, y: y + 22 }, "#ed271d", 4);
+  ctx.strokeStyle = "#ed271d";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(arrowLeft, y + 10);
+  ctx.lineTo(arrowRight, y + 10);
+  ctx.moveTo(arrowRight, y + 22);
+  ctx.lineTo(arrowLeft, y + 22);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function actionPreviewFromOptions(options: RenderBoardOptions): ActionPreview | undefined {
+  if (!options.selected || !options.hover || !options.highlights) {
+    return undefined;
+  }
+
+  const actions = options.highlights.actionsByTile.get(coordinateKey(options.hover)) ?? [];
+  return actionPreviewForTile(actions, options.selected, options.hover, options.movementTrail);
+}
+
+function drawActionPreview(ctx: CanvasRenderingContext2D, state: GameState, options: RenderBoardOptions) {
+  const preview = actionPreviewFromOptions(options);
+  if (!preview) {
+    return;
+  }
+
+  ctx.save();
+  if (preview.kind === "move") {
+    drawRoute(ctx, preview.path);
+  } else {
+    if (preview.route && preview.route.length > 1) {
+      drawRoute(ctx, preview.route);
+    }
+    ctx.fillStyle = "rgba(238, 42, 32, 0.38)";
+    ctx.fillRect(preview.defender[0] * tileSize, preview.defender[1] * tileSize, tileSize, tileSize);
+    drawAttackArrow(ctx, preview.attacker, preview.defender);
+    drawAttackCard(ctx, state, options.images, preview);
+  }
+  ctx.restore();
+}
+
 function drawDebugOverlays(ctx: CanvasRenderingContext2D, state: GameState, options: RenderBoardOptions) {
   for (let row = 0; row < state.map.length; row += 1) {
     for (let col = 0; col < state.map[row].length; col += 1) {
@@ -346,6 +602,7 @@ export function renderBoard(ctx: CanvasRenderingContext2D, state: GameState, opt
   drawCaptureProgress(ctx, state);
   drawUnits(ctx, state, options.images);
   drawDebugOverlays(ctx, state, options);
+  drawActionPreview(ctx, state, options);
   drawCursor(ctx, options);
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -241,6 +241,95 @@ dd {
   overflow: auto;
 }
 
+.buy-menu {
+  display: grid;
+  width: min(220px, 100%);
+  border: 2px solid #ff5e58;
+  background: rgba(248, 246, 211, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.72);
+}
+
+.buy-menu-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) minmax(54px, max-content);
+  gap: 6px;
+  align-items: center;
+  min-height: 31px;
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+  border-bottom: 1px solid rgba(97, 105, 120, 0.25);
+  background: linear-gradient(90deg, rgba(255, 255, 245, 0.92), rgba(238, 242, 215, 0.72));
+  color: #101832;
+  padding: 3px 8px;
+  text-align: left;
+}
+
+.buy-menu-row:last-child {
+  border-bottom: 0;
+}
+
+.buy-menu-row:hover:not(:disabled) {
+  background: linear-gradient(90deg, #fffdf2, #dcefff);
+}
+
+.buy-menu-row:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.buy-unit-icon {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  color: #162033;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.buy-unit-icon img {
+  max-width: 24px;
+  max-height: 24px;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+.buy-unit-name,
+.buy-unit-cost {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.buy-unit-name {
+  font-size: 16px;
+}
+
+.buy-unit-cost {
+  font-size: 15px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.action-row {
+  display: grid;
+  grid-template-columns: minmax(78px, max-content) minmax(0, 1fr);
+  gap: 4px;
+  align-items: start;
+}
+
+.action-row-readonly {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.action-row button {
+  width: 100%;
+  white-space: normal;
+}
+
 pre {
   margin: 0;
   padding: 5px;


### PR DESCRIPTION
## Summary

This PR makes server-backed local games playable enough for the current development loop.

- Start newly-created games through first-turn initialization so the active player receives opening income.
- Keep source-less/global legal actions such as `end-turn` available in the UI even when no selected tile has local actions.
- Add server action submission from the board/action inspector, including buy actions and end turn.
- Add an AW-style deployment menu with unit sprites, ordering, labels, and CO-adjusted costs.
- Add movement/attack previews, including cursor-trail movement routes, moved-attack previews, and attack callouts.
- Allow a second click on an unambiguous valid movement target to submit the move.
- Tweak the movement arrow endpoint so the route stroke stops before the arrowhead.

## Notes

The current route preview is still a frontend approximation and can diverge from real movement/path cost in diagonal or wandering cursor cases. That follow-up is tracked in #143 rather than closed by this PR.

## Validation

- MSBuild Debug: `AdvanceWarsServer.sln`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/misc`
- `yarn test`
- `yarn typecheck`
- `yarn build`
- Browser smoke on `http://127.0.0.1:5173/` with no console errors