### PR TITLE
Implement Jess Turbo Charge resupply

### DIFF
--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -2048,6 +2048,9 @@ Result GameState::DoCOPowerAction() {
 			HealUnits(currentPlayer, 1);
 			DamageUnits(GetEnemyPlayer(), 1);
 			return Result::Succeeded;
+		case CommandingOfficier::Type::Jess:
+			IfFailedReturn(ResupplyPlayersUnits(&GetCurrentPlayer()));
+			return Result::Succeeded;
 		case CommandingOfficier::Type::Kindle:
 			DamageUnitsOnUrbanTerrain(GetEnemyPlayer(), 3);
 			return Result::Succeeded;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -2137,8 +2137,8 @@ Result GameState::ResupplyPlayersUnits(const Player* player) {
 	};
 
 
-	for (int y = 0; y < m_spmap->GetCols(); ++y) {
-		for (int x = 0; x < m_spmap->GetRows(); ++x) {
+	for (int y = 0; y < m_spmap->GetRows(); ++y) {
+		for (int x = 0; x < m_spmap->GetCols(); ++x) {
 			IfFailedReturn(tryResupplyUnit(x, y));
 		}
 	}

--- a/AdvanceWarsServer/test/json/co/jess/overdrive-still-resupplies-all-unit-classes.json
+++ b/AdvanceWarsServer/test/json/co/jess/overdrive-still-resupplies-all-unit-classes.json
@@ -1,0 +1,115 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-overdrive-still-resupplies-all-unit-classes",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 2, "fuel": 11, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 22, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "bcopter" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 2, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 3, "fuel": 33, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 44, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "mech" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-overdrive-still-resupplies-all-unit-classes",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "bcopter" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 2, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 15, "unit": { "ammo": 3, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "mech" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/jess/overdrive-vehicle-movement.json
+++ b/AdvanceWarsServer/test/json/co/jess/overdrive-vehicle-movement.json
@@ -1,0 +1,112 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-overdrive-vehicle-movement",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 54000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "super-co-power"
+    },
+    {
+      "type": "move-wait",
+      "source": [0, 0],
+      "target": [8, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-overdrive-vehicle-movement",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 62, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 2,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/jess/turbo-charge-resupplies-all-unit-classes.json
+++ b/AdvanceWarsServer/test/json/co/jess/turbo-charge-resupplies-all-unit-classes.json
@@ -1,0 +1,115 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-turbo-charge-resupplies-all-unit-classes",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 2, "fuel": 11, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 22, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "bcopter" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 2, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 3, "fuel": 33, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 44, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "mech" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-turbo-charge-resupplies-all-unit-classes",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "bcopter" } },
+        { "terrain": 15, "unit": { "ammo": 1, "fuel": 2, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "battleship" } },
+        { "terrain": 15, "unit": { "ammo": 3, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "mech" } },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/jess/turbo-charge-vehicle-movement.json
+++ b/AdvanceWarsServer/test/json/co/jess/turbo-charge-vehicle-movement.json
@@ -1,0 +1,110 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-turbo-charge-vehicle-movement",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 27000,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    {
+      "type": "co-power"
+    },
+    {
+      "type": "move-wait",
+      "source": [0, 0],
+      "target": [7, 0]
+    }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "jess-turbo-charge-vehicle-movement",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 63, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Jess",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 10800
+        },
+        "power-status": 1,
+        "luck-policy": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -10,7 +10,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - COP and SCOP action charge gates, power-status transitions, star-cost increase, and meter spending.
 - All checked-in normal/COP/SCOP attack and defense chart values.
 - Andy COP/SCOP healing.
-- Jess SCOP resupply.
+- Jess COP/SCOP resupply.
 - Active weather JSON parsing/serialization, weather movement/fuel costs, and Drake/Olaf weather-changing powers.
 - Drake, Hawke, Kindle, Olaf, Rachel, Sturm, and Von Bolt COP/SCOP HP effects, including Drake fuel drain and Von Bolt next-turn stun.
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
@@ -86,7 +86,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#83](https://github.com/ryparikh/AdvanceWarsServer/issues/83): Jess Turbo Charge COP resupply side effect.
 - [#85](https://github.com/ryparikh/AdvanceWarsServer/issues/85): Sturm all-terrain movement rules.
 - [#86](https://github.com/ryparikh/AdvanceWarsServer/issues/86): Lash terrain-star attack and movement effects.
 - [#87](https://github.com/ryparikh/AdvanceWarsServer/issues/87): Javier indirect-defense and Comm Tower defense bonuses.


### PR DESCRIPTION
## Summary
- Add Jess Turbo Charge COP resupply for the current player's units.
- Add JSON regression fixtures covering Jess COP/SCOP resupply across land, air, sea, and footsoldier unit classes.
- Add Jess COP/SCOP vehicle movement fixtures for Turbo Charge +1 move and Overdrive +2 move.
- Fix all-unit resupply iteration on rectangular maps by using row and column bounds in the correct order.
- Update `CO_SUPPORT.md` to mark Jess COP/SCOP resupply as supported and remove #83 from tracked follow-ups.

## Root Cause
Jess SCOP already called the all-unit resupply helper, but Jess COP only activated the COP status and spent meter charge. AWBW documents Turbo Charge as resupplying all units' fuel and ammo, matching Overdrive's resupply side effect.

While adding movement coverage, a rectangular-map fixture also exposed that the shared all-unit resupply helper iterated rows/columns backwards, so Jess COP/SCOP resupply could fail on non-square maps.

Reference: https://awbw.fandom.com/wiki/Jess

## Existing Coverage Confirmed
- Damage modifiers are covered by `test/json/co/jess/contract.json` for normal/COP/SCOP stat charts.
- Jess vehicle movement is implemented through the shared CO movement helper and now has dedicated COP/SCOP JSON fixtures.

## Tests
- First added `test/json/co/jess/turbo-charge-resupplies-all-unit-classes.json` and observed the expected failure: Turbo Charge left friendly units at damaged fuel/ammo values.
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/jess` - passed
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co` - passed
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json` - passed

## Risk
Low. The Jess COP production change uses the existing resupply helper already used by Jess SCOP; the helper loop fix broadens that existing behavior to rectangular maps.

Closes #83