### PR TITLE
Gate heuristic auto-resign behind a setting

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -183,6 +183,9 @@ public:
 			to_json(jstate, *this);
 			std::cout << "Chose an invalid action:" << jaction.dump() << "\n" << jstate.dump() << std::endl;
 		}
+		if (actedGameState.FHeuristicAutoResign()) {
+			actedGameState.CheckPlayerResigns();
+		}
 		return actedGameState;
 	}
 
@@ -238,6 +241,12 @@ public:
 	bool AnyValidActions() const noexcept;
 	Result EndTurn() noexcept;
 	bool CheckPlayerResigns() noexcept;
+	bool FHeuristicAutoResign() const noexcept {
+		return m_fHeuristicAutoResign;
+	}
+	void SetHeuristicAutoResign(bool enabled) noexcept {
+		m_fHeuristicAutoResign = enabled;
+	}
 	bool FGameOver() const noexcept {
 		return m_fGameOver;
 	}
@@ -335,6 +344,7 @@ private:
 	std::optional<std::string> m_terminalReason;
 	std::optional<std::uint32_t> m_combatRngSeed;
 	std::optional<std::mt19937> m_combatRng;
+	bool m_fHeuristicAutoResign = false;
 	WeatherType m_weather{ WeatherType::Clear };
 	std::optional<int> m_weatherTurnsRemaining;
 };

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -183,7 +183,6 @@ public:
 			to_json(jstate, *this);
 			std::cout << "Chose an invalid action:" << jaction.dump() << "\n" << jstate.dump() << std::endl;
 		}
-		actedGameState.CheckPlayerResigns();
 		return actedGameState;
 	}
 

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -2347,6 +2347,7 @@ GameState::GameState(const GameState& other) noexcept :
 	m_terminalReason = other.m_terminalReason;
 	m_combatRngSeed = other.m_combatRngSeed;
 	m_combatRng = other.m_combatRng;
+	m_fHeuristicAutoResign = other.m_fHeuristicAutoResign;
 	m_weather = other.m_weather;
 	m_weatherTurnsRemaining = other.m_weatherTurnsRemaining;
 }
@@ -2373,6 +2374,7 @@ GameState& GameState::operator=(const GameState& other) noexcept {
 		m_terminalReason = other.m_terminalReason;
 		m_combatRngSeed = other.m_combatRngSeed;
 		m_combatRng = other.m_combatRng;
+		m_fHeuristicAutoResign = other.m_fHeuristicAutoResign;
 		m_weather = other.m_weather;
 		m_weatherTurnsRemaining = other.m_weatherTurnsRemaining;
 	}
@@ -2394,6 +2396,10 @@ void GameState::to_json(json& j, const GameState& gameState) {
 
 	if (gameState.m_combatRngSeed.has_value()) {
 		j["combat-rng-seed"] = gameState.m_combatRngSeed.value();
+	}
+
+	if (gameState.m_fHeuristicAutoResign) {
+		j["heuristic-auto-resign"] = true;
 	}
 
 	if (gameState.m_weather != WeatherType::Clear) {
@@ -2566,6 +2572,13 @@ void GameState::from_json(json& j, GameState& gameState) {
 	}
 	else {
 		gameState.ClearCombatRngSeed();
+	}
+
+	if (j.contains("heuristic-auto-resign")) {
+		j.at("heuristic-auto-resign").get_to(gameState.m_fHeuristicAutoResign);
+	}
+	else {
+		gameState.m_fHeuristicAutoResign = false;
 	}
 
 	if (j.contains("weather")) {

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -105,7 +105,6 @@ Result BuildActionTrace(GameState gameState, const std::vector<Action>& actions,
 
 	for (const Action& action : actions) {
 		IfFailedReturn(gameState.DoAction(action));
-		gameState.CheckPlayerResigns();
 
 		json actedGameState;
 		GameState::to_json(actedGameState, gameState);

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -158,6 +158,76 @@ json OneActionBeforeEndTurnGameState() {
 	};
 }
 
+json LowArmyValueNonTerminalGameState() {
+	json row = json::array();
+	for (int x = 0; x < 7; ++x) {
+		row.push_back({ { "terrain", 1 } });
+	}
+
+	row.at(0)["unit"] = {
+		{ "health", 100 },
+		{ "hidden", false },
+		{ "moved", false },
+		{ "owner", "orange-star" },
+		{ "type", "infantry" },
+	};
+	for (int x = 1; x < 5; ++x) {
+		row.at(x)["unit"] = {
+			{ "health", 100 },
+			{ "hidden", false },
+			{ "moved", false },
+			{ "owner", "blue-moon" },
+			{ "type", "tank" },
+		};
+	}
+	row.at(6) = {
+		{ "terrain", 47 },
+		{ "property", {
+			{ "capture-points", 20 },
+			{ "owner", "blue-moon" },
+		} },
+	};
+
+	return {
+		{ "activePlayer", 0 },
+		{ "cap-limit", 21 },
+		{ "game-over", false },
+		{ "gameId", "rest-no-heuristic-resign" },
+		{ "map", json::array({ row }) },
+		{ "players", json::array({
+			{
+				{ "armyType", "orange-star" },
+				{ "co", "Andy" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 3 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+			{
+				{ "armyType", "blue-moon" },
+				{ "co", "Adder" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 2 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+		}) },
+		{ "turn-count", 5 },
+		{ "unit-cap", 50 },
+		{ "winner", -1 },
+	};
+}
+
 bool RunCreateGetAndLegalActionContract() {
 	RestGameService service;
 	ApiResponse create = service.CreateGame(StandardCreatePayload("mcts").dump());
@@ -423,6 +493,36 @@ bool RunExplicitEndTurnStepContract() {
 	return true;
 }
 
+bool RunNoHeuristicResignContract() {
+	RestGameService service;
+	json fixture = LowArmyValueNonTerminalGameState();
+	GameState gameState;
+	GameState::from_json(fixture, gameState);
+	service.StoreGameForTesting(std::move(gameState));
+
+	const std::string gameId = fixture.at("gameId").get<std::string>();
+	json waitAction = {
+		{ "type", "move-wait" },
+		{ "source", json::array({ 0, 0 }) },
+		{ "target", json::array({ 0, 0 }) },
+	};
+	ApiResponse step = service.SubmitAction(gameId, waitAction.dump());
+	if (!Expect(step.status == 200, "low army value legal step should return 200")) {
+		return false;
+	}
+	if (!Expect(step.body.at("game-over") == false, "low army value alone should not end a standard game")) {
+		return false;
+	}
+	if (!Expect(step.body.at("winner") == -1, "low army value alone should not choose a winner")) {
+		return false;
+	}
+	if (!Expect(step.body.contains("terminalReason") && step.body.at("terminalReason").is_null(), "low army value alone should keep null terminalReason")) {
+		return false;
+	}
+
+	return true;
+}
+
 bool RunTerminalContract() {
 	RestGameService service;
 
@@ -508,6 +608,9 @@ int RunRestApiContractTests() {
 		return 1;
 	}
 	if (!RunExplicitEndTurnStepContract()) {
+		return 1;
+	}
+	if (!RunNoHeuristicResignContract()) {
 		return 1;
 	}
 	if (!RunTerminalContract()) {

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -243,6 +243,9 @@ bool RunCreateGetAndLegalActionContract() {
 	if (!Expect(create.body.at("settings").at("mode") == "standard", "settings mode should be standard")) {
 		return false;
 	}
+	if (!Expect(create.body.at("settings").at("heuristicAutoResign") == false, "heuristic auto-resign should default off")) {
+		return false;
+	}
 	if (!Expect(!create.body.contains("combat-rng-seed"), "create should not expose combat RNG seed")) {
 		return false;
 	}
@@ -494,6 +497,12 @@ bool RunExplicitEndTurnStepContract() {
 }
 
 bool RunNoHeuristicResignContract() {
+	json waitAction = {
+		{ "type", "move-wait" },
+		{ "source", json::array({ 0, 0 }) },
+		{ "target", json::array({ 0, 0 }) },
+	};
+
 	RestGameService service;
 	json fixture = LowArmyValueNonTerminalGameState();
 	GameState gameState;
@@ -501,11 +510,6 @@ bool RunNoHeuristicResignContract() {
 	service.StoreGameForTesting(std::move(gameState));
 
 	const std::string gameId = fixture.at("gameId").get<std::string>();
-	json waitAction = {
-		{ "type", "move-wait" },
-		{ "source", json::array({ 0, 0 }) },
-		{ "target", json::array({ 0, 0 }) },
-	};
 	ApiResponse step = service.SubmitAction(gameId, waitAction.dump());
 	if (!Expect(step.status == 200, "low army value legal step should return 200")) {
 		return false;
@@ -517,6 +521,46 @@ bool RunNoHeuristicResignContract() {
 		return false;
 	}
 	if (!Expect(step.body.contains("terminalReason") && step.body.at("terminalReason").is_null(), "low army value alone should keep null terminalReason")) {
+		return false;
+	}
+
+	RestGameService optInService;
+	json optInFixture = LowArmyValueNonTerminalGameState();
+	GameState optInGameState;
+	GameState::from_json(optInFixture, optInGameState);
+	optInGameState.SetHeuristicAutoResign(true);
+	optInService.StoreGameForTesting(std::move(optInGameState));
+
+	const std::string optInGameId = optInFixture.at("gameId").get<std::string>();
+	ApiResponse optInGet = optInService.GetGame(optInGameId);
+	if (!Expect(optInGet.status == 200, "opt-in heuristic game should be retrievable")) {
+		return false;
+	}
+	if (!Expect(optInGet.body.at("settings").at("heuristicAutoResign") == true, "opt-in heuristic setting should serialize as enabled")) {
+		return false;
+	}
+
+	ApiResponse optInStep = optInService.SubmitAction(optInGameId, waitAction.dump());
+	if (!Expect(optInStep.status == 200, "opt-in heuristic legal step should return 200")) {
+		return false;
+	}
+	if (!Expect(optInStep.body.at("game-over") == true, "opt-in heuristic should be able to end a game")) {
+		return false;
+	}
+	if (!Expect(optInStep.body.at("winner") == 1, "opt-in heuristic should choose the stronger player")) {
+		return false;
+	}
+	if (!Expect(optInStep.body.at("terminalReason") == "heuristic-resign", "opt-in heuristic should report heuristic-resign")) {
+		return false;
+	}
+
+	json createPayload = StandardCreatePayload("mcts");
+	createPayload["settings"] = { { "heuristicAutoResign", true } };
+	ApiResponse create = optInService.CreateGame(createPayload.dump());
+	if (!Expect(create.status == 201, "create should accept heuristicAutoResign setting")) {
+		return false;
+	}
+	if (!Expect(create.body.at("settings").at("heuristicAutoResign") == true, "create should return resolved opt-in heuristic setting")) {
 		return false;
 	}
 

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -31,7 +31,7 @@ constexpr std::array<MapTemplate, 2> MapTemplates{ {
 	{ "mcts", "res/AWBW/MapSources/MCTS.json" },
 } };
 
-json StandardSettingsJson() {
+json StandardSettingsJson(bool heuristicAutoResign = false) {
 	return {
 		{ "mode", "standard" },
 		{ "fog", false },
@@ -43,6 +43,7 @@ json StandardSettingsJson() {
 		{ "unitCap", 50 },
 		{ "captureLimit", 21 },
 		{ "bannedUnits", json::array({ "blackbomb" }) },
+		{ "heuristicAutoResign", heuristicAutoResign },
 	};
 }
 
@@ -161,7 +162,7 @@ ApiResponse ValidateSettings(const json& request) {
 	}
 
 	std::string invalidField;
-	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "bannedUnits" }, invalidField)) {
+	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "bannedUnits", "heuristicAutoResign" }, invalidField)) {
 		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown settings field.", { { "field", "settings." + invalidField } });
 	}
 
@@ -196,19 +197,24 @@ ApiResponse ValidateSettings(const json& request) {
 		if (settings.contains("bannedUnits") && !IsStandardBannedUnits(settings.at("bannedUnits"))) {
 			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only the standard blackbomb ban is supported.", { { "field", "settings.bannedUnits" }, { "value", settings.at("bannedUnits") } });
 		}
+		if (settings.contains("heuristicAutoResign") && !settings.at("heuristicAutoResign").is_boolean()) {
+			return ErrorResponse(HttpBadRequest, "invalid-field", "heuristicAutoResign must be a boolean.", { { "field", "settings.heuristicAutoResign" } });
+		}
 	}
 	catch (const std::exception&) {
 		return ErrorResponse(HttpBadRequest, "invalid-field", "settings contains a value with the wrong type.", { { "field", "settings" } });
 	}
 
-	return JsonResponse(HttpOk, StandardSettingsJson());
+	const bool heuristicAutoResign = settings.contains("heuristicAutoResign") && settings.at("heuristicAutoResign").get<bool>();
+	return JsonResponse(HttpOk, StandardSettingsJson(heuristicAutoResign));
 }
 
 json SerializeGameForApi(const GameState& gameState) {
 	json game;
 	GameState::to_json(game, gameState);
 	game.erase("combat-rng-seed");
-	game["settings"] = StandardSettingsJson();
+	game.erase("heuristic-auto-resign");
+	game["settings"] = StandardSettingsJson(gameState.FHeuristicAutoResign());
 	if (gameState.GetTerminalReason().has_value()) {
 		game["terminalReason"] = gameState.GetTerminalReason().value();
 	}
@@ -404,6 +410,7 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 	if (settingsValidation.status != HttpOk) {
 		return settingsValidation;
 	}
+	const bool heuristicAutoResign = settingsValidation.body.at("heuristicAutoResign").get<bool>();
 
 	std::fstream filestream(mapTemplate->path, std::ios::in);
 	if (filestream.fail() || filestream.eof()) {
@@ -475,6 +482,7 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 		}
 		gameState.SetCombatRngSeed(request.at("seed").get<std::uint32_t>());
 	}
+	gameState.SetHeuristicAutoResign(heuristicAutoResign);
 
 	if (gameState.StartFirstTurn() == Result::Failed) {
 		return ErrorResponse(HttpInternalServerError, "game-initialization-failed", "Game could not run the opening turn start.", { { "mapId", mapId } });
@@ -576,6 +584,10 @@ ApiResponse RestGameService::SubmitAction(const std::string& gameId, const std::
 
 	if (game->second->DoAction(action) == Result::Failed) {
 		return ErrorResponseWithGame(HttpUnprocessableEntity, "illegal-action", "Action failed during execution.", currentGame);
+	}
+
+	if (game->second->FHeuristicAutoResign()) {
+		game->second->CheckPlayerResigns();
 	}
 
 	return JsonResponse(HttpOk, SerializeGameForApi(*game->second));

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -578,7 +578,6 @@ ApiResponse RestGameService::SubmitAction(const std::string& gameId, const std::
 		return ErrorResponseWithGame(HttpUnprocessableEntity, "illegal-action", "Action failed during execution.", currentGame);
 	}
 
-	game->second->CheckPlayerResigns();
 	return JsonResponse(HttpOk, SerializeGameForApi(*game->second));
 }
 

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -64,7 +64,7 @@ Explicitly deferred modes and options:
 | Game lifecycle API | `POST /games` ignores request body and creates a hardcoded Lefty game. | Create/get/reset/step/terminal contract for map, players, settings, and seed. | Partial | #66 |
 | Submitted action validation | Legal actions are generated, but direct submitted actions can bypass some validation or mutate before failing. | Submitted actions are validated and rejected atomically. | Partial | #67 |
 | Step semantics | REST action application commits exactly the submitted action and can report an `EndTurn`-only legal-action list without advancing. | One submitted action causes exactly one committed action. | Complete | #68 |
-| Terminal reasons | HQ capture, lab win, rout/fuel-out behavior exist. Canonical Standard/API stepping does not auto-resign by heuristic army value. | Terminal reason should be explicit: HQ, lab, rout, capture limit, day limit, timeout, resign. | Partial | #74, #77, #82 |
+| Terminal reasons | HQ capture, lab win, rout/fuel-out behavior exist. Canonical Standard/API stepping does not auto-resign by heuristic army value unless `heuristicAutoResign` is explicitly enabled. | Terminal reason should be explicit: HQ, lab, rout, capture limit, day limit, timeout, resign, or opt-in heuristic resign. | Partial | #74, #77, #82 |
 | State tensor | `Tensor.cpp` exists as planned home. | Deterministic current-player-relative tensor. | Partial | #3 |
 | Action encoding and masks | `Action` variants and legal action generation exist. | Stable encoded action space plus mask. | Partial | #4 |
 | MCTS sequence handling | Existing MCTS needs action-level self-play cleanup. | Same-player action sequences backed up correctly until `EndTurn`. | Partial | #5 |
@@ -88,7 +88,7 @@ Explicitly deferred modes and options:
 | Black Bomb explode | Black Bomb movement/fuel/no-weapon fixtures exist; explosion action is absent. | Black Bomb explosion if predeployed/custom games need it; production banned in Standard. | Deferred from production, incomplete as unit behavior | #33, #75 |
 | Missile silo launch | Terrain exists, but launch behavior is incomplete. | Launch action, empty silo state, damage area, legal action generation. | Partial | #42 |
 | Resign/delete | Explicit player actions do not exist yet. | Explicit resign and delete-unit actions if AWBW permits delete. | Partial | #77 |
-| Heuristic auto-resign | Canonical Standard/API and MCTS-style `applyAction` paths do not call the army-value resign heuristic; experimental random simulation still opts in explicitly. | Standard terminal logic should not auto-resign except through explicit/tracked rules. | Complete | none |
+| Heuristic auto-resign | Canonical Standard/API and MCTS-style `applyAction` paths call the army-value resign heuristic only when `heuristicAutoResign` is explicitly enabled; it defaults off. | Standard terminal logic should not auto-resign except through explicit/tracked rules. | Complete | none |
 
 ## Units
 

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -64,7 +64,7 @@ Explicitly deferred modes and options:
 | Game lifecycle API | `POST /games` ignores request body and creates a hardcoded Lefty game. | Create/get/reset/step/terminal contract for map, players, settings, and seed. | Partial | #66 |
 | Submitted action validation | Legal actions are generated, but direct submitted actions can bypass some validation or mutate before failing. | Submitted actions are validated and rejected atomically. | Partial | #67 |
 | Step semantics | REST action application commits exactly the submitted action and can report an `EndTurn`-only legal-action list without advancing. | One submitted action causes exactly one committed action. | Complete | #68 |
-| Terminal reasons | HQ capture, lab win, rout/fuel-out behavior exist; heuristic auto-resign also exists. | Terminal reason should be explicit: HQ, lab, rout, capture limit, day limit, timeout, resign. | Partial | #69, #74, #77, #82 |
+| Terminal reasons | HQ capture, lab win, rout/fuel-out behavior exist. Canonical Standard/API stepping does not auto-resign by heuristic army value. | Terminal reason should be explicit: HQ, lab, rout, capture limit, day limit, timeout, resign. | Partial | #74, #77, #82 |
 | State tensor | `Tensor.cpp` exists as planned home. | Deterministic current-player-relative tensor. | Partial | #3 |
 | Action encoding and masks | `Action` variants and legal action generation exist. | Stable encoded action space plus mask. | Partial | #4 |
 | MCTS sequence handling | Existing MCTS needs action-level self-play cleanup. | Same-player action sequences backed up correctly until `EndTurn`. | Partial | #5 |
@@ -87,8 +87,8 @@ Explicitly deferred modes and options:
 | CO power actions | Power gates, spending, meter math, many direct effects, and mass effects are covered. | Full CO behavior. | Partial | #83, #84, #86, #87, #88, #89, #99, #100, #101, #102, #103 |
 | Black Bomb explode | Black Bomb movement/fuel/no-weapon fixtures exist; explosion action is absent. | Black Bomb explosion if predeployed/custom games need it; production banned in Standard. | Deferred from production, incomplete as unit behavior | #33, #75 |
 | Missile silo launch | Terrain exists, but launch behavior is incomplete. | Launch action, empty silo state, damage area, legal action generation. | Partial | #42 |
-| Resign/delete | Heuristic resign exists; explicit player actions do not. | Explicit resign and delete-unit actions if AWBW permits delete. | Partial | #77 |
-| Heuristic auto-resign | Engine can defeat a player by army-value heuristic. | Standard terminal logic should not auto-resign except through explicit/tracked rules. | Partial | #69 |
+| Resign/delete | Explicit player actions do not exist yet. | Explicit resign and delete-unit actions if AWBW permits delete. | Partial | #77 |
+| Heuristic auto-resign | Canonical Standard/API and MCTS-style `applyAction` paths do not call the army-value resign heuristic; experimental random simulation still opts in explicitly. | Standard terminal logic should not auto-resign except through explicit/tracked rules. | Complete | none |
 
 ## Units
 
@@ -183,7 +183,6 @@ Standard API, settings, and terminal behavior:
 - #66: Add REST game lifecycle and step API contract for self-play.
 - #67: Validate and atomically reject illegal submitted actions.
 - #68: Make REST action stepping explicit and remove implicit auto-end-turn.
-- #69: Remove heuristic auto-resign from Standard engine terminal logic.
 - #70: Support AWBW map imports with all two-player country identities.
 - #74: Implement day-limit victory and draw resolution.
 - #75: Add game setup support for unit bans and the Standard Black Bomb ban.

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -100,4 +100,4 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] #66 Add REST game lifecycle and step API contract for self-play.
 - [ ] #67 Validate and atomically reject illegal submitted actions.
 - [x] #68 Make REST action stepping explicit and remove implicit auto-end-turn.
-- [ ] #69 Remove heuristic auto-resign from Standard engine terminal logic.
+- [x] #69 Remove heuristic auto-resign from Standard engine terminal logic.

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -100,4 +100,4 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] #66 Add REST game lifecycle and step API contract for self-play.
 - [ ] #67 Validate and atomically reject illegal submitted actions.
 - [x] #68 Make REST action stepping explicit and remove implicit auto-end-turn.
-- [x] #69 Remove heuristic auto-resign from Standard engine terminal logic.
+- [x] #69 Gate heuristic auto-resign behind an explicit setting that defaults off.

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,7 +33,7 @@ Minimal request:
 }
 ```
 
-`settings` is optional. If present, `mode` belongs inside `settings`; v1 accepts only strict Standard values. `seed` is optional and request-only: it enables deterministic combat RNG but is not returned in normal API game-state responses.
+`settings` is optional. If present, `mode` belongs inside `settings`; v1 accepts only strict Standard values. `settings.heuristicAutoResign` is a training/early-stop option that defaults to `false`; when set to `true`, the existing army-value heuristic can end a game with `terminalReason: "heuristic-resign"` after a legal step. `seed` is optional and request-only: it enables deterministic combat RNG but is not returned in normal API game-state responses.
 
 Supported v1 map ids are `lefty` and `mcts`.
 

--- a/docs/ISSUE_66_REST_CONTRACT_PLAN.md
+++ b/docs/ISSUE_66_REST_CONTRACT_PLAN.md
@@ -46,7 +46,7 @@ This file captures the issue #66 REST contract decisions from the design intervi
 - Illegal action returns non-2xx error plus current authoritative game state.
 - Error responses use status codes plus stable `error.code`.
 - REST step validates against generated legal actions before mutation and applies exactly one action.
-- Add `terminalReason`; canonical Standard/API responses should report real terminal rules, not heuristic army-value resigns.
+- Add `terminalReason`; canonical Standard/API responses should report real terminal rules unless the caller opts into `settings.heuristicAutoResign`.
 - Fix `Action::operator==` to include `unloadIndex`.
 - Unknown ids and unknown JSON fields are parse/validation errors, not silent `Invalid` enums or ignored extras.
 - Opened #138 for configurable training-only heuristic resign or early stopping.
@@ -85,10 +85,13 @@ Resolved v1 settings:
     "incomePerProperty": 1000,
     "unitCap": 50,
     "captureLimit": 21,
-    "bannedUnits": ["blackbomb"]
+    "bannedUnits": ["blackbomb"],
+    "heuristicAutoResign": false
   }
 }
 ```
+
+`heuristicAutoResign` defaults to `false`. It may be set to `true` for training/early-stop runs that intentionally want the army-value heuristic to produce `terminalReason: "heuristic-resign"` after legal steps.
 
 Do not include day limit, timer/live settings, lab units, High Funds, tag COs, random weather, or fog metadata in v1. Reject those if submitted.
 

--- a/docs/ISSUE_66_REST_CONTRACT_PLAN.md
+++ b/docs/ISSUE_66_REST_CONTRACT_PLAN.md
@@ -46,10 +46,10 @@ This file captures the issue #66 REST contract decisions from the design intervi
 - Illegal action returns non-2xx error plus current authoritative game state.
 - Error responses use status codes plus stable `error.code`.
 - REST step validates against generated legal actions before mutation and applies exactly one action.
-- Add `terminalReason`, including `heuristic-resign` for current heuristic behavior.
+- Add `terminalReason`; canonical Standard/API responses should report real terminal rules, not heuristic army-value resigns.
 - Fix `Action::operator==` to include `unloadIndex`.
 - Unknown ids and unknown JSON fields are parse/validation errors, not silent `Invalid` enums or ignored extras.
-- Opened #138 for configurable heuristic resign.
+- Opened #138 for configurable training-only heuristic resign or early stopping.
 - Opened #139 for full map catalog expansion.
 - Opened #140 for explicit or randomized starting player setup.
 - Opened #141 for game cache persistence, cleanup, or TTL policy.


### PR DESCRIPTION
## Summary
- Add a `settings.heuristicAutoResign` option that defaults to `false` in resolved REST settings.
- Keep canonical Standard/API stepping from auto-resigning by army value unless that setting is explicitly enabled.
- Preserve the existing heuristic as an opt-in early-stop/training behavior; when enabled it can produce `terminalReason: "heuristic-resign"` after a legal step.
- Add REST contract regression coverage for default-off behavior, opt-in behavior, and create-time settings round-trip.
- Update API and roadmap docs to describe the setting.

## Root Cause
`GameState::applyAction`, REST `SubmitAction`, and deterministic replay trace generation called `CheckPlayerResigns()` after otherwise legal actions. That made the heuristic part of the canonical path even though it is not an AWBW Standard terminal rule. The desired behavior is to keep the heuristic available, but only behind an explicit setting that defaults off.

## Tests
- Added failing-first REST contract regression: before implementation it failed because `GameState` did not expose `SetHeuristicAutoResign` and `settings.heuristicAutoResign` was not accepted/serialized.
- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

## Residual Risk
This is a small settings bridge rather than the full game-settings model tracked separately. The heuristic remains intentionally available for explicit early-stop callers.

Closes #69