### PR TITLE
Implement Sturm all-terrain movement

### DIFF
--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -502,7 +502,15 @@ int GameState::GetWeatherMovementCost(const Terrain& terrain, const Player& play
 	}
 
 	int baseCost = iterMovementCost->second;
-	if (baseCost < 1 || m_weather == WeatherType::Clear) {
+	if (baseCost < 1) {
+		return baseCost;
+	}
+
+	if (player.m_co.m_type == CommandingOfficier::Type::Sturm && m_weather != WeatherType::Snow) {
+		return 1;
+	}
+
+	if (m_weather == WeatherType::Clear) {
 		return baseCost;
 	}
 

--- a/AdvanceWarsServer/test/json/co/sturm/movement-clear-road-plain-forest-fuel.json
+++ b/AdvanceWarsServer/test/json/co/sturm/movement-clear-road-plain-forest-fuel.json
@@ -1,0 +1,47 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-clear-road-plain-forest-fuel",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 80, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "recon" } },
+        { "terrain": 15 },
+        { "terrain": 1 },
+        { "terrain": 3 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-wait", "source": [0, 0], "target": [3, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-clear-road-plain-forest-fuel",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 1 },
+        { "terrain": 3, "unit": { "ammo": 0, "fuel": 77, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "recon" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sturm/movement-mountain-river-submitted-move.json
+++ b/AdvanceWarsServer/test/json/co/sturm/movement-mountain-river-submitted-move.json
@@ -1,0 +1,47 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-mountain-river-submitted-move",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 2 },
+        { "terrain": 4 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-wait", "source": [0, 0], "target": [3, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-mountain-river-submitted-move",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 2 },
+        { "terrain": 4 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 96, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sturm/movement-mountain-river-valid-actions.json
+++ b/AdvanceWarsServer/test/json/co/sturm/movement-mountain-river-valid-actions.json
@@ -1,0 +1,34 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-mountain-river-valid-actions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 2 },
+        { "terrain": 4 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-wait", "source": [0, 0], "target": [1, 0] },
+        { "type": "move-wait", "source": [0, 0], "target": [2, 0] },
+        { "type": "move-wait", "source": [0, 0], "target": [3, 0] }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/sturm/movement-rain-road-plain-forest-fuel.json
+++ b/AdvanceWarsServer/test/json/co/sturm/movement-rain-road-plain-forest-fuel.json
@@ -1,0 +1,49 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-rain-road-plain-forest-fuel",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 80, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "recon" } },
+        { "terrain": 15 },
+        { "terrain": 1 },
+        { "terrain": 3 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-wait", "source": [0, 0], "target": [3, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-rain-road-plain-forest-fuel",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 1 },
+        { "terrain": 3, "unit": { "ammo": 0, "fuel": 77, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "recon" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "rain",
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sturm/movement-snow-uses-weather-costs.json
+++ b/AdvanceWarsServer/test/json/co/sturm/movement-snow-uses-weather-costs.json
@@ -1,0 +1,45 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-snow-uses-weather-costs",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 80, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "recon" } },
+        { "terrain": 1 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "snow",
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-wait", "source": [0, 0], "target": [1, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-snow-uses-weather-costs",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 1, "unit": { "ammo": 0, "fuel": 77, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "recon" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "snow",
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sturm/movement-tank-cannot-enter-pipe.json
+++ b/AdvanceWarsServer/test/json/co/sturm/movement-tank-cannot-enter-pipe.json
@@ -1,0 +1,24 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sturm-movement-tank-cannot-enter-pipe",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 101 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Sturm", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 6, "scop-stars": 4, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "move-wait", "source": [0, 0], "target": [1, 0] }
+  ]
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -16,7 +16,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented economy and unit-cost effects: Colin, Hachi, and Kanbei build-cost modifiers; Colin Gold Rush and Power of Money; Sasha income, Market Crash, and War Bonds; and Kindle property-based attack bonuses including High Society's owned-property scaling.
 - Implemented Rachel day-to-day property repair: compatible owned properties repair up to 3 displayed HP instead of the normal 2, with funds charged for displayed HP actually restored.
 - Implemented production effects: Hachi's Merchant Union allows standard ground-unit deployment, including Piperunners, from owned empty cities; Sensei's Copter Command/Airborne Assault spawn 9 HP unwaited Infantry/Mechs on owned empty cities in top-row, left-to-right order until the unit cap is reached.
-- Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, and Sensei transports.
+- Implemented movement modifiers: Adder, Andy SCOP, Drake sea units, Jake SCOP, Jess vehicles, Koal, Max direct units, Sami transports/footsoldiers, Sensei transports, and Sturm legal-terrain movement costs outside snow.
 - Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
@@ -43,6 +43,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 - Weather JSON uses `"weather": "rain"` or `"weather": "snow"`. CO-created weather also writes `"weather-turns-remaining"` and expires on a later `BeginTurn`.
 - Rain and snow movement costs follow the AWBW weather tables, including Drake rain immunity, Olaf snow immunity, and Olaf treating rain like snow.
+- Sturm units pay 1 fuel/move point on terrain their movement type can legally enter in clear and rain weather, including during active COP/SCOP turns. Snow disables this passive, so normal snow movement costs apply. Illegal terrain remains illegal, including non-Piperunner units entering pipes.
 - Rain vision penalties are intentionally deferred because this simulator does not yet have fog-of-war or vision state; that broader subsystem is tracked by [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90).
 
 ## HP Effect Notes
@@ -86,7 +87,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#85](https://github.com/ryparikh/AdvanceWarsServer/issues/85): Sturm all-terrain movement rules.
 - [#86](https://github.com/ryparikh/AdvanceWarsServer/issues/86): Lash terrain-star attack and movement effects.
 - [#87](https://github.com/ryparikh/AdvanceWarsServer/issues/87): Javier indirect-defense and Comm Tower defense bonuses.
 - [#88](https://github.com/ryparikh/AdvanceWarsServer/issues/88): Kanbei Samurai Spirit counterattack bonus.

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -84,7 +84,7 @@ Explicitly deferred modes and options:
 | Load and unload | APC, T-Copter, Lander, Black Boat, Cruiser, Carrier, loaded-unit destruction, and many boundaries are covered. | AWBW free unload behavior and legal terrain/occupancy. | Partial because submitted invalid actions need atomic rejection | #67 |
 | Combine/join | Joining/refund/capture-preservation fixtures exist. | AWBW join/refund behavior. | Complete for current Standard coverage | none |
 | Black Boat repair action | Dedicated repair/resupply fixtures exist. | AWBW Black Boat repair and resupply. | Complete for current Standard coverage | none |
-| CO power actions | Power gates, spending, meter math, many direct effects, and mass effects are covered. | Full CO behavior. | Partial | #83, #84, #85, #86, #87, #88, #89, #99, #100, #101, #102, #103 |
+| CO power actions | Power gates, spending, meter math, many direct effects, and mass effects are covered. | Full CO behavior. | Partial | #83, #84, #86, #87, #88, #89, #99, #100, #101, #102, #103 |
 | Black Bomb explode | Black Bomb movement/fuel/no-weapon fixtures exist; explosion action is absent. | Black Bomb explosion if predeployed/custom games need it; production banned in Standard. | Deferred from production, incomplete as unit behavior | #33, #75 |
 | Missile silo launch | Terrain exists, but launch behavior is incomplete. | Launch action, empty silo state, damage area, legal action generation. | Partial | #42 |
 | Resign/delete | Heuristic resign exists; explicit player actions do not. | Explicit resign and delete-unit actions if AWBW permits delete. | Partial | #77 |
@@ -112,7 +112,7 @@ The unit fixture manifest lives at `AdvanceWarsServer/test/json/units/README.md`
 
 | Area | Current implementation | Standard target | Status | Issue |
 | --- | --- | --- | --- | --- |
-| Core terrain movement | JSON fixtures cover many terrain, weather, air, land, and sea movement cases. | AWBW movement tables. | Partial where Piperunner/Sturm/Teleport remain | #35, #85, #93 |
+| Core terrain movement | JSON fixtures cover many terrain, weather, air, land, sea, and Sturm all-terrain movement cases. | AWBW movement tables. | Partial where Piperunner/Teleport remain | #35, #93 |
 | Properties and income | Cities/Bases/Airports/Ports/HQ income behavior exists; Labs/Com Towers no-income fixtures exist. | AWBW fund-producing properties only. | Complete for normal income, configurable settings partial | #65 |
 | Property repair/resupply | Begin-turn property service is gated by owner, property type, and unit class; Labs and Com Towers do not repair or resupply. | Land on City/Base/HQ, air on Airport, sea on Port; owner only. | Complete for normal property service | none |
 | Rachel property repair | Rachel repairs +1 extra displayed HP on compatible owned properties, with affordable partial repair and no off-class service. | Rachel repairs +1 extra displayed HP on compatible properties. | Complete | none |
@@ -137,7 +137,7 @@ Detailed implementation notes live in `CO_SUPPORT.md`.
 | Rachel property repair | Compatible owned property service repairs Rachel units up to 3 displayed HP and respects off-class restrictions. | Complete | none |
 | Jess COP resupply | SCOP resupply exists; COP resupply missing. | Partial | #83 |
 | Eagle air fuel upkeep | Missing. | Partial | #84 |
-| Sturm all-terrain movement | Missing/incomplete. | Partial | #85 |
+| Sturm all-terrain movement | Legal terrain costs 1 outside snow; snow disables the passive and normal snow costs apply. | Complete | none |
 | Lash terrain-star effects | Missing/incomplete. | Partial | #86 |
 | Javier indirect and Comm Tower defense | Missing/incomplete. | Partial | #87 |
 | Kanbei Samurai Spirit counterattack | Missing/incomplete. | Partial | #88 |
@@ -211,7 +211,6 @@ Properties, economy, and COs:
 
 - #83: Implement Jess Turbo Charge COP resupply side effect.
 - #84: Implement Eagle air-unit fuel upkeep modifier.
-- #85: Implement Sturm all-terrain movement rules.
 - #86: Implement Lash terrain-star attack and movement effects.
 - #87: Implement Javier indirect-defense and comm-tower defense bonuses.
 - #88: Implement Kanbei Samurai Spirit counterattack bonus.


### PR DESCRIPTION
## Summary
- Apply Sturm's all-terrain movement passive in the shared movement-cost helper for legal terrain outside snow.
- Preserve normal illegal-terrain handling and snow movement costs, including pipe restrictions for non-Piperunners.
- Add focused Sturm JSON fixtures and update CO/Standard support docs.

## Root Cause
Movement costs were terrain/weather/unit based only. Sturm's AWBW passive was not represented, so legal-action generation and submitted move validation charged normal clear/rain movement costs.

## Tests
- Failing before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/sturm` showed clear/rain fuel mismatches and missing mountain/river valid actions for Sturm.
- Passing after implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/co/sturm`
- Passing: `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- Passing: `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`

## Residual Risk
- Build emitted the existing `C4244` warning in `GameState.cpp`; no new warnings were introduced by this change.

Closes #85