### PR TITLE
[codex] Implement CO support items 86-100

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -294,7 +294,9 @@ private:
 	int GetCOBuildCost(const Player& player, UnitProperties::Type unitType) const noexcept;
 	int GetCOIncomeForProperty(const Player& player, Terrain::Type terrainType) const noexcept;
 	int GetCOFundsAttackModifier(const Player& player, const CommandingOfficier::Type& co) const noexcept;
+	int GetCOCombatDefenseModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& attacker) const noexcept;
 	int GetCOCaptureProgress(const Player& player, const Unit& unit) const noexcept;
+	int CountOwnedComTowers(const Player& player) const noexcept;
 	int CountOwnedProperties(const Player& player) const noexcept;
 	bool FCanProduceUnitFromTerrain(const Player& player, Terrain::Type terrainType, UnitProperties::Type unitType) const noexcept;
 

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -288,7 +288,7 @@ private:
 	Result DoCOPowerAction();
 	Result DoSCOPowerAction();
 	Result ResupplyPlayersUnits(const Player* player);
-	int calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain);
+	int calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain, bool fCounterAttack);
 	int GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit, const Terrain& terrain) const noexcept;
 	int GetCOIndirectRangeModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
 	int GetCOBuildCost(const Player& player, UnitProperties::Type unitType) const noexcept;

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -299,6 +299,7 @@ private:
 	int CountOwnedComTowers(const Player& player) const noexcept;
 	int CountOwnedProperties(const Player& player) const noexcept;
 	bool FCanProduceUnitFromTerrain(const Player& player, Terrain::Type terrainType, UnitProperties::Type unitType) const noexcept;
+	int PlayerIndex(const Player& player) const noexcept;
 
 	int GetMaxGoodLuck(const Player& player) noexcept;
 	int GetMaxBadLuck(const Player& player) noexcept;

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -289,7 +289,7 @@ private:
 	Result DoSCOPowerAction();
 	Result ResupplyPlayersUnits(const Player* player);
 	int calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain);
-	int GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Terrain::Type& terrainType) const noexcept;
+	int GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit, const Terrain& terrain) const noexcept;
 	int GetCOIndirectRangeModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
 	int GetCOBuildCost(const Player& player, UnitProperties::Type unitType) const noexcept;
 	int GetCOIncomeForProperty(const Player& player, Terrain::Type terrainType) const noexcept;

--- a/AdvanceWarsServer/inc/RestGameService.h
+++ b/AdvanceWarsServer/inc/RestGameService.h
@@ -15,7 +15,7 @@ struct ApiResponse {
 class RestGameService {
 public:
 	ApiResponse CreateGame(const std::string& requestBody);
-	ApiResponse GetGame(const std::string& gameId) const;
+	ApiResponse GetGame(const std::string& gameId, const std::string& query = "") const;
 	ApiResponse ListActions(const std::string& gameId, const std::string& query) const;
 	ApiResponse SubmitAction(const std::string& gameId, const std::string& requestBody);
 

--- a/AdvanceWarsServer/src/AdvanceWarsServer.cpp
+++ b/AdvanceWarsServer/src/AdvanceWarsServer.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<AdvanceWarsServer> AdvanceWarsServer::s_spServer{ nullptr };
 /*static*/ tx_response AdvanceWarsServer::get_game_handler(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {
 	std::string gameId = parameters.find("gameid")->second;
 	AdvanceWarsServer& server = AdvanceWarsServer::getInstance();
-	return ToHttpResponse(server.m_gameService.GetGame(gameId), response_body);
+	return ToHttpResponse(server.m_gameService.GetGame(gameId, QueryFromRequest(request)), response_body);
 }
 
 /*static*/ tx_response AdvanceWarsServer::post_game_actions(const http_request& request, const Parameters& parameters, const std::string& data, std::string& response_body) {

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1371,7 +1371,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 	}
 
 	// Calculate Attacker damange
-	int attackDamage = calculateDamage(pattackingplayer, pdefendingplayer, pattackingplayer->m_co.m_type, pdefendingplayer->m_co.m_type, *pattacker, *pdefender, pAttackerTile->GetTerrain(), pDefenderTile->GetTerrain());
+	int attackDamage = calculateDamage(pattackingplayer, pdefendingplayer, pattackingplayer->m_co.m_type, pdefendingplayer->m_co.m_type, *pattacker, *pdefender, pAttackerTile->GetTerrain(), pDefenderTile->GetTerrain(), false);
 	if (attackDamage <= -1) {
 		if (!fSonjaPower) {
 			return Result::Failed;
@@ -1414,7 +1414,7 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		return Result::Succeeded;
 	}
 
-	attackDamage = calculateDamage(pdefendingplayer, pattackingplayer, pdefendingplayer->m_co.m_type, pattackingplayer->m_co.m_type, *pdefender, *pattacker, pDefenderTile->GetTerrain(), pAttackerTile->GetTerrain());
+	attackDamage = calculateDamage(pdefendingplayer, pattackingplayer, pdefendingplayer->m_co.m_type, pattackingplayer->m_co.m_type, *pdefender, *pattacker, pDefenderTile->GetTerrain(), pAttackerTile->GetTerrain(), true);
 	if (attackDamage >= 0) {
 		int attackerVisualHealthStart = (pattacker->health + 9) / 10;
 		pattacker->health -= attackDamage;
@@ -1463,7 +1463,7 @@ bool GameState::FPlayerRouted(const Player& player) const noexcept {
 	return true;
 }
 
-int GameState::calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain) {
+int GameState::calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain, bool fCounterAttack) {
 	int defenderTerrainStars = defenderTerrain.m_defense;
 	int baseDamage = -1;
 	// Use machine gun against footsolider
@@ -1545,6 +1545,10 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 	int attackerHealth = (attacker.health + 9) / 10;
 	int defenderHealth = (defender.health + 9) / 10;
 	double damage = ((baseDamage * attackValue / 100.0) + goodLuckRoll - badLuckRoll) * attackerHealth / 10.0 * ((200 - (defenceValue + defenderTerrainStars * defenderHealth)) / 100.0);
+	if (fCounterAttack && attackerCO == CommandingOfficier::Type::Kanbei && pattackingplayer->PowerStatus() == 2) {
+		damage *= 1.5;
+	}
+
 	if (damage <= 0) {
 		return 0;
 	}

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1527,23 +1527,14 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 		badLuckRoll = RollCombatLuck(badLuckDistribution.min(), badLuckDistribution.max());
 	}
 
-	int nComTowers = 0;
-	for (int x = 0; x < m_spmap->GetCols(); ++x) {
-		for (int y = 0; y < m_spmap->GetRows(); ++y) {
-			const MapTile* pTile = nullptr;
-			m_spmap->TryGetTile(x, y, &pTile);
-			const Terrain& terrain = pTile->GetTerrain();
-			if (MapTile::IsProperty(terrain.m_type) && terrain.m_type == Terrain::Type::ComTower  && pTile->m_spPropertyInfo->m_owner == pattackingplayer) {
-				++nComTowers;
-			}
-		}
-	}
+	int nComTowers = CountOwnedComTowers(*pattackingplayer);
 
 	int attackValue = rgCharts[static_cast<int>(attackerCO)][pattackingplayer->PowerStatus()][static_cast<int>(attacker.m_properties.m_type)].first + 10 * nComTowers;
 	int defenceValue = rgCharts[static_cast<int>(defenderCO)][pdefendingplayer->PowerStatus()][static_cast<int>(defender.m_properties.m_type)].second;
 
 	attackValue += GetCOFundsAttackModifier(*pattackingplayer, attackerCO);
 	attackValue += GetCOTerrainModifier(*pattackingplayer, attackerCO, attacker, attackerTerrain);
+	defenceValue += GetCOCombatDefenseModifier(*pdefendingplayer, defenderCO, attacker);
 	if (defender.IsAirUnit()) {
 		defenderTerrainStars = 0;
 	}
@@ -1702,6 +1693,43 @@ int GameState::GetCOFundsAttackModifier(const Player& player, const CommandingOf
 	}
 
 	return 0;
+}
+
+int GameState::GetCOCombatDefenseModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& attacker) const noexcept {
+	if (co != CommandingOfficier::Type::Javier) {
+		return 0;
+	}
+
+	int modifier = CountOwnedComTowers(player) * 10 * (player.PowerStatus() + 1);
+	if (UnitProperties::IsIndirectAttack(attacker.m_properties.m_type)) {
+		if (player.PowerStatus() == 2) {
+			modifier += 80;
+		}
+		else if (player.PowerStatus() == 1) {
+			modifier += 40;
+		}
+		else {
+			modifier += 20;
+		}
+	}
+
+	return modifier;
+}
+
+int GameState::CountOwnedComTowers(const Player& player) const noexcept {
+	int towers = 0;
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			const MapTile* pTile = nullptr;
+			m_spmap->TryGetTile(x, y, &pTile);
+			const Terrain& terrain = pTile->GetTerrain();
+			if (MapTile::IsProperty(terrain.m_type) && terrain.m_type == Terrain::Type::ComTower && pTile->m_spPropertyInfo->m_owner == &player) {
+				++towers;
+			}
+		}
+	}
+
+	return towers;
 }
 
 int GameState::CountOwnedProperties(const Player& player) const noexcept {

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1775,6 +1775,7 @@ int GameState::GetMaxGoodLuck(const Player& player) noexcept {
 		if (status == 1) {
 			return 39;
 		}
+		return 9;
 	case CommandingOfficier::Type::Nell:
 		if (status == 0) {
 			return 19;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1360,18 +1360,18 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 	Player* pattackingplayer = &GetCurrentPlayer();
 	Player* pdefendingplayer = &GetEnemyPlayer();
 	bool fSonjaPower = pdefendingplayer->m_co.m_type == CommandingOfficier::Type::Sonja && pdefendingplayer->PowerStatus() == 2;
+	Unit* pActingUnit = pattacker;
+	MapTile* pCombatAttackerTile = pAttackerTile;
+	MapTile* pCombatDefenderTile = pDefenderTile;
 
 	if (fSonjaPower) {
-		Player* playerswap = pattackingplayer;
-		pattackingplayer = pdefendingplayer;
-		pdefendingplayer = playerswap;
-		Unit* unitswap = pattacker;
-		pattacker = pdefender;
-		pdefender = unitswap;
+		std::swap(pattackingplayer, pdefendingplayer);
+		std::swap(pattacker, pdefender);
+		std::swap(pCombatAttackerTile, pCombatDefenderTile);
 	}
 
 	// Calculate Attacker damange
-	int attackDamage = calculateDamage(pattackingplayer, pdefendingplayer, pattackingplayer->m_co.m_type, pdefendingplayer->m_co.m_type, *pattacker, *pdefender, pAttackerTile->GetTerrain(), pDefenderTile->GetTerrain(), false);
+	int attackDamage = calculateDamage(pattackingplayer, pdefendingplayer, pattackingplayer->m_co.m_type, pdefendingplayer->m_co.m_type, *pattacker, *pdefender, pCombatAttackerTile->GetTerrain(), pCombatDefenderTile->GetTerrain(), fSonjaPower);
 	if (attackDamage <= -1) {
 		if (!fSonjaPower) {
 			return Result::Failed;
@@ -1395,26 +1395,26 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 		}
 	}
 
-	pattacker->m_moved = true;
+	pActingUnit->m_moved = true;
 	if (pdefender->health <= 0) {
-		pDefenderTile->TryDestroyUnit();
-		if (pDefenderTile->m_spPropertyInfo != nullptr && pDefenderTile->m_spPropertyInfo->m_capturePoints != 20) {
-			pDefenderTile->m_spPropertyInfo->m_capturePoints = 20;
+		pCombatDefenderTile->TryDestroyUnit();
+		if (pCombatDefenderTile->m_spPropertyInfo != nullptr && pCombatDefenderTile->m_spPropertyInfo->m_capturePoints != 20) {
+			pCombatDefenderTile->m_spPropertyInfo->m_capturePoints = 20;
 		}
 		if (FPlayerRouted(*pdefendingplayer)) {
 			m_fGameOver = true;
-			m_winningPlayer = m_isFirstPlayerTurn ? 0 : 1;
+			m_winningPlayer = PlayerIndex(*pattackingplayer);
 			m_terminalReason = "rout";
 		}
 		return Result::Succeeded;
 	}
 
 	// Calculate counter attack only for direct combat
-	if (pattacker->m_properties.m_range.first != 1 || pdefender->m_properties.m_range.first != 1) {
+	if (!fSonjaPower && (pattacker->m_properties.m_range.first != 1 || pdefender->m_properties.m_range.first != 1)) {
 		return Result::Succeeded;
 	}
 
-	attackDamage = calculateDamage(pdefendingplayer, pattackingplayer, pdefendingplayer->m_co.m_type, pattackingplayer->m_co.m_type, *pdefender, *pattacker, pDefenderTile->GetTerrain(), pAttackerTile->GetTerrain(), true);
+	attackDamage = calculateDamage(pdefendingplayer, pattackingplayer, pdefendingplayer->m_co.m_type, pattackingplayer->m_co.m_type, *pdefender, *pattacker, pCombatDefenderTile->GetTerrain(), pCombatAttackerTile->GetTerrain(), !fSonjaPower);
 	if (attackDamage >= 0) {
 		int attackerVisualHealthStart = (pattacker->health + 9) / 10;
 		pattacker->health -= attackDamage;
@@ -1433,13 +1433,13 @@ Result GameState::DoAttackAction(int x, int y, const Action& action) {
 	}
 
 	if (pattacker->health <= 0) {
-		pAttackerTile->TryDestroyUnit();
-		if (pAttackerTile->m_spPropertyInfo != nullptr && pAttackerTile->m_spPropertyInfo->m_capturePoints != 20) {
-			pAttackerTile->m_spPropertyInfo->m_capturePoints = 20;
+		pCombatAttackerTile->TryDestroyUnit();
+		if (pCombatAttackerTile->m_spPropertyInfo != nullptr && pCombatAttackerTile->m_spPropertyInfo->m_capturePoints != 20) {
+			pCombatAttackerTile->m_spPropertyInfo->m_capturePoints = 20;
 		}
 		if (FPlayerRouted(*pattackingplayer)) {
 			m_fGameOver = true;
-			m_winningPlayer = m_isFirstPlayerTurn ? 1 : 0;
+			m_winningPlayer = PlayerIndex(*pdefendingplayer);
 			m_terminalReason = "rout";
 		}
 		return Result::Succeeded;
@@ -1461,6 +1461,10 @@ bool GameState::FPlayerRouted(const Player& player) const noexcept {
 	}
 
 	return true;
+}
+
+int GameState::PlayerIndex(const Player& player) const noexcept {
+	return &player == &m_arrPlayers[0] ? 0 : 1;
 }
 
 int GameState::calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain, bool fCounterAttack) {
@@ -1546,6 +1550,9 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 	int defenderHealth = (defender.health + 9) / 10;
 	double damage = ((baseDamage * attackValue / 100.0) + goodLuckRoll - badLuckRoll) * attackerHealth / 10.0 * ((200 - (defenceValue + defenderTerrainStars * defenderHealth)) / 100.0);
 	if (fCounterAttack && attackerCO == CommandingOfficier::Type::Kanbei && pattackingplayer->PowerStatus() == 2) {
+		damage *= 1.5;
+	}
+	if (fCounterAttack && attackerCO == CommandingOfficier::Type::Sonja) {
 		damage *= 1.5;
 	}
 

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -510,6 +510,10 @@ int GameState::GetWeatherMovementCost(const Terrain& terrain, const Player& play
 		return 1;
 	}
 
+	if (player.m_co.m_type == CommandingOfficier::Type::Lash && player.PowerStatus() != 0 && m_weather != WeatherType::Snow) {
+		return 1;
+	}
+
 	if (m_weather == WeatherType::Clear) {
 		return baseCost;
 	}
@@ -1539,9 +1543,12 @@ int GameState::calculateDamage(const Player* pattackingplayer, const Player* pde
 	int defenceValue = rgCharts[static_cast<int>(defenderCO)][pdefendingplayer->PowerStatus()][static_cast<int>(defender.m_properties.m_type)].second;
 
 	attackValue += GetCOFundsAttackModifier(*pattackingplayer, attackerCO);
-	attackValue += GetCOTerrainModifier(*pattackingplayer, attackerCO, attackerTerrain.m_type);
+	attackValue += GetCOTerrainModifier(*pattackingplayer, attackerCO, attacker, attackerTerrain);
 	if (defender.IsAirUnit()) {
 		defenderTerrainStars = 0;
+	}
+	else if (defenderCO == CommandingOfficier::Type::Lash && pdefendingplayer->PowerStatus() == 2) {
+		defenderTerrainStars *= 2;
 	}
 
 	int attackerHealth = (attacker.health + 9) / 10;
@@ -1579,10 +1586,10 @@ int GameState::GetCOIndirectRangeModifier(const Player& player, const Commanding
 	return 0;
 }
 
-int GameState::GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Terrain::Type& terrainType) const noexcept {
+int GameState::GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit, const Terrain& terrain) const noexcept {
 	switch (co) {
 	case CommandingOfficier::Type::Jake:
-		if (terrainType != Terrain::Type::Plain) {
+		if (terrain.m_type != Terrain::Type::Plain) {
 			break;
 		}
 
@@ -1595,7 +1602,7 @@ int GameState::GetCOTerrainModifier(const Player& player, const CommandingOffici
 		
 		return 10;
 	case CommandingOfficier::Type::Koal:
-		if (terrainType != Terrain::Type::Road) {
+		if (terrain.m_type != Terrain::Type::Road) {
 			break;
 		}
 
@@ -1608,7 +1615,7 @@ int GameState::GetCOTerrainModifier(const Player& player, const CommandingOffici
 		
 		return 10;
 	case CommandingOfficier::Type::Kindle:
-		if (!FKindleUrbanTerrain(terrainType)) {
+		if (!FKindleUrbanTerrain(terrain.m_type)) {
 			break;
 		}
 
@@ -1620,6 +1627,16 @@ int GameState::GetCOTerrainModifier(const Player& player, const CommandingOffici
 		}
 
 		return 40;
+	case CommandingOfficier::Type::Lash:
+		if (unit.IsAirUnit()) {
+			break;
+		}
+
+		if (player.m_powerStatus == 2) {
+			return terrain.m_defense * 20;
+		}
+
+		return terrain.m_defense * 10;
 	default:
 		break;
 	}

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -29,6 +29,74 @@ json StandardCreatePayload(const std::string& mapId = "lefty") {
 	};
 }
 
+json SonjaHiddenHpGameState() {
+	return {
+		{ "activePlayer", 0 },
+		{ "cap-limit", 21 },
+		{ "game-over", false },
+		{ "gameId", "rest-sonja-hidden-hp" },
+		{ "map", json::array({
+			json::array({
+				{
+					{ "terrain", 15 },
+					{ "unit", {
+						{ "ammo", 9 },
+						{ "fuel", 70 },
+						{ "health", 88 },
+						{ "hidden", false },
+						{ "moved", false },
+						{ "owner", "orange-star" },
+						{ "type", "tank" },
+					} },
+				},
+				{
+					{ "terrain", 15 },
+					{ "unit", {
+						{ "ammo", 9 },
+						{ "fuel", 70 },
+						{ "health", 73 },
+						{ "hidden", false },
+						{ "moved", false },
+						{ "owner", "blue-moon" },
+						{ "type", "tank" },
+					} },
+				},
+			}),
+		}) },
+		{ "players", json::array({
+			{
+				{ "armyType", "orange-star" },
+				{ "co", "Andy" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 3 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+			{
+				{ "armyType", "blue-moon" },
+				{ "co", "Sonja" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 3 },
+					{ "scop-stars", 2 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 3 },
+			},
+		}) },
+		{ "turn-count", 1 },
+		{ "unit-cap", 50 },
+		{ "winner", -1 },
+	};
+}
+
 bool RunCreateGetAndLegalActionContract() {
 	RestGameService service;
 	ApiResponse create = service.CreateGame(StandardCreatePayload("mcts").dump());
@@ -114,6 +182,70 @@ bool RunCreateGetAndLegalActionContract() {
 		return false;
 	}
 	if (!Expect(tileActions.body.at("source").at(0) == x && tileActions.body.at("source").at(1) == y, "tile legal action envelope should include source")) {
+		return false;
+	}
+
+	return true;
+}
+
+bool RunSonjaHiddenHpPerspectiveContract() {
+	RestGameService service;
+	json fixture = SonjaHiddenHpGameState();
+	GameState gameState;
+	GameState::from_json(fixture, gameState);
+	service.StoreGameForTesting(std::move(gameState));
+
+	const std::string gameId = fixture.at("gameId").get<std::string>();
+	ApiResponse full = service.GetGame(gameId);
+	if (!Expect(full.status == 200, "full get should return 200")) {
+		return false;
+	}
+	const json& fullSonjaUnit = full.body.at("map").at(0).at(1).at("unit");
+	if (!Expect(fullSonjaUnit.at("health") == 73, "full get should expose authoritative Sonja HP")) {
+		return false;
+	}
+	if (!Expect(!fullSonjaUnit.contains("hidden-health"), "full get should not mark hidden HP")) {
+		return false;
+	}
+
+	ApiResponse attackerView = service.GetGame(gameId, "player=0");
+	if (!Expect(attackerView.status == 200, "player 0 get should return 200")) {
+		return false;
+	}
+	const json& visibleAndyUnit = attackerView.body.at("map").at(0).at(0).at("unit");
+	if (!Expect(visibleAndyUnit.at("health") == 88, "player perspective should keep own HP exact")) {
+		return false;
+	}
+	const json& hiddenSonjaUnit = attackerView.body.at("map").at(0).at(1).at("unit");
+	if (!Expect(hiddenSonjaUnit.at("health").is_null(), "opponent perspective should hide Sonja HP")) {
+		return false;
+	}
+	if (!Expect(hiddenSonjaUnit.at("hidden-health") == true, "opponent perspective should flag hidden Sonja HP")) {
+		return false;
+	}
+
+	ApiResponse defenderView = service.GetGame(gameId, "player=1");
+	if (!Expect(defenderView.status == 200, "player 1 get should return 200")) {
+		return false;
+	}
+	const json& ownSonjaUnit = defenderView.body.at("map").at(0).at(1).at("unit");
+	if (!Expect(ownSonjaUnit.at("health") == 73, "Sonja player should see own exact HP")) {
+		return false;
+	}
+	if (!Expect(!ownSonjaUnit.contains("hidden-health"), "Sonja player should not see own HP as hidden")) {
+		return false;
+	}
+
+	ApiResponse unsupportedPlayer = service.GetGame(gameId, "player=2");
+	if (!Expect(unsupportedPlayer.status == 422, "unsupported perspective player should return 422")) {
+		return false;
+	}
+	if (!Expect(unsupportedPlayer.body.at("error").at("code") == "invalid-player", "unsupported perspective should use invalid-player code")) {
+		return false;
+	}
+
+	ApiResponse invalidQuery = service.GetGame(gameId, "viewer=0");
+	if (!Expect(invalidQuery.status == 400, "unknown get query field should return 400")) {
 		return false;
 	}
 
@@ -243,6 +375,9 @@ bool RunCreateValidationContract() {
 
 int RunRestApiContractTests() {
 	if (!RunCreateGetAndLegalActionContract()) {
+		return 1;
+	}
+	if (!RunSonjaHiddenHpPerspectiveContract()) {
 		return 1;
 	}
 	if (!RunStepAndErrorContract()) {

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
@@ -217,6 +218,40 @@ json SerializeGameForApi(const GameState& gameState) {
 	return game;
 }
 
+void RedactSonjaHiddenHp(json& unit, const std::string& sonjaArmyType) {
+	if (!unit.is_object()) {
+		return;
+	}
+
+	if (unit.contains("owner") && unit.at("owner").is_string() && unit.at("owner").get<std::string>() == sonjaArmyType) {
+		unit["health"] = nullptr;
+		unit["hidden-health"] = true;
+	}
+
+	if (unit.contains("loaded-units") && unit.at("loaded-units").is_array()) {
+		for (json& loadedUnit : unit["loaded-units"]) {
+			RedactSonjaHiddenHp(loadedUnit, sonjaArmyType);
+		}
+	}
+}
+
+void RedactHiddenHpForPerspective(json& game, int playerIndex) {
+	const int opponentIndex = playerIndex == 0 ? 1 : 0;
+	const json& opponent = game.at("players").at(opponentIndex);
+	if (opponent.at("co") != "Sonja") {
+		return;
+	}
+
+	const std::string sonjaArmyType = opponent.at("armyType").get<std::string>();
+	for (json& row : game["map"]) {
+		for (json& tile : row) {
+			if (tile.contains("unit")) {
+				RedactSonjaHiddenHp(tile["unit"], sonjaArmyType);
+			}
+		}
+	}
+}
+
 ApiResponse UnknownGameResponse() {
 	return ErrorResponse(HttpNotFound, "unknown-game-id", "Game id was not found.");
 }
@@ -232,7 +267,17 @@ bool TryGetInteger(const std::string& value, int& parsed) {
 	}
 }
 
-std::map<std::string, std::string> ParseQueryString(const std::string& query, bool& valid) {
+bool ContainsQueryField(std::initializer_list<const char*> allowedFields, const std::string& key) {
+	for (const char* allowedField : allowedFields) {
+		if (key == allowedField) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+std::map<std::string, std::string> ParseQueryString(const std::string& query, std::initializer_list<const char*> allowedFields, bool& valid) {
 	valid = true;
 	std::map<std::string, std::string> parsed;
 	if (query.empty()) {
@@ -250,7 +295,7 @@ std::map<std::string, std::string> ParseQueryString(const std::string& query, bo
 
 		std::string key = part.substr(0, equals);
 		std::string value = part.substr(equals + 1);
-		if ((key != "x" && key != "y") || parsed.find(key) != parsed.end()) {
+		if (!ContainsQueryField(allowedFields, key) || parsed.find(key) != parsed.end()) {
 			valid = false;
 			return parsed;
 		}
@@ -443,13 +488,31 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 	return response;
 }
 
-ApiResponse RestGameService::GetGame(const std::string& gameId) const {
+ApiResponse RestGameService::GetGame(const std::string& gameId, const std::string& query) const {
 	const auto game = FindGame(gameId);
 	if (game == m_games.end()) {
 		return UnknownGameResponse();
 	}
 
-	return JsonResponse(HttpOk, SerializeGameForApi(*game->second));
+	bool validQuery = true;
+	std::map<std::string, std::string> queryParams = ParseQueryString(query, { "player" }, validQuery);
+	if (!validQuery) {
+		return ErrorResponse(HttpBadRequest, "invalid-query", "Game query may only include player.");
+	}
+
+	int playerIndex = -1;
+	if (!queryParams.empty()) {
+		if (!TryGetInteger(queryParams["player"], playerIndex) || playerIndex < 0 || playerIndex > 1) {
+			return ErrorResponse(HttpUnprocessableEntity, "invalid-player", "Player perspective must be 0 or 1.", { { "field", "player" }, { "value", queryParams["player"] } });
+		}
+	}
+
+	json response = SerializeGameForApi(*game->second);
+	if (playerIndex != -1) {
+		RedactHiddenHpForPerspective(response, playerIndex);
+	}
+
+	return JsonResponse(HttpOk, std::move(response));
 }
 
 ApiResponse RestGameService::ListActions(const std::string& gameId, const std::string& query) const {
@@ -459,7 +522,7 @@ ApiResponse RestGameService::ListActions(const std::string& gameId, const std::s
 	}
 
 	bool validQuery = true;
-	std::map<std::string, std::string> queryParams = ParseQueryString(query, validQuery);
+	std::map<std::string, std::string> queryParams = ParseQueryString(query, { "x", "y" }, validQuery);
 	if (!validQuery || queryParams.size() == 1) {
 		return ErrorResponse(HttpBadRequest, "invalid-query", "Legal action query must include both x and y, or neither.");
 	}

--- a/AdvanceWarsServer/test/json/co/javier/direct-no-tower-no-indirect-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/direct-no-tower-no-indirect-defense.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-direct-no-tower-no-indirect-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-direct-no-tower-no-indirect-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 73, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 45, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 3150, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 4200, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/direct-one-tower-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/direct-one-tower-defense.json
@@ -1,0 +1,51 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-direct-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-direct-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 64, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 51, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 3500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 3850, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/indirect-one-tower-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/indirect-one-tower-defense.json
@@ -1,0 +1,59 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 51, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 1400, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 2800, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/indirect-one-tower-terrain-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/indirect-one-tower-terrain-defense.json
@@ -1,0 +1,67 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-one-tower-terrain-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        {
+          "terrain": 43,
+          "property": { "capture-points": 20, "owner": "blue-moon" },
+          "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" }
+        },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-one-tower-terrain-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        {
+          "terrain": 43,
+          "property": { "capture-points": 20, "owner": "blue-moon" },
+          "unit": { "ammo": 9, "fuel": 70, "health": 72, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" }
+        },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 1400, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/indirect-two-towers-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/indirect-two-towers-defense.json
@@ -1,0 +1,59 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-two-towers-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-two-towers-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 58, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 1400, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 2800, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/indirect-zero-tower-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/indirect-zero-tower-defense.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-zero-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-indirect-zero-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 44, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 1750, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 3500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/tower-of-power-one-tower-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/tower-of-power-one-tower-defense.json
@@ -1,0 +1,59 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-tower-of-power-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-tower-of-power-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/javier/tower-shield-one-tower-defense.json
+++ b/AdvanceWarsServer/test/json/co/javier/tower-shield-one-tower-defense.json
@@ -1,0 +1,59 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-tower-shield-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 1, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "javier-tower-shield-one-tower-defense",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 129, "property": { "capture-points": 20, "owner": "blue-moon" } }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 79, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Javier", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 1, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/d2d-direct-counter-baseline.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/d2d-direct-counter-baseline.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-d2d-direct-counter-baseline",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-d2d-direct-counter-baseline",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 50, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 62, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 4550, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 3850, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/morale-boost-direct-counter-baseline.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/morale-boost-direct-counter-baseline.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-morale-boost-direct-counter-baseline",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 1, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-morale-boost-direct-counter-baseline",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 43, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 67, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 4550, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 1, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-attacking-no-counter-bonus.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-attacking-no-counter-bonus.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-attacking-no-counter-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-attacking-no-counter-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 96, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 18, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 5600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-counterattack-bonus.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-counterattack-bonus.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-counterattack-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-counterattack-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 1, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 78, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 7000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-damaged-counterattack-rounding.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-damaged-counterattack-rounding.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-damaged-counterattack-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 83, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 69, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-damaged-counterattack-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 22, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 50, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 4900, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-no-counter-against-indirect.json
+++ b/AdvanceWarsServer/test/json/co/kanbei/samurai-spirit-no-counter-against-indirect.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-no-counter-against-indirect",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "kanbei-samurai-spirit-no-counter-against-indirect",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 72, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Kanbei", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/prime-tactics-doubles-defense-terrain-stars.json
+++ b/AdvanceWarsServer/test/json/co/lash/prime-tactics-doubles-defense-terrain-stars.json
@@ -1,0 +1,61 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-prime-tactics-doubles-defense-terrain-stars",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        {
+          "terrain": 34,
+          "property": { "capture-points": 20, "owner": "neutral" },
+          "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" }
+        }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-prime-tactics-doubles-defense-terrain-stars",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        {
+          "terrain": 34,
+          "property": { "capture-points": 20, "owner": "neutral" },
+          "unit": { "ammo": 9, "fuel": 70, "health": 79, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" }
+        }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/prime-tactics-snow-uses-weather-costs.json
+++ b/AdvanceWarsServer/test/json/co/lash/prime-tactics-snow-uses-weather-costs.json
@@ -1,0 +1,45 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-prime-tactics-snow-uses-weather-costs",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 80, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "recon" } },
+        { "terrain": 1 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "snow",
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-wait", "source": [0, 0], "target": [1, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-prime-tactics-snow-uses-weather-costs",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 1, "unit": { "ammo": 0, "fuel": 77, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "recon" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "weather": "snow",
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-attack-air-unaffected.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-attack-air-unaffected.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-air-unaffected",
+    "map": [
+      [
+        { "terrain": 2, "unit": { "ammo": 6, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "bcopter" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-air-unaffected",
+    "map": [
+      [
+        { "terrain": 2, "unit": { "ammo": 5, "fuel": 99, "health": 95, "hidden": false, "moved": true, "owner": "orange-star", "type": "bcopter" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 45, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 1750, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 3500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-attack-defender-terrain-composes.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-attack-defender-terrain-composes.json
@@ -1,0 +1,61 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-defender-terrain-composes",
+    "map": [
+      [
+        { "terrain": 2, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        {
+          "terrain": 34,
+          "property": { "capture-points": 20, "owner": "neutral" },
+          "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" }
+        }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-defender-terrain-composes",
+    "map": [
+      [
+        { "terrain": 2, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        {
+          "terrain": 34,
+          "property": { "capture-points": 20, "owner": "neutral" },
+          "unit": { "ammo": 9, "fuel": 70, "health": 32, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" }
+        }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 2100, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 4200, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-attack-forest-stars.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-attack-forest-stars.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-forest-stars",
+    "map": [
+      [
+        { "terrain": 3, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-forest-stars",
+    "map": [
+      [
+        { "terrain": 3, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 16, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 2800, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 5600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-attack-mountain-high-star.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-attack-mountain-high-star.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-mountain-high-star",
+    "map": [
+      [
+        { "terrain": 2, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-mountain-high-star",
+    "map": [
+      [
+        { "terrain": 2, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 2, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 3150, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 6300, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-attack-property-stars.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-attack-property-stars.json
@@ -1,0 +1,61 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-property-stars",
+    "map": [
+      [
+        {
+          "terrain": 34,
+          "property": { "capture-points": 20, "owner": "neutral" },
+          "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" }
+        }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-property-stars",
+    "map": [
+      [
+        {
+          "terrain": 34,
+          "property": { "capture-points": 20, "owner": "neutral" },
+          "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" }
+        }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 9, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 3150, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 6300, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-attack-road-zero-star.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-attack-road-zero-star.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-road-zero-star",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-attack-road-zero-star",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 30, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 2450, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 4900, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/lash/terrain-tactics-movement-costs-one.json
+++ b/AdvanceWarsServer/test/json/co/lash/terrain-tactics-movement-costs-one.json
@@ -1,0 +1,34 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "lash-terrain-tactics-movement-costs-one",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 2 },
+        { "terrain": 4 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Lash", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 4, "scop-stars": 3, "star-value": 9000 }, "power-status": 1, "luck-policy": 0 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 0 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-wait", "source": [0, 0], "target": [1, 0] },
+        { "type": "move-wait", "source": [0, 0], "target": [2, 0] },
+        { "type": "move-wait", "source": [0, 0], "target": [3, 0] }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/co/nell/luck-cop-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/nell/luck-cop-high-roll.json
@@ -1,0 +1,44 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-cop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 27000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "co-power" },
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-cop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 73, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 36, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 10800 }, "power-status": 1, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 4300, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/nell/luck-d2d-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/nell/luck-d2d-high-roll.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-d2d-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-d2d-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 84, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 26, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 450, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 750, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/nell/luck-d2d-low-roll.json
+++ b/AdvanceWarsServer/test/json/co/nell/luck-d2d-low-roll.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-d2d-low-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-d2d-low-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 73, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 45, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 450, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/nell/luck-damaged-rounding.json
+++ b/AdvanceWarsServer/test/json/co/nell/luck-damaged-rounding.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-damaged-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 55, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-damaged-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 22, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 56, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 550, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/nell/luck-normal-co-high-roll-baseline.json
+++ b/AdvanceWarsServer/test/json/co/nell/luck-normal-co-high-roll-baseline.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-normal-co-high-roll-baseline",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-normal-co-high-roll-baseline",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 78, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 36, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/nell/luck-scop-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/nell/luck-scop-high-roll.json
@@ -1,0 +1,48 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-scop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 54000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "super-co-power" },
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "nell-luck-scop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Nell", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 10800 }, "power-status": 2, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 7000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/rachel/luck-cop-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/rachel/luck-cop-high-roll.json
@@ -1,0 +1,44 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-cop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 27000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "co-power" },
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-cop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 60, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 56, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 10800 }, "power-status": 1, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 3000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/rachel/luck-d2d-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/rachel/luck-d2d-high-roll.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-d2d-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-d2d-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 78, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 36, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/rachel/luck-d2d-low-roll.json
+++ b/AdvanceWarsServer/test/json/co/rachel/luck-d2d-low-roll.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-d2d-low-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-d2d-low-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 73, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 45, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 450, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 600, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/rachel/luck-damaged-rounding.json
+++ b/AdvanceWarsServer/test/json/co/rachel/luck-damaged-rounding.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-damaged-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 55, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-damaged-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 17, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 62, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 550, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/rachel/luck-scop-high-roll.json
+++ b/AdvanceWarsServer/test/json/co/rachel/luck-scop-high-roll.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-scop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "rachel-luck-scop-high-roll",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 40, "hidden": false, "moved": true, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 86, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Rachel", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 2, "luck-policy": 2 },
+      { "armyType": "blue-moon", "co": "Andy", "funds": 0, "power-meter": { "charge": 1000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/counter-break-first-strike-counter-bonus.json
+++ b/AdvanceWarsServer/test/json/co/sonja/counter-break-first-strike-counter-bonus.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counter-break-first-strike-counter-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 2, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counter-break-first-strike-counter-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 10, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 96, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 6300, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 2, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/counterattack-cop-bonus.json
+++ b/AdvanceWarsServer/test/json/co/sonja/counterattack-cop-bonus.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-cop-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 1, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-cop-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 46, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 51, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 4900, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 1, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/counterattack-d2d-bonus.json
+++ b/AdvanceWarsServer/test/json/co/sonja/counterattack-d2d-bonus.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-d2d-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 0, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-d2d-bonus",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 59, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 45, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 4550, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 4900, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 0, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/counterattack-damaged-rounding.json
+++ b/AdvanceWarsServer/test/json/co/sonja/counterattack-damaged-rounding.json
@@ -1,0 +1,43 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-damaged-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 83, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 69, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 0, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "direction": "east", "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-damaged-rounding",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 67, "hidden": false, "moved": true, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 70, "health": 20, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 3150, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 4200, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 0, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/co/sonja/counterattack-no-counter-against-indirect.json
+++ b/AdvanceWarsServer/test/json/co/sonja/counterattack-no-counter-against-indirect.json
@@ -1,0 +1,53 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-no-counter-against-indirect",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 0, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "attack", "source": [0, 0], "target": [0, 2] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sonja-counterattack-no-counter-against-indirect",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 8, "fuel": 50, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "artillery" } }
+      ],
+      [
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 30, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 2450, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Sonja", "funds": 0, "power-meter": { "charge": 4900, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 }, "power-status": 0, "luck-policy": 3 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -20,16 +20,16 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
-- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Javier indirect-defense and Comm Tower defense modifiers, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Kanbei Samurai Spirit counterattack damage, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Javier indirect-defense and Comm Tower defense modifiers, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Kanbei Samurai Spirit counterattack damage, Sonja counterattack damage and hidden-HP API redaction, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
 ## Luck Notes
 
 - JSON combat fixtures can force deterministic luck with `"luck-policy"`: `0` uses normal RNG or `"combat-rng-seed"`, `1` forces the lowest total luck outcome, `2` forces the highest total luck outcome, and `3` forces the middle value of each luck range.
 - For bad-luck COs, the lowest total outcome uses minimum good luck and maximum bad luck; the highest total outcome uses maximum good luck and minimum bad luck.
-- Sonja's AWBW combat luck is covered separately from her information and counterattack effects: she keeps +0..+9 good luck and 0..9 bad luck in day-to-day, Enhanced Vision, and Counter Break, while COP/SCOP still use the universal AWBW +10 attack/+10 defense chart bonus.
+- Sonja keeps +0..+9 good luck and 0..9 bad luck in day-to-day, Enhanced Vision, and Counter Break, while COP/SCOP still use the universal AWBW +10 attack/+10 defense chart bonus.
 - Flak uses independent AWBW good-luck and bad-luck rolls. Day-to-day uses 0..24 good luck and 0..9 bad luck, Brute Force uses 0..49 and 0..19, and Barbaric Blow uses 0..89 and 0..39; the resulting total ranges are -9..+24, -19..+49, and -39..+89.
 - Jugger uses independent AWBW good-luck and bad-luck rolls. Day-to-day uses 0..29 good luck and 0..14 bad luck, Overclock uses 0..54 and 0..24, and System Crash uses 0..94 and 0..44; the resulting total ranges are -14..+29, -24..+54, and -44..+94.
-- Sonja's hidden HP, fog vision, day-to-day counterattack multiplier, and Counter Break first-strike edge cases remain tracked by [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89) and [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90), rather than by the combat-luck fixtures.
+- Sonja's fog-only vision effects remain tracked by [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90), rather than by the combat-luck fixtures.
 
 ## Power Meter Notes
 
@@ -67,6 +67,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Javier receives +20 defense against indirect attacks day-to-day, +40 during Tower Shield, and +80 during Tower of Power. Owned Comm Towers add +10 defense per tower day-to-day, +20 during Tower Shield, and +30 during Tower of Power. These bonuses compose with normal terrain defense.
 - Javier's fog-only vision effects remain deferred to [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90).
 - Kanbei's Samurai Spirit multiplies real counterattack damage by 1.5 after the normal combat formula has applied his SCOP attack and defense chart values. Normal attacks during Samurai Spirit and attacks that cannot receive a counterattack do not receive this extra multiplier.
+- Sonja counterattacks multiply real damage by 1.5 after her normal chart, luck, health, and defense calculations. Counter Break first-strike damage is treated as a counterattack for this multiplier; the original acting unit is still the unit marked moved. Opponent-facing `GET /games/:gameid?player=N` responses redact exact HP for enemy Sonja units with `"health": null` and `"hidden-health": true`, while no-query debug responses and Sonja's own player perspective keep authoritative HP.
 
 ## Economy Notes
 
@@ -98,6 +99,5 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89): Sonja counterattack bonus and hidden-HP API redaction.
 - [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90): fog, vision, hiding visibility, and fog-only CO effects.
 - [#99](https://github.com/ryparikh/AdvanceWarsServer/issues/99) and [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100): deterministic luck CO combat fixtures for Nell and Rachel.

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -20,7 +20,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
-- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Javier indirect-defense and Comm Tower defense modifiers, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
 ## Luck Notes
 
@@ -62,6 +62,11 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Lash receives +10 attack per attacker terrain star during day-to-day and Terrain Tactics, while Prime Tactics doubles the terrain-star attack bonus to +20 per star and doubles terrain-star defense for Lash defenders. Air units do not receive Lash's terrain-star attack or defense benefits.
 - Lash's Terrain Tactics and Prime Tactics make legal terrain movement cost 1 fuel/move point outside snow. Snow uses normal weather movement costs, and illegal terrain remains illegal.
 
+## Defense Notes
+
+- Javier receives +20 defense against indirect attacks day-to-day, +40 during Tower Shield, and +80 during Tower of Power. Owned Comm Towers add +10 defense per tower day-to-day, +20 during Tower Shield, and +30 during Tower of Power. These bonuses compose with normal terrain defense.
+- Javier's fog-only vision effects remain deferred to [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90).
+
 ## Economy Notes
 
 - Colin, Hachi, and Kanbei cost modifiers apply to unit construction. Hachi's Merchant Union uses the simulator's standard ground-production list for city deployment, matching the AWBW wiki's Piperunner note that Piperunners can be built at Bases or spawned from Cities during Hachi's SCOP.
@@ -92,7 +97,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#87](https://github.com/ryparikh/AdvanceWarsServer/issues/87): Javier indirect-defense and Comm Tower defense bonuses.
 - [#88](https://github.com/ryparikh/AdvanceWarsServer/issues/88): Kanbei Samurai Spirit counterattack bonus.
 - [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89): Sonja counterattack bonus and hidden-HP API redaction.
 - [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90): fog, vision, hiding visibility, and fog-only CO effects.

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -27,6 +27,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - JSON combat fixtures can force deterministic luck with `"luck-policy"`: `0` uses normal RNG or `"combat-rng-seed"`, `1` forces the lowest total luck outcome, `2` forces the highest total luck outcome, and `3` forces the middle value of each luck range.
 - For bad-luck COs, the lowest total outcome uses minimum good luck and maximum bad luck; the highest total outcome uses maximum good luck and minimum bad luck.
 - Nell uses positive good luck only: +0..+19 day-to-day, +0..+59 during Lady Luck, and +0..+99 during Lucky Star. Her fixtures include a standard-CO high-roll baseline plus low/high, power, super, and damaged-unit rounding coverage.
+- Rachel uses standard +0..+9 good luck day-to-day and during Covering Fire, while Lucky Lass raises combat luck to +0..+39. Her combat-luck fixtures are separate from her property-repair and missile-effect coverage.
 - Sonja keeps +0..+9 good luck and 0..9 bad luck in day-to-day, Enhanced Vision, and Counter Break, while COP/SCOP still use the universal AWBW +10 attack/+10 defense chart bonus.
 - Flak uses independent AWBW good-luck and bad-luck rolls. Day-to-day uses 0..24 good luck and 0..9 bad luck, Brute Force uses 0..49 and 0..19, and Barbaric Blow uses 0..89 and 0..39; the resulting total ranges are -9..+24, -19..+49, and -39..+89.
 - Jugger uses independent AWBW good-luck and bad-luck rolls. Day-to-day uses 0..29 good luck and 0..14 bad luck, Overclock uses 0..54 and 0..24, and System Crash uses 0..94 and 0..44; the resulting total ranges are -14..+29, -24..+54, and -44..+94.
@@ -101,4 +102,3 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
 - [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90): fog, vision, hiding visibility, and fog-only CO effects.
-- [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100): deterministic luck CO combat fixtures for Rachel.

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -20,7 +20,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
-- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Javier indirect-defense and Comm Tower defense modifiers, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Javier indirect-defense and Comm Tower defense modifiers, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Kanbei Samurai Spirit counterattack damage, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
 ## Luck Notes
 
@@ -66,6 +66,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 - Javier receives +20 defense against indirect attacks day-to-day, +40 during Tower Shield, and +80 during Tower of Power. Owned Comm Towers add +10 defense per tower day-to-day, +20 during Tower Shield, and +30 during Tower of Power. These bonuses compose with normal terrain defense.
 - Javier's fog-only vision effects remain deferred to [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90).
+- Kanbei's Samurai Spirit multiplies real counterattack damage by 1.5 after the normal combat formula has applied his SCOP attack and defense chart values. Normal attacks during Samurai Spirit and attacks that cannot receive a counterattack do not receive this extra multiplier.
 
 ## Economy Notes
 
@@ -97,7 +98,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#88](https://github.com/ryparikh/AdvanceWarsServer/issues/88): Kanbei Samurai Spirit counterattack bonus.
 - [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89): Sonja counterattack bonus and hidden-HP API redaction.
 - [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90): fog, vision, hiding visibility, and fog-only CO effects.
 - [#99](https://github.com/ryparikh/AdvanceWarsServer/issues/99) and [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100): deterministic luck CO combat fixtures for Nell and Rachel.

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -26,6 +26,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 - JSON combat fixtures can force deterministic luck with `"luck-policy"`: `0` uses normal RNG or `"combat-rng-seed"`, `1` forces the lowest total luck outcome, `2` forces the highest total luck outcome, and `3` forces the middle value of each luck range.
 - For bad-luck COs, the lowest total outcome uses minimum good luck and maximum bad luck; the highest total outcome uses maximum good luck and minimum bad luck.
+- Nell uses positive good luck only: +0..+19 day-to-day, +0..+59 during Lady Luck, and +0..+99 during Lucky Star. Her fixtures include a standard-CO high-roll baseline plus low/high, power, super, and damaged-unit rounding coverage.
 - Sonja keeps +0..+9 good luck and 0..9 bad luck in day-to-day, Enhanced Vision, and Counter Break, while COP/SCOP still use the universal AWBW +10 attack/+10 defense chart bonus.
 - Flak uses independent AWBW good-luck and bad-luck rolls. Day-to-day uses 0..24 good luck and 0..9 bad luck, Brute Force uses 0..49 and 0..19, and Barbaric Blow uses 0..89 and 0..39; the resulting total ranges are -9..+24, -19..+49, and -39..+89.
 - Jugger uses independent AWBW good-luck and bad-luck rolls. Day-to-day uses 0..29 good luck and 0..14 bad luck, Overclock uses 0..54 and 0..24, and System Crash uses 0..94 and 0..44; the resulting total ranges are -14..+29, -24..+54, and -44..+94.
@@ -100,4 +101,4 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
 - [#90](https://github.com/ryparikh/AdvanceWarsServer/issues/90): fog, vision, hiding visibility, and fog-only CO effects.
-- [#99](https://github.com/ryparikh/AdvanceWarsServer/issues/99) and [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100): deterministic luck CO combat fixtures for Nell and Rachel.
+- [#100](https://github.com/ryparikh/AdvanceWarsServer/issues/100): deterministic luck CO combat fixtures for Rachel.

--- a/CO_SUPPORT.md
+++ b/CO_SUPPORT.md
@@ -20,7 +20,7 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 - Implemented fuel-upkeep modifiers: Eagle air units consume 2 less fuel per day.
 - Implemented capture modifiers: Sami footsoldiers capture at 150% displayed HP rounded down during day-to-day and Double Time, and capture instantly during Victory March.
 - Implemented action-state effects: Eagle Lightning Strike refreshes map-present non-footsoldier units for an extra action.
-- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
+- Implemented terrain/range/luck helpers: Jake plains attack, Koal road attack, Lash terrain-star attack and Prime Tactics terrain-star defense, Grit day-to-day/COP/SCOP indirect range, Jake COP/SCOP indirect range for vehicles, Max indirect range penalty, Nell/Rachel/Flak/Jugger/Sonja luck bounds, and Sonja SCOP counter-break combat ordering.
 
 ## Luck Notes
 
@@ -57,6 +57,11 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 - Indirect range modifiers adjust maximum range only; minimum range is unchanged. Grit applies to all indirect units, Jake applies to vehicle indirects during COP/SCOP, and Max applies his -1 maximum-range penalty to indirect units without changing adjacent direct attacks.
 
+## Terrain Notes
+
+- Lash receives +10 attack per attacker terrain star during day-to-day and Terrain Tactics, while Prime Tactics doubles the terrain-star attack bonus to +20 per star and doubles terrain-star defense for Lash defenders. Air units do not receive Lash's terrain-star attack or defense benefits.
+- Lash's Terrain Tactics and Prime Tactics make legal terrain movement cost 1 fuel/move point outside snow. Snow uses normal weather movement costs, and illegal terrain remains illegal.
+
 ## Economy Notes
 
 - Colin, Hachi, and Kanbei cost modifiers apply to unit construction. Hachi's Merchant Union uses the simulator's standard ground-production list for city deployment, matching the AWBW wiki's Piperunner note that Piperunners can be built at Bases or spawned from Cities during Hachi's SCOP.
@@ -87,7 +92,6 @@ The gameplay reference for CO mechanics is the [Advance Wars By Web Wiki CO page
 
 These AWBW mechanics are not implemented yet. They are tracked as GitHub issues so the markdown is only a summary, not the source of truth.
 
-- [#86](https://github.com/ryparikh/AdvanceWarsServer/issues/86): Lash terrain-star attack and movement effects.
 - [#87](https://github.com/ryparikh/AdvanceWarsServer/issues/87): Javier indirect-defense and Comm Tower defense bonuses.
 - [#88](https://github.com/ryparikh/AdvanceWarsServer/issues/88): Kanbei Samurai Spirit counterattack bonus.
 - [#89](https://github.com/ryparikh/AdvanceWarsServer/issues/89): Sonja counterattack bonus and hidden-HP API redaction.

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,7 @@ The C++ engine is authoritative for legal actions and state transitions. REST cl
 | --- | --- | --- |
 | `POST` | `/games` | Create a Standard game from a setup payload. |
 | `GET` | `/games/:gameid` | Fetch the current authoritative game state. |
+| `GET` | `/games/:gameid?player=0` | Fetch game state for one player perspective. |
 | `GET` | `/games/:gameid/actions` | Fetch all legal actions for the active player. |
 | `GET` | `/games/:gameid/actions?x=4&y=7` | Fetch legal actions for one selected coordinate. |
 | `POST` | `/games/:gameid/actions` | Submit exactly one action. |
@@ -39,6 +40,8 @@ Supported v1 map ids are `lefty` and `mcts`.
 ## Responses
 
 Successful create returns `201 Created`, a full game-state JSON body, and `Location: /games/:gameId`. Successful get and step responses return `200 OK` with the full current game state. Game-state responses include resolved `settings` and `terminalReason`; active games use `null` for `terminalReason`.
+
+`GET /games/:gameid` without a query is the full authoritative/debug view and includes exact unit `health`. `GET /games/:gameid?player=0` or `player=1` returns a player-perspective view. In a perspective view, enemy Sonja units hide exact HP as `"health": null` with `"hidden-health": true`; the authoritative engine state and Sonja player's own view keep exact HP.
 
 Each player object includes a `power-meter` object. `cop-stars` and `scop-stars` are the CO's meter split, `charge` is current meter charge, and `star-value` is the current value of one star. `cop-threshold` and `scop-threshold` are the current charge thresholds for legal COP and SCOP actions, while `can-use-cop` and `can-use-scop` reflect whether those global power actions are currently available from meter charge.
 
@@ -92,7 +95,7 @@ Status mapping:
 - `400 Bad Request`: malformed JSON, wrong field type, invalid query shape, unknown JSON field, unknown action/unit id.
 - `404 Not Found`: unknown `gameId`.
 - `409 Conflict`: action submitted after terminal state.
-- `422 Unprocessable Entity`: valid JSON but invalid setup/action, such as unknown `mapId`, unsupported setting, unsupported CO/army, illegal action, or invalid coordinate.
+- `422 Unprocessable Entity`: valid JSON but invalid setup/action, such as unknown `mapId`, unsupported setting, unsupported CO/army, illegal action, invalid coordinate, or invalid player perspective.
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary

Implements the remaining CO support items requested in this stack:

- Lash terrain-star attack, Prime Tactics defense, and terrain movement fixtures
- Javier indirect and Comm Tower defense modifiers
- Kanbei Samurai Spirit counterattack bonus
- Sonja counterattack bonus, Counter Break ordering fixes, and hidden-HP player-perspective API redaction
- Nell deterministic luck combat coverage
- Rachel combat luck correction and deterministic fixtures

## Verification

- `MSBuild.exe AdvanceWarsServer.sln /m:1 /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `git diff --check`

Closes #86
Closes #87
Closes #88
Closes #89
Closes #99
Closes #100
