### PR TITLE
Add explicit REST end-turn regression

### DIFF
--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -97,6 +97,67 @@ json SonjaHiddenHpGameState() {
 	};
 }
 
+json OneActionBeforeEndTurnGameState() {
+	json row = json::array();
+	for (int x = 0; x < 8; ++x) {
+		row.push_back({ { "terrain", 1 } });
+	}
+
+	row.at(0)["unit"] = {
+		{ "health", 100 },
+		{ "hidden", false },
+		{ "moved", false },
+		{ "owner", "blue-moon" },
+		{ "type", "infantry" },
+	};
+	row.at(7)["unit"] = {
+		{ "health", 100 },
+		{ "hidden", false },
+		{ "moved", true },
+		{ "owner", "orange-star" },
+		{ "type", "infantry" },
+	};
+
+	return {
+		{ "activePlayer", 1 },
+		{ "cap-limit", 21 },
+		{ "game-over", false },
+		{ "gameId", "rest-explicit-end-turn" },
+		{ "map", json::array({ row }) },
+		{ "players", json::array({
+			{
+				{ "armyType", "orange-star" },
+				{ "co", "Andy" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 3 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+			{
+				{ "armyType", "blue-moon" },
+				{ "co", "Adder" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 2 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+		}) },
+		{ "turn-count", 1 },
+		{ "unit-cap", 50 },
+		{ "winner", -1 },
+	};
+}
+
 bool RunCreateGetAndLegalActionContract() {
 	RestGameService service;
 	ApiResponse create = service.CreateGame(StandardCreatePayload("mcts").dump());
@@ -299,6 +360,69 @@ bool RunStepAndErrorContract() {
 	return true;
 }
 
+bool RunExplicitEndTurnStepContract() {
+	RestGameService service;
+	json fixture = OneActionBeforeEndTurnGameState();
+	GameState gameState;
+	GameState::from_json(fixture, gameState);
+	service.StoreGameForTesting(std::move(gameState));
+
+	const std::string gameId = fixture.at("gameId").get<std::string>();
+	json lastUnitAction = {
+		{ "type", "move-wait" },
+		{ "source", json::array({ 0, 0 }) },
+		{ "target", json::array({ 0, 0 }) },
+	};
+	ApiResponse lastUnitStep = service.SubmitAction(gameId, lastUnitAction.dump());
+	if (!Expect(lastUnitStep.status == 200, "last unit step should return 200")) {
+		return false;
+	}
+	if (!Expect(lastUnitStep.body.at("activePlayer") == 1, "last unit step should not implicitly end player 2 turn")) {
+		return false;
+	}
+	if (!Expect(lastUnitStep.body.at("turn-count") == 1, "last unit step should not implicitly advance the day")) {
+		return false;
+	}
+
+	ApiResponse onlyEndTurnActions = service.ListActions(gameId, "");
+	if (!Expect(onlyEndTurnActions.status == 200, "end-turn-only legal actions should return 200")) {
+		return false;
+	}
+	if (!Expect(onlyEndTurnActions.body.at("activePlayer") == 1, "end-turn-only legal actions should keep active player")) {
+		return false;
+	}
+	if (!Expect(onlyEndTurnActions.body.at("actions").is_array() && onlyEndTurnActions.body.at("actions").size() == 1, "legal actions should contain only end-turn")) {
+		return false;
+	}
+	if (!Expect(onlyEndTurnActions.body.at("actions").front().at("type") == "end-turn", "only legal action should be end-turn")) {
+		return false;
+	}
+
+	ApiResponse afterList = service.GetGame(gameId);
+	if (!Expect(afterList.status == 200, "get after end-turn-only legal actions should return 200")) {
+		return false;
+	}
+	if (!Expect(afterList.body.at("activePlayer") == 1, "listing end-turn-only actions should not advance active player")) {
+		return false;
+	}
+	if (!Expect(afterList.body.at("turn-count") == 1, "listing end-turn-only actions should not advance the day")) {
+		return false;
+	}
+
+	ApiResponse explicitEndTurn = service.SubmitAction(gameId, R"({"type":"end-turn"})");
+	if (!Expect(explicitEndTurn.status == 200, "explicit end-turn should return 200")) {
+		return false;
+	}
+	if (!Expect(explicitEndTurn.body.at("activePlayer") == 0, "explicit end-turn should advance to player 1")) {
+		return false;
+	}
+	if (!Expect(explicitEndTurn.body.at("turn-count") == 2, "explicit player 2 end-turn should advance the day")) {
+		return false;
+	}
+
+	return true;
+}
+
 bool RunTerminalContract() {
 	RestGameService service;
 
@@ -381,6 +505,9 @@ int RunRestApiContractTests() {
 		return 1;
 	}
 	if (!RunStepAndErrorContract()) {
+		return 1;
+	}
+	if (!RunExplicitEndTurnStepContract()) {
 		return 1;
 	}
 	if (!RunTerminalContract()) {

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -63,7 +63,7 @@ Explicitly deferred modes and options:
 | --- | --- | --- | --- | --- |
 | Game lifecycle API | `POST /games` ignores request body and creates a hardcoded Lefty game. | Create/get/reset/step/terminal contract for map, players, settings, and seed. | Partial | #66 |
 | Submitted action validation | Legal actions are generated, but direct submitted actions can bypass some validation or mutate before failing. | Submitted actions are validated and rejected atomically. | Partial | #67 |
-| Step semantics | REST action application can auto-end-turn after a submitted action. | One submitted action causes exactly one committed action. | Partial | #68 |
+| Step semantics | REST action application commits exactly the submitted action and can report an `EndTurn`-only legal-action list without advancing. | One submitted action causes exactly one committed action. | Complete | #68 |
 | Terminal reasons | HQ capture, lab win, rout/fuel-out behavior exist; heuristic auto-resign also exists. | Terminal reason should be explicit: HQ, lab, rout, capture limit, day limit, timeout, resign. | Partial | #69, #74, #77, #82 |
 | State tensor | `Tensor.cpp` exists as planned home. | Deterministic current-player-relative tensor. | Partial | #3 |
 | Action encoding and masks | `Action` variants and legal action generation exist. | Stable encoded action space plus mask. | Partial | #4 |

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -99,5 +99,5 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] #65 Define and enforce normal Global League Standard game settings.
 - [ ] #66 Add REST game lifecycle and step API contract for self-play.
 - [ ] #67 Validate and atomically reject illegal submitted actions.
-- [ ] #68 Make REST action stepping explicit and remove implicit auto-end-turn.
+- [x] #68 Make REST action stepping explicit and remove implicit auto-end-turn.
 - [ ] #69 Remove heuristic auto-resign from Standard engine terminal logic.

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ Supported v1 map ids are `lefty` and `mcts`.
 
 ## Responses
 
-Successful create returns `201 Created`, a full game-state JSON body, and `Location: /games/:gameId`. Successful get and step responses return `200 OK` with the full current game state. Game-state responses include resolved `settings` and `terminalReason`; active games use `null` for `terminalReason`.
+Successful create returns `201 Created`, a full game-state JSON body, and `Location: /games/:gameId`. Successful get and step responses return `200 OK` with the full current game state. A step commits exactly the submitted action: if only `end-turn` remains legal after a unit action, the server reports that legal action and waits for the client to submit it. Game-state responses include resolved `settings` and `terminalReason`; active games use `null` for `terminalReason`.
 
 `GET /games/:gameid` without a query is the full authoritative/debug view and includes exact unit `health`. `GET /games/:gameid?player=0` or `player=1` returns a player-perspective view. In a perspective view, enemy Sonja units hide exact HP as `"health": null` with `"hidden-health": true`; the authoritative engine state and Sonja player's own view keep exact HP.
 


### PR DESCRIPTION
## Summary
- Add a REST API contract regression for the state where a submitted unit action leaves only `end-turn` legal.
- Assert the API reports the `end-turn` action without advancing active player or day, then advances only after an explicit `end-turn` submission.
- Document the exact step semantics and mark #68 complete in the local tracking docs.

## Root Cause / Notes
The current REST service already applies exactly the submitted action; the gap was missing caller-facing coverage and stale docs that still described possible auto-advance behavior.

## Tests
- Added `RunExplicitEndTurnStepContract`; it passed immediately against the current implementation, confirming no production REST change was needed.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

## Risk
Low. This is a focused contract-test and documentation update; no production code paths changed.

Closes #68