### PR TITLE
Validate submitted actions atomically

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -295,6 +295,7 @@ private:
 	Result DoRepairAction(int x, int y, const Action& action);
 	Result DoCOPowerAction();
 	Result DoSCOPowerAction();
+	Result ExecuteAction(const Action& action) noexcept;
 	Result ResupplyPlayersUnits(const Player* player);
 	int calculateDamage(const Player* pattackingplayer, const Player* pdefendingplayer, const CommandingOfficier::Type& attackerCO, const CommandingOfficier::Type& defenderCO, const Unit& attacker, const Unit& defender, const Terrain& attackerTerrain, const Terrain& defenderTerrain, bool fCounterAttack);
 	int GetCOTerrainModifier(const Player& player, const CommandingOfficier::Type& co, const Unit& unit, const Terrain& terrain) const noexcept;

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -720,8 +720,8 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 		return Result::Succeeded;
 	}
 
-	const MapTile* pmaptile;
-	m_spmap->TryGetTile(x, y, &pmaptile);
+	const MapTile* pmaptile = nullptr;
+	IfFailedReturn(m_spmap->TryGetTile(x, y, &pmaptile));
 	const Unit* pUnit = pmaptile->TryGetUnit();
 	const Terrain& terrain = pmaptile->GetTerrain();
 
@@ -957,6 +957,26 @@ bool GameState::AnyValidActions() const noexcept {
 }
 
 Result GameState::DoAction(const Action& action) noexcept {
+	std::vector<Action> vecActions;
+	if (!action.m_optSource.has_value()) {
+		IfFailedReturn(GetValidActions(vecActions));
+	}
+	else {
+		const std::pair<int, int>& source = action.m_optSource.value();
+		IfFailedReturn(GetValidActions(source.first, source.second, vecActions));
+	}
+
+	if (std::find(vecActions.begin(), vecActions.end(), action) == vecActions.end()) {
+		return Result::Failed;
+	}
+
+	GameState actedGameState{ Clone() };
+	IfFailedReturn(actedGameState.ExecuteAction(action));
+	*this = actedGameState;
+	return Result::Succeeded;
+}
+
+Result GameState::ExecuteAction(const Action& action) noexcept {
 	if (m_fGameOver) {
 		return Result::Failed;
 	}
@@ -975,20 +995,8 @@ Result GameState::DoAction(const Action& action) noexcept {
 	}
 
 	const std::pair<int, int>& source = action.m_optSource.value();
-	std::vector<Action> vecActions;
 	int x = source.first;
 	int y = source.second;
-	GetValidActions(x, y, vecActions);
-	bool fValid = false;
-	for (const Action& validAction : vecActions) {
-		if (validAction == action) {
-			fValid = true;
-		}
-	}
-
-	if (!fValid) {
-		return Result::Failed;
-	}
 
 	switch (action.m_type) {
 	default:
@@ -998,10 +1006,10 @@ Result GameState::DoAction(const Action& action) noexcept {
 	case Action::Type::Buy:
 		return DoBuyAction(x, y, action);
 	case Action::Type::MoveAttack:
-		DoMoveAction(x, y, action);
+		IfFailedReturn(DoMoveAction(x, y, action));
 		return DoAttackAction(x, y, action);
 	case Action::Type::MoveCapture:
-		DoMoveAction(x, y, action);
+		IfFailedReturn(DoMoveAction(x, y, action));
 		return DoCaptureAction(x, y, action);
 	case Action::Type::MoveCombine:
 		return DoMoveCombineAction(x, y, action);

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -226,7 +226,16 @@ Result JsonTestRunner::run() {
 
 	if (!test.vecFailedActions.empty()) {
 		for (const Action& action : test.vecFailedActions) {
+			json beforeState;
+			GameState::to_json(beforeState, test.initialGameState);
 			if (test.initialGameState.DoAction(action) == Result::Succeeded) {
+				return Result::Failed;
+			}
+			json afterState;
+			GameState::to_json(afterState, test.initialGameState);
+			m_strExpected = beforeState.dump();
+			m_strActual = afterState.dump();
+			if (m_strActual != m_strExpected) {
 				return Result::Failed;
 			}
 		}

--- a/AdvanceWarsServer/src/Map.cpp
+++ b/AdvanceWarsServer/src/Map.cpp
@@ -139,6 +139,7 @@ Result Map::TryDestroyUnit(unsigned int x, unsigned int y) noexcept {
 
 Map* Map::Clone(const std::array<Player, 2>& arrPlayers) const {
 	std::unique_ptr<Map> spNewMap{ new Map() };
+	spNewMap->m_fHasHeadquarters = m_fHasHeadquarters;
 	spNewMap->m_vecvecMapTile.reserve(GetRows());
 	for (int y = 0; y < GetRows(); ++y) {
 		std::vector<MapTile> vecCloneTiles;

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -228,6 +228,179 @@ json LowArmyValueNonTerminalGameState() {
 	};
 }
 
+json InvalidActionRejectionGameState() {
+	json map = json::array({
+		json::array({
+			{
+				{ "terrain", 15 },
+				{ "unit", {
+					{ "ammo", 0 },
+					{ "fuel", 99 },
+					{ "health", 100 },
+					{ "hidden", false },
+					{ "moved", false },
+					{ "owner", "orange-star" },
+					{ "type", "infantry" },
+				} },
+			},
+			{ { "terrain", 15 } },
+			{ { "terrain", 15 } },
+			{ { "terrain", 15 } },
+			{ { "terrain", 15 } },
+		}),
+		json::array({
+			{
+				{ "terrain", 15 },
+				{ "unit", {
+					{ "ammo", 9 },
+					{ "fuel", 50 },
+					{ "health", 100 },
+					{ "hidden", false },
+					{ "moved", false },
+					{ "owner", "orange-star" },
+					{ "type", "artillery" },
+				} },
+			},
+			{ { "terrain", 15 } },
+			{
+				{ "terrain", 15 },
+				{ "unit", {
+					{ "ammo", 0 },
+					{ "fuel", 60 },
+					{ "health", 100 },
+					{ "hidden", false },
+					{ "loaded-units", json::array({
+						{
+							{ "ammo", 0 },
+							{ "fuel", 99 },
+							{ "health", 100 },
+							{ "hidden", false },
+							{ "moved", true },
+							{ "owner", "orange-star" },
+							{ "type", "infantry" },
+						},
+					}) },
+					{ "moved", false },
+					{ "owner", "orange-star" },
+					{ "type", "apc" },
+				} },
+			},
+			{
+				{ "terrain", 15 },
+				{ "unit", {
+					{ "ammo", 0 },
+					{ "fuel", 99 },
+					{ "health", 100 },
+					{ "hidden", false },
+					{ "moved", false },
+					{ "owner", "orange-star" },
+					{ "type", "infantry" },
+				} },
+			},
+			{ { "terrain", 15 } },
+		}),
+		json::array({
+			{
+				{ "terrain", 34 },
+				{ "property", {
+					{ "capture-points", 20 },
+					{ "owner", "blue-moon" },
+				} },
+				{ "unit", {
+					{ "ammo", 9 },
+					{ "fuel", 70 },
+					{ "health", 100 },
+					{ "hidden", false },
+					{ "moved", false },
+					{ "owner", "orange-star" },
+					{ "type", "tank" },
+				} },
+			},
+			{ { "terrain", 15 } },
+			{ { "terrain", 15 } },
+			{ { "terrain", 15 } },
+			{
+				{ "terrain", 35 },
+				{ "property", {
+					{ "capture-points", 20 },
+					{ "owner", "orange-star" },
+				} },
+			},
+		}),
+	});
+
+	return {
+		{ "activePlayer", 0 },
+		{ "cap-limit", 21 },
+		{ "game-over", false },
+		{ "gameId", "rest-invalid-action-rejection" },
+		{ "map", map },
+		{ "players", json::array({
+			{
+				{ "armyType", "orange-star" },
+				{ "co", "Andy" },
+				{ "funds", 5000 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 3 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+			{
+				{ "armyType", "blue-moon" },
+				{ "co", "Adder" },
+				{ "funds", 0 },
+				{ "power-meter", {
+					{ "charge", 0 },
+					{ "cop-stars", 2 },
+					{ "scop-stars", 3 },
+					{ "star-value", 9000 },
+				} },
+				{ "power-status", 0 },
+				{ "luck-policy", 1 },
+			},
+		}) },
+		{ "turn-count", 1 },
+		{ "unit-cap", 50 },
+		{ "winner", -1 },
+	};
+}
+
+bool ExpectIllegalActionRejectedAtomically(RestGameService& service, const std::string& gameId, const json& action, const std::string& description) {
+	ApiResponse before = service.GetGame(gameId);
+	if (!Expect(before.status == 200, description + " setup should be retrievable")) {
+		return false;
+	}
+
+	const std::string beforeDump = before.body.dump();
+	ApiResponse illegal = service.SubmitAction(gameId, action.dump());
+	if (!Expect(illegal.status == 422, description + " should return 422")) {
+		return false;
+	}
+	if (!Expect(illegal.body.at("error").at("code") == "illegal-action", description + " should use illegal-action code")) {
+		return false;
+	}
+	if (!Expect(illegal.body.contains("game"), description + " should return the current game")) {
+		return false;
+	}
+	if (!Expect(illegal.body.at("game").dump() == beforeDump, description + " response game should be unchanged")) {
+		return false;
+	}
+
+	ApiResponse after = service.GetGame(gameId);
+	if (!Expect(after.status == 200, description + " post-check should be retrievable")) {
+		return false;
+	}
+	if (!Expect(after.body.dump() == beforeDump, description + " should not mutate stored game state")) {
+		return false;
+	}
+
+	return true;
+}
+
 bool RunCreateGetAndLegalActionContract() {
 	RestGameService service;
 	ApiResponse create = service.CreateGame(StandardCreatePayload("mcts").dump());
@@ -427,6 +600,65 @@ bool RunStepAndErrorContract() {
 
 	ApiResponse invalidPayload = service.SubmitAction(gameId, R"({"type":"end-turn","unexpected":true})");
 	if (!Expect(invalidPayload.status == 400, "unknown action field should return 400")) {
+		return false;
+	}
+
+	return true;
+}
+
+bool RunInvalidActionAtomicRejectionContract() {
+	RestGameService service;
+	json fixture = InvalidActionRejectionGameState();
+	GameState gameState;
+	GameState::from_json(fixture, gameState);
+	service.StoreGameForTesting(std::move(gameState));
+
+	const std::string gameId = fixture.at("gameId").get<std::string>();
+
+	if (!ExpectIllegalActionRejectedAtomically(service, gameId, {
+		{ "type", "move-wait" },
+		{ "source", json::array({ 0, 0 }) },
+		{ "target", json::array({ 4, 0 }) },
+	}, "invalid move")) {
+		return false;
+	}
+
+	if (!ExpectIllegalActionRejectedAtomically(service, gameId, {
+		{ "type", "attack" },
+		{ "source", json::array({ 0, 1 }) },
+		{ "target", json::array({ 1, 1 }) },
+	}, "invalid attack")) {
+		return false;
+	}
+
+	if (!ExpectIllegalActionRejectedAtomically(service, gameId, {
+		{ "type", "unload" },
+		{ "source", json::array({ 2, 1 }) },
+		{ "direction", "east" },
+		{ "unloadIndex", 0 },
+	}, "invalid unload")) {
+		return false;
+	}
+
+	if (!ExpectIllegalActionRejectedAtomically(service, gameId, {
+		{ "type", "buy" },
+		{ "source", json::array({ 4, 2 }) },
+		{ "unit", "tank" },
+	}, "invalid buy")) {
+		return false;
+	}
+
+	if (!ExpectIllegalActionRejectedAtomically(service, gameId, {
+		{ "type", "move-capture" },
+		{ "source", json::array({ 0, 2 }) },
+		{ "target", json::array({ 0, 2 }) },
+	}, "invalid capture")) {
+		return false;
+	}
+
+	if (!ExpectIllegalActionRejectedAtomically(service, gameId, {
+		{ "type", "co-power" },
+	}, "invalid power")) {
 		return false;
 	}
 
@@ -649,6 +881,9 @@ int RunRestApiContractTests() {
 		return 1;
 	}
 	if (!RunStepAndErrorContract()) {
+		return 1;
+	}
+	if (!RunInvalidActionAtomicRejectionContract()) {
 		return 1;
 	}
 	if (!RunExplicitEndTurnStepContract()) {

--- a/AdvanceWarsServer/src/Unit.cpp
+++ b/AdvanceWarsServer/src/Unit.cpp
@@ -66,6 +66,7 @@ Unit::Unit(const UnitProperties::Type& type, const Player* owner): m_owner(owner
 
 Unit* Unit::Clone(const Player* pNewOwner) const {
 	std::unique_ptr<Unit> spClone(new Unit(m_properties.m_type, pNewOwner));
+	spClone->m_properties = m_properties;
 	spClone->health = health;
 	spClone->m_moved = m_moved;
 	spClone->m_hidden = m_hidden;

--- a/AdvanceWarsServer/test/json/action-validation/invalid-actions-atomic.json
+++ b/AdvanceWarsServer/test/json/action-validation/invalid-actions-atomic.json
@@ -1,0 +1,65 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "invalid-actions-atomic",
+    "map": [
+      [
+        {
+          "terrain": 15,
+          "unit": {
+            "ammo": 0,
+            "fuel": 99,
+            "health": 100,
+            "hidden": false,
+            "moved": false,
+            "owner": "orange-star",
+            "type": "infantry"
+          }
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "luck-policy": 1,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    {
+      "type": "move-wait",
+      "source": [999, 999],
+      "target": [0, 0]
+    },
+    {
+      "type": "co-power"
+    }
+  ]
+}

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -55,9 +55,7 @@ Use `failedActions` to assert that actions are rejected from the initial state.
 }
 ```
 
-Each action must return `Result::Failed`.
-
-Important: current invalid-action behavior is not fully atomic in all paths. If a fixture checks multiple `failedActions`, keep them independent from the same initial state and watch #67 for the broader validation cleanup.
+Each action must return `Result::Failed` and leave the serialized game state unchanged.
 
 ### Valid Actions Fixture
 


### PR DESCRIPTION
## Summary
- Validate submitted `DoAction` requests against generated legal actions before execution.
- Execute validated actions on a cloned game state and commit only on success so failed execution cannot partially mutate the authoritative state.
- Preserve mutable clone state for units and map HQ metadata so transactional execution matches existing mechanics.
- Add REST coverage for invalid move, attack, unload, buy, capture, and power submissions, plus an engine JSON fixture for failed-action atomicity.

## Root Cause
Invalid source coordinates and late execution failures were not treated as a single atomic action contract. `DoAction` could enter execution paths after only partial validation, and the JSON failed-action runner only checked for `Result::Failed`, not whether state changed.

## Tests
- Failing before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/action-validation` returned exit code 1 after adding the new invalid-action fixture.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/action-validation`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

## Risk
`DoAction` now clones before committing a valid action, so there may be a performance cost for simulation-heavy callers. The full JSON suite and REST contract suite pass with the clone preservation fixes included.

Closes #67