### PR TITLE
Audit CO power meter costs and charge math

### DIFF
--- a/AdvanceWarsServer/inc/Player.h
+++ b/AdvanceWarsServer/inc/Player.h
@@ -7,11 +7,11 @@ public:
 	PowerMeter(const CommandingOfficier::Type& type);
 	void AddCharge(int charge) noexcept;
 	bool FCopCharged() const noexcept {
-		return m_nCopStars > 0 && m_nCharge >= m_nCopStars * m_nStarValue;
+		return m_nCopStars > 0 && m_nCharge >= GetCopThreshold();
 	}
 
 	bool FScopCharged() const noexcept {
-		return m_nCharge >= GetTotalCharge();
+		return m_nCharge >= GetScopThreshold();
 	}
 
 	void UseCop() noexcept;
@@ -21,8 +21,16 @@ public:
 		return m_nCharge;
 	}
 
-	inline int GetTotalCharge() const noexcept {
+	inline int GetCopThreshold() const noexcept {
+		return m_nCopStars * m_nStarValue;
+	}
+
+	inline int GetScopThreshold() const noexcept {
 		return (m_nCopStars + m_nScopStars) * m_nStarValue;
+	}
+
+	inline int GetTotalCharge() const noexcept {
+		return GetScopThreshold();
 	}
 
 	static void to_json(json& j, const PowerMeter& powerMeter);

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1371,7 +1371,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		int defenderVisualHealthEnd = std::max((pdefender->health + 9) / 10, 0);
 		int defenderUnitCost = (defenderVisualHealthStart - defenderVisualHealthEnd) * Unit::GetUnitCost(pdefender->m_properties.m_type);
 		if (pattackingplayer->PowerStatus() == 0) {
-			pattackingplayer->m_powerMeter.AddCharge(0.5 * defenderUnitCost);
+			pattackingplayer->m_powerMeter.AddCharge(defenderUnitCost / 2);
 		}
 		AddSashaWarBondsFunds(*pattackingplayer, defenderUnitCost);
 
@@ -1409,7 +1409,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		int attackerVisualHealthEnd = std::max((pattacker->health + 9) / 10, 0);
 		int attackerUnitCost = (attackerVisualHealthStart - attackerVisualHealthEnd) * Unit::GetUnitCost(pattacker->m_properties.m_type);
 		if (pdefendingplayer->PowerStatus() == 0) {
-			pdefendingplayer->m_powerMeter.AddCharge(0.5 * attackerUnitCost);
+			pdefendingplayer->m_powerMeter.AddCharge(attackerUnitCost / 2);
 		}
 		AddSashaWarBondsFunds(*pdefendingplayer, attackerUnitCost);
 		if (pattackingplayer->PowerStatus() == 0) {

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -41,11 +41,13 @@ Result RunCommandingOfficierContract(json& jContract, std::string& expected, std
 	json actualPowerMeter;
 	PowerMeter::to_json(actualPowerMeter, powerMeter);
 	const json& expectedPowerMeter = jContract.at("power-meter");
-	if (actualPowerMeter["cop-stars"] != expectedPowerMeter.at("cop-stars") ||
-		actualPowerMeter["scop-stars"] != expectedPowerMeter.at("scop-stars")) {
-		expected = expectedPowerMeter.dump();
-		actual = actualPowerMeter.dump();
-		return Result::Failed;
+	for (const auto& expectedField : expectedPowerMeter.items()) {
+		const std::string& key = expectedField.key();
+		if (!actualPowerMeter.contains(key) || actualPowerMeter.at(key) != expectedField.value()) {
+			expected = expectedPowerMeter.dump();
+			actual = actualPowerMeter.dump();
+			return Result::Failed;
+		}
 	}
 
 	const DamageCharts& charts = rgCharts[static_cast<int>(co.m_type)];

--- a/AdvanceWarsServer/src/Player.cpp
+++ b/AdvanceWarsServer/src/Player.cpp
@@ -71,8 +71,8 @@ PowerMeter::PowerMeter(const CommandingOfficier::Type& type) {
 		m_nScopStars = 4;
 		break;
 	case CommandingOfficier::Type::Sturm:
-		m_nCopStars = 5;
-		m_nScopStars = 5;
+		m_nCopStars = 6;
+		m_nScopStars = 4;
 		break;
 	case CommandingOfficier::Type::VonBolt:
 		m_nCopStars = 0;
@@ -97,7 +97,7 @@ void PowerMeter::UseScop() noexcept {
 }
 
 void PowerMeter::UseCop() noexcept {
-	m_nCharge -= m_nCopStars * m_nStarValue;
+	m_nCharge -= GetCopThreshold();
 	IncreaseStarCost();
 }
 
@@ -162,6 +162,10 @@ void from_json(json& j, Player& player) {
 		{"scop-stars", powerMeter.m_nScopStars},
 		{"charge", powerMeter.m_nCharge},
 		{"star-value", powerMeter.m_nStarValue},
+		{"cop-threshold", powerMeter.GetCopThreshold()},
+		{"scop-threshold", powerMeter.GetScopThreshold()},
+		{"can-use-cop", powerMeter.FCopCharged()},
+		{"can-use-scop", powerMeter.FScopCharged()},
 	};
 }
 

--- a/AdvanceWarsServer/test/json/co/power-meter/attacker-damage-charges-both-meters.json
+++ b/AdvanceWarsServer/test/json/co/power-meter/attacker-damage-charges-both-meters.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "attacker-damage-charges-both-meters",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "attacker-damage-charges-both-meters",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 99,
+            "health": 96,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 25,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 350,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 700,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-meter/counterattack-damage-charges-both-meters.json
+++ b/AdvanceWarsServer/test/json/co/power-meter/counterattack-damage-charges-both-meters.json
@@ -1,0 +1,140 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "counterattack-damage-charges-both-meters",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "counterattack-damage-charges-both-meters",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 1,
+            "fuel": 99,
+            "health": 68,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 1,
+            "fuel": 99,
+            "health": 45,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "tank"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 3850,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 4550,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-meter/destroyed-cheap-unit-uses-lost-visual-hp.json
+++ b/AdvanceWarsServer/test/json/co/power-meter/destroyed-cheap-unit-uses-lost-visual-hp.json
@@ -1,0 +1,155 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "destroyed-cheap-unit-uses-lost-visual-hp",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 10,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "apc"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "destroyed-cheap-unit-uses-lost-visual-hp",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "tank"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "apc"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 50,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 100,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-meter/expensive-unit-cost-scales-charge.json
+++ b/AdvanceWarsServer/test/json/co/power-meter/expensive-unit-cost-scales-charge.json
@@ -1,0 +1,155 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "expensive-unit-cost-scales-charge",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 2,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "anti-air"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 9,
+            "fuel": 99,
+            "health": 40,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "bomber"
+          }
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "expensive-unit-cost-scales-charge",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 1,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "anti-air"
+          }
+        },
+        {
+          "terrain": 15
+        },
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 4400,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 8800,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-meter/serializes-thresholds-and-availability.json
+++ b/AdvanceWarsServer/test/json/co/power-meter/serializes-thresholds-and-availability.json
@@ -1,0 +1,16 @@
+{
+  "co-contract": {
+    "name": "Andy",
+    "power-meter": {
+      "cop-stars": 3,
+      "scop-stars": 3,
+      "charge": 0,
+      "star-value": 9000,
+      "cop-threshold": 27000,
+      "scop-threshold": 54000,
+      "can-use-cop": false,
+      "can-use-scop": false
+    },
+    "stats": []
+  }
+}

--- a/AdvanceWarsServer/test/json/co/power-meter/zero-damage-combat-adds-no-charge.json
+++ b/AdvanceWarsServer/test/json/co/power-meter/zero-damage-combat-adds-no-charge.json
@@ -1,0 +1,148 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "zero-damage-combat-adds-no-charge",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "apc"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "move-attack",
+      "source": [0, 0],
+      "direction": "east",
+      "target": [0, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "zero-damage-combat-adds-no-charge",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 1,
+            "hidden": false,
+            "moved": true,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 47,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "blue-moon",
+            "type": "apc"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sturm/contract.json
+++ b/AdvanceWarsServer/test/json/co/sturm/contract.json
@@ -2,8 +2,8 @@
   "co-contract": {
     "name": "Sturm",
     "power-meter": {
-      "cop-stars": 5,
-      "scop-stars": 5
+      "cop-stars": 6,
+      "scop-stars": 4
     },
     "stats": [
       {

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -1,6 +1,6 @@
 # Commanding Officer Support
 
-The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page](https://awbw.fandom.com/wiki/CO). The simulator currently supports a simplified CO model: JSON identity, power-meter costs, power-status transitions, and the checked-in normal/COP/SCOP damage charts are treated as source-of-truth behavior. The broader Standard rules matrix is maintained in `STANDARD_ENGINE_COMPLETENESS.md`.
+The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page](https://awbw.fandom.com/wiki/CO), cross-checked against the official AWBW CO chart when auditing meter data. The simulator currently supports a simplified CO model: JSON identity, power-meter costs, power-status transitions, and the checked-in normal/COP/SCOP damage charts are treated as source-of-truth behavior. The broader Standard rules matrix is maintained in `STANDARD_ENGINE_COMPLETENESS.md`.
 
 ## Supported
 
@@ -28,6 +28,14 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - For bad-luck COs, the lowest total outcome uses minimum good luck and maximum bad luck; the highest total outcome uses maximum good luck and minimum bad luck.
 - Sonja's AWBW combat luck is covered separately from her information and counterattack effects: she keeps +0..+9 good luck and 0..9 bad luck in day-to-day, Enhanced Vision, and Counter Break, while COP/SCOP still use the universal AWBW +10 attack/+10 defense chart bonus.
 - Sonja's hidden HP, fog vision, day-to-day counterattack multiplier, and Counter Break first-strike edge cases remain tracked by [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89) and [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90), rather than by the combat-luck fixtures.
+
+## Power Meter Notes
+
+- CO star costs are covered by contract fixtures for every CO. The audited values match the AWBW wiki/official chart, including Sturm at 6+4 stars and Von Bolt as SCOP-only at 0+10 stars.
+- Power meters start at a star value of 9000. COP threshold is `cop-stars * star-value`; SCOP/full threshold is `(cop-stars + scop-stars) * star-value`. After either power is used, the star value is multiplied by 1.2, truncated to an integer, and capped at 55720.
+- Combat charge uses displayed HP lost and the simulator's scaled unit cost, where `Unit::GetUnitCost` is one tenth of the normal build price. Damage dealt grants half of the lost displayed-HP value to the attacker, integer-truncated if needed; damage received grants the full lost displayed-HP value to the defender.
+- Zero displayed-HP loss adds no charge. Destruction charge is based on the displayed HP actually removed before the unit reaches zero. Combat does not add charge for a side whose CO power status is active, and direct HP effects from powers do not add meter charge.
+- Serialized player JSON exposes `"charge"`, `"star-value"`, `"cop-stars"`, `"scop-stars"`, `"cop-threshold"`, `"scop-threshold"`, `"can-use-cop"`, and `"can-use-scop"` so clients can display meter progress and identify legal power actions without duplicating the threshold formula.
 
 ## Weather Notes
 
@@ -76,7 +84,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#81](https://github.com/ryparikh/AdvanceWarsServer/issues/81): CO star costs and power-meter charge math audit.
 - [#83](https://github.com/ryparikh/AdvanceWarsServer/issues/83): Jess Turbo Charge COP resupply side effect.
 - [#85](https://github.com/ryparikh/AdvanceWarsServer/issues/85): Sturm all-terrain movement rules.
 - [#86](https://github.com/ryparikh/AdvanceWarsServer/issues/86): Lash terrain-star attack and movement effects.

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -1,6 +1,6 @@
 # Standard Engine Completeness Matrix
 
-Last reviewed: 2026-05-18
+Last reviewed: 2026-05-25
 
 This document tracks the simulator against the first playable target: normal Advance Wars By Web Global League Standard games that can be driven through a REST API or AI training loop. Local source code and JSON fixtures are the source of truth for current implementation behavior. The gameplay target is checked against the local report at `C:\Users\Roshan\Downloads\advance-wars-by-web-report.md` and the [Advance Wars By Web Wiki](https://awbw.fandom.com/wiki/Advance_Wars_By_Web_Wiki), especially [Metagame](https://awbw.fandom.com/wiki/Metagame), [AWBW Guide](https://awbw.fandom.com/wiki/AWBW_Guide), [Units](https://awbw.fandom.com/wiki/Units), [Properties](https://awbw.fandom.com/wiki/Properties), [Damage Formula](https://awbw.fandom.com/wiki/Damage_Formula), [CO](https://awbw.fandom.com/wiki/CO), and [Changes in AWBW](https://awbw.fandom.com/wiki/Changes_in_AWBW).
 
@@ -78,13 +78,13 @@ Explicitly deferred modes and options:
 | Area | Current implementation | Standard target | Status | Issue |
 | --- | --- | --- | --- | --- |
 | Movement and wait | Covered broadly by JSON fixtures. | AWBW movement/fuel/path legality. | Partial because submitted invalid actions need atomic rejection | #67 |
-| Combat actions | Direct, indirect, counterattack, ammo, HP, terrain, and many CO/power cases are covered. | AWBW combat formula and data. | Audit | #80, #81 |
+| Combat actions | Direct, indirect, counterattack, ammo, HP, terrain, and many CO/power cases are covered. | AWBW combat formula and data. | Audit | #80 |
 | Capture | Capture progress, interruption, HQ capture, Labs, Com Towers, Airports, Ports, Sami capture, and capture-limit counting have fixtures. | AWBW capture points and capture-limit counting. | Complete for current Standard coverage | none |
 | Buy | Production fixtures cover common buy legality, unit cap, and Piperunner production from Bases/Hachi Merchant Union cities. | Add setup bans, lab units, and ghosted blockers. | Partial | #75, #76, #78 |
 | Load and unload | APC, T-Copter, Lander, Black Boat, Cruiser, Carrier, loaded-unit destruction, and many boundaries are covered. | AWBW free unload behavior and legal terrain/occupancy. | Partial because submitted invalid actions need atomic rejection | #67 |
 | Combine/join | Joining/refund/capture-preservation fixtures exist. | AWBW join/refund behavior. | Complete for current Standard coverage | none |
 | Black Boat repair action | Dedicated repair/resupply fixtures exist. | AWBW Black Boat repair and resupply. | Complete for current Standard coverage | none |
-| CO power actions | Power gates, spending, many direct effects, and mass effects are covered. | Full CO behavior and meter math. | Partial | #81, #83, #84, #85, #86, #87, #88, #89, #99, #100, #101, #102, #103 |
+| CO power actions | Power gates, spending, meter math, many direct effects, and mass effects are covered. | Full CO behavior. | Partial | #83, #84, #85, #86, #87, #88, #89, #99, #100, #101, #102, #103 |
 | Black Bomb explode | Black Bomb movement/fuel/no-weapon fixtures exist; explosion action is absent. | Black Bomb explosion if predeployed/custom games need it; production banned in Standard. | Deferred from production, incomplete as unit behavior | #33, #75 |
 | Missile silo launch | Terrain exists, but launch behavior is incomplete. | Launch action, empty silo state, damage area, legal action generation. | Partial | #42 |
 | Resign/delete | Heuristic resign exists; explicit player actions do not. | Explicit resign and delete-unit actions if AWBW permits delete. | Partial | #77 |
@@ -131,8 +131,8 @@ Detailed implementation notes live in `CO_SUPPORT.md`.
 | Area | Current implementation | Status | Issue |
 | --- | --- | --- | --- |
 | CO parsing and contracts | All COs parse/serialize with contract fixtures. | Complete | none |
-| Power costs and meter state | Star costs and charge exist. | Audit | #81 |
-| Checked-in attack/defense charts | Normal/COP/SCOP charts exist. | Audit with combat data | #80, #81 |
+| Power costs and meter state | Star costs, combat charge math, thresholds, and availability flags are covered by fixtures and serialized for clients. | Complete | none |
+| Checked-in attack/defense charts | Normal/COP/SCOP charts exist. | Audit with combat data | #80 |
 | Mass HP, weather, economy, production, range, movement, capture, and many power effects | See `CO_SUPPORT.md`. | Partial but broad support exists | focused gaps below |
 | Rachel property repair | Compatible owned property service repairs Rachel units up to 3 displayed HP and respects off-class restrictions. | Complete | none |
 | Jess COP resupply | SCOP resupply exists; COP resupply missing. | Partial | #83 |
@@ -207,7 +207,6 @@ Actions, units, and data:
 
 Properties, economy, and COs:
 
-- #81: Verify CO star costs and power-meter charge math against AWBW.
 - #83: Implement Jess Turbo Charge COP resupply side effect.
 - #84: Implement Eagle air-unit fuel upkeep modifier.
 - #85: Implement Sturm all-terrain movement rules.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Notes
 
-Last reviewed: 2026-05-24
+Last reviewed: 2026-05-25
 
 The C++ engine is authoritative for legal actions and state transitions. REST clients should create games, fetch state, request legal actions, and submit exactly one server-validated action at a time.
 
@@ -39,6 +39,8 @@ Supported v1 map ids are `lefty` and `mcts`.
 ## Responses
 
 Successful create returns `201 Created`, a full game-state JSON body, and `Location: /games/:gameId`. Successful get and step responses return `200 OK` with the full current game state. Game-state responses include resolved `settings` and `terminalReason`; active games use `null` for `terminalReason`.
+
+Each player object includes a `power-meter` object. `cop-stars` and `scop-stars` are the CO's meter split, `charge` is current meter charge, and `star-value` is the current value of one star. `cop-threshold` and `scop-threshold` are the current charge thresholds for legal COP and SCOP actions, while `can-use-cop` and `can-use-scop` reflect whether those global power actions are currently available from meter charge.
 
 Legal-action responses use an envelope:
 

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -1,6 +1,6 @@
 # JSON Fixture Guide
 
-Last reviewed: 2026-05-18
+Last reviewed: 2026-05-25
 
 The JSON suite under `AdvanceWarsServer/test/json` is the main executable documentation for engine behavior. The test runner recursively discovers `.json` files and runs each fixture independently.
 
@@ -108,7 +108,7 @@ For COs with bad luck, "lowest" means minimum good luck and maximum bad luck. "H
 
 ### CO Contract Fixture
 
-Use `co-contract` to check CO parser round-trip, power-meter stars, and checked-in chart values.
+Use `co-contract` to check CO parser round-trip, power-meter stars, thresholds, availability flags, and checked-in chart values.
 
 ```json
 {
@@ -116,7 +116,11 @@ Use `co-contract` to check CO parser round-trip, power-meter stars, and checked-
     "name": "Andy",
     "power-meter": {
       "cop-stars": 3,
-      "scop-stars": 6
+      "scop-stars": 6,
+      "cop-threshold": 27000,
+      "scop-threshold": 81000,
+      "can-use-cop": false,
+      "can-use-scop": false
     },
     "stats": [
       {
@@ -131,6 +135,8 @@ Use `co-contract` to check CO parser round-trip, power-meter stars, and checked-
 ```
 
 Use `invalid-co` to assert that an unknown CO string is rejected.
+
+Power-meter expectations are partial in CO contract fixtures: include only the fields relevant to the behavior under test. State-transition fixtures compare the full serialized game state, including `"charge"`, `"star-value"`, `"cop-threshold"`, `"scop-threshold"`, `"can-use-cop"`, and `"can-use-scop"` for each player.
 
 ## Action JSON
 

--- a/frontend/src/gameState/schema.ts
+++ b/frontend/src/gameState/schema.ts
@@ -35,7 +35,11 @@ const powerMeterSchema = z.object({
   "cop-stars": finiteInteger.min(0).max(20),
   "scop-stars": finiteInteger.min(0).max(20),
   charge: finiteInteger.min(0).max(1_000_000),
-  "star-value": finiteInteger.min(1).max(1_000_000)
+  "star-value": finiteInteger.min(1).max(1_000_000),
+  "cop-threshold": finiteInteger.min(0).max(1_000_000).optional(),
+  "scop-threshold": finiteInteger.min(0).max(1_000_000).optional(),
+  "can-use-cop": z.boolean().optional(),
+  "can-use-scop": z.boolean().optional()
 });
 
 export const playerSchema = z.object({


### PR DESCRIPTION
## Summary
- Audits CO power-meter star costs against AWBW references and corrects Sturm from 5+5 to 6+4.
- Adds focused CO meter fixtures for threshold serialization, attacker/defender charge, counterattack charge, zero displayed damage, destruction, and expensive-unit scaling.
- Serializes COP/SCOP thresholds and availability flags for clients, and updates the frontend game-state schema.
- Documents the meter formula, integer truncation, and current completeness status.

## AWBW references
- AWBW Wiki CO page / data module for CO power bars.
- Official AWBW CO chart at https://awbw.amarriner.com/co.php.
- AWBW Damage Formula wiki page for combat context.

## Verification
- `MSBuild AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal` passes. Existing warning remains: `AdvanceWarsServer/src/GameState.cpp(1547)` double-to-int conversion.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co` passes.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json` passes.
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract` passes.
- `yarn typecheck` passes.
- `yarn test` passes.
- `yarn build` passes.
- `git diff --check` passes with only CRLF conversion warnings.

Closes #81.
Closes #145.