### PR TITLE
Define Standard game settings enforcement

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <optional>
 #include <random>
+#include <string>
+#include <vector>
 
 #include "Map.h"
 #include "Player.h"
@@ -159,6 +161,21 @@ public:
 		Snow,
 	};
 
+	struct GameSettings {
+		std::string m_mode{ "standard" };
+		bool m_fog{ false };
+		WeatherType m_weather{ WeatherType::Clear };
+		bool m_coPowers{ true };
+		bool m_tags{ false };
+		int m_startingFunds{ 0 };
+		int m_incomePerProperty{ 1000 };
+		int m_unitCap{ 50 };
+		int m_captureLimit{ 21 };
+		std::optional<int> m_dayLimit;
+		std::vector<UnitProperties::Type> m_bannedUnits{ UnitProperties::Type::BlackBomb };
+		bool m_heuristicAutoResign{ false };
+	};
+
 	GameState() noexcept;
 	GameState(std::string guid, std::array<Player, 2>&& arrPlayers) noexcept;
 	GameState(const GameState& other) noexcept;
@@ -242,10 +259,10 @@ public:
 	Result EndTurn() noexcept;
 	bool CheckPlayerResigns() noexcept;
 	bool FHeuristicAutoResign() const noexcept {
-		return m_fHeuristicAutoResign;
+		return m_settings.m_heuristicAutoResign;
 	}
 	void SetHeuristicAutoResign(bool enabled) noexcept {
-		m_fHeuristicAutoResign = enabled;
+		m_settings.m_heuristicAutoResign = enabled;
 	}
 	bool FGameOver() const noexcept {
 		return m_fGameOver;
@@ -258,6 +275,12 @@ public:
 	bool FEnemyHasLabs() const noexcept;
 	void SetCombatRngSeed(std::uint32_t seed);
 	void ClearCombatRngSeed() noexcept;
+	const GameSettings& GetSettings() const noexcept {
+		return m_settings;
+	}
+	void SetSettings(const GameSettings& settings) noexcept {
+		m_settings = settings;
+	}
 	static void to_json(json& j, const GameState& gameState);
 	static void from_json(json& j, GameState& gameState);
 private:
@@ -308,7 +331,9 @@ private:
 	int CountOwnedComTowers(const Player& player) const noexcept;
 	int CountOwnedProperties(const Player& player) const noexcept;
 	bool FCanProduceUnitFromTerrain(const Player& player, Terrain::Type terrainType, UnitProperties::Type unitType) const noexcept;
+	bool FUnitBanned(UnitProperties::Type unitType) const noexcept;
 	int PlayerIndex(const Player& player) const noexcept;
+	Result ResolveDayLimit() noexcept;
 
 	int GetMaxGoodLuck(const Player& player) noexcept;
 	int GetMaxBadLuck(const Player& player) noexcept;
@@ -336,8 +361,7 @@ private:
 	std::string m_guid;
 	std::unique_ptr<Map> m_spmap;
 	std::array<Player, 2> m_arrPlayers;
-	int m_nUnitCap = 50;
-	int m_nCaptureLimit = 21;
+	GameSettings m_settings;
 	int m_nTurnCount = 0;
 	bool m_isFirstPlayerTurn{ true };
 	bool m_fGameOver = false;
@@ -345,7 +369,6 @@ private:
 	std::optional<std::string> m_terminalReason;
 	std::optional<std::uint32_t> m_combatRngSeed;
 	std::optional<std::mt19937> m_combatRng;
-	bool m_fHeuristicAutoResign = false;
 	WeatherType m_weather{ WeatherType::Clear };
 	std::optional<int> m_weatherTurnsRemaining;
 };

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -44,6 +44,104 @@ GameState::WeatherType WeatherTypeFromString(const std::string& weather) {
 	throw std::invalid_argument("Unknown weather: " + weather);
 }
 
+json GameSettingsToJson(const GameState::GameSettings& settings) {
+	json bannedUnits = json::array();
+	for (UnitProperties::Type unitType : settings.m_bannedUnits) {
+		bannedUnits.push_back(UnitProperties::getTypename(unitType));
+	}
+
+	json dayLimit = nullptr;
+	if (settings.m_dayLimit.has_value()) {
+		dayLimit = settings.m_dayLimit.value();
+	}
+
+	return {
+		{ "mode", settings.m_mode },
+		{ "fog", settings.m_fog },
+		{ "weather", WeatherTypeToString(settings.m_weather) },
+		{ "coPowers", settings.m_coPowers },
+		{ "tags", settings.m_tags },
+		{ "startingFunds", settings.m_startingFunds },
+		{ "incomePerProperty", settings.m_incomePerProperty },
+		{ "unitCap", settings.m_unitCap },
+		{ "captureLimit", settings.m_captureLimit },
+		{ "dayLimit", dayLimit },
+		{ "bannedUnits", bannedUnits },
+		{ "heuristicAutoResign", settings.m_heuristicAutoResign },
+	};
+}
+
+GameState::GameSettings GameSettingsFromJson(const json& settingsJson) {
+	GameState::GameSettings settings;
+	if (!settingsJson.is_object()) {
+		throw std::invalid_argument("settings must be an object");
+	}
+
+	if (settingsJson.contains("mode")) {
+		settingsJson.at("mode").get_to(settings.m_mode);
+	}
+	if (settingsJson.contains("fog")) {
+		settingsJson.at("fog").get_to(settings.m_fog);
+	}
+	if (settingsJson.contains("weather")) {
+		std::string weather;
+		settingsJson.at("weather").get_to(weather);
+		settings.m_weather = WeatherTypeFromString(weather);
+	}
+	if (settingsJson.contains("coPowers")) {
+		settingsJson.at("coPowers").get_to(settings.m_coPowers);
+	}
+	if (settingsJson.contains("tags")) {
+		settingsJson.at("tags").get_to(settings.m_tags);
+	}
+	if (settingsJson.contains("startingFunds")) {
+		settingsJson.at("startingFunds").get_to(settings.m_startingFunds);
+	}
+	if (settingsJson.contains("incomePerProperty")) {
+		settingsJson.at("incomePerProperty").get_to(settings.m_incomePerProperty);
+	}
+	if (settingsJson.contains("unitCap")) {
+		settingsJson.at("unitCap").get_to(settings.m_unitCap);
+	}
+	if (settingsJson.contains("captureLimit")) {
+		settingsJson.at("captureLimit").get_to(settings.m_captureLimit);
+	}
+	if (settingsJson.contains("dayLimit")) {
+		if (settingsJson.at("dayLimit").is_null()) {
+			settings.m_dayLimit.reset();
+		}
+		else {
+			int dayLimit = 0;
+			settingsJson.at("dayLimit").get_to(dayLimit);
+			if (dayLimit <= 0) {
+				throw std::invalid_argument("dayLimit must be positive or null");
+			}
+			settings.m_dayLimit = dayLimit;
+		}
+	}
+	if (settingsJson.contains("bannedUnits")) {
+		if (!settingsJson.at("bannedUnits").is_array()) {
+			throw std::invalid_argument("bannedUnits must be an array");
+		}
+
+		settings.m_bannedUnits.clear();
+		for (const json& bannedUnitJson : settingsJson.at("bannedUnits")) {
+			std::string bannedUnit;
+			bannedUnitJson.get_to(bannedUnit);
+			UnitProperties::Type bannedUnitType = UnitProperties::unitTypeFromString(bannedUnit);
+			if (bannedUnitType == UnitProperties::Type::Invalid) {
+				throw std::invalid_argument("Unknown banned unit: " + bannedUnit);
+			}
+			settings.m_bannedUnits.push_back(bannedUnitType);
+		}
+	}
+	if (settingsJson.contains("heuristicAutoResign")) {
+		settingsJson.at("heuristicAutoResign").get_to(settings.m_heuristicAutoResign);
+	}
+
+	return settings;
+}
+
 bool FProducesIncome(Terrain::Type terrainType) noexcept {
 	return MapTile::IsProperty(terrainType) &&
 		terrainType != Terrain::Type::ComTower &&
@@ -181,6 +279,10 @@ Result GameState::BeginTurn() noexcept {
 	// TODO Refactor to get rid of 4O(n^2)
 	if (m_isFirstPlayerTurn) {
 		++m_nTurnCount;
+		if (m_settings.m_dayLimit.has_value() && m_nTurnCount > m_settings.m_dayLimit.value()) {
+			IfFailedReturn(ResolveDayLimit());
+			return Result::Succeeded;
+		}
 	}
 
 	TickTemporaryWeather();
@@ -288,6 +390,28 @@ Result GameState::BeginTurn() noexcept {
 			}
 		}
 	}
+	return Result::Succeeded;
+}
+
+Result GameState::ResolveDayLimit() noexcept {
+	if (m_fGameOver) {
+		return Result::Succeeded;
+	}
+
+	const int firstPlayerProperties = CountOwnedProperties(m_arrPlayers[0]);
+	const int secondPlayerProperties = CountOwnedProperties(m_arrPlayers[1]);
+	if (firstPlayerProperties > secondPlayerProperties) {
+		m_winningPlayer = 0;
+	}
+	else if (secondPlayerProperties > firstPlayerProperties) {
+		m_winningPlayer = 1;
+	}
+	else {
+		m_winningPlayer = 2;
+	}
+
+	m_fGameOver = true;
+	m_terminalReason = "day-limit";
 	return Result::Succeeded;
 }
 
@@ -642,7 +766,7 @@ bool GameState::FAtUnitCap() const noexcept {
 	//	}
 	//}
 
-	return GetCurrentPlayer().m_unitsCached >= m_nUnitCap;
+	return GetCurrentPlayer().m_unitsCached >= m_settings.m_unitCap;
 }
 
 int GameState::GetFuelAfterMove(int xSrc, int ySrc, int xDest, int yDest) {
@@ -1252,7 +1376,7 @@ Result GameState::DoCaptureAction(int x, int y, const Action& action) {
 				}
 			}
 		}
-		if (totalProperties >= m_nCaptureLimit) {
+		if (totalProperties >= m_settings.m_captureLimit) {
 			m_fGameOver = true;
 			m_winningPlayer = m_isFirstPlayerTurn ? 0 : 1;
 			m_terminalReason = "capture-limit";
@@ -1671,6 +1795,10 @@ int GameState::GetCOBuildCost(const Player& player, UnitProperties::Type unitTyp
 }
 
 bool GameState::FCanProduceUnitFromTerrain(const Player& player, Terrain::Type terrainType, UnitProperties::Type unitType) const noexcept {
+	if (FUnitBanned(unitType)) {
+		return false;
+	}
+
 	switch (terrainType) {
 	case Terrain::Type::Airport:
 		return UnitProperties::IsAirUnit(unitType);
@@ -1688,11 +1816,19 @@ bool GameState::FCanProduceUnitFromTerrain(const Player& player, Terrain::Type t
 }
 
 int GameState::GetCOIncomeForProperty(const Player& player, Terrain::Type) const noexcept {
-	if (player.m_co.m_type == CommandingOfficier::Type::Sasha) {
-		return 1100;
+	if (m_settings.m_incomePerProperty == 0) {
+		return 0;
 	}
 
-	return 1000;
+	if (player.m_co.m_type == CommandingOfficier::Type::Sasha) {
+		return m_settings.m_incomePerProperty + 100;
+	}
+
+	return m_settings.m_incomePerProperty;
+}
+
+bool GameState::FUnitBanned(UnitProperties::Type unitType) const noexcept {
+	return std::find(m_settings.m_bannedUnits.begin(), m_settings.m_bannedUnits.end(), unitType) != m_settings.m_bannedUnits.end();
 }
 
 int GameState::GetCOFundsAttackModifier(const Player& player, const CommandingOfficier::Type& co) const noexcept {
@@ -2346,8 +2482,7 @@ GameState::GameState(const GameState& other) noexcept :
 {
 	m_guid = other.m_guid;
 	m_spmap.reset(other.m_spmap->Clone(m_arrPlayers));
-	m_nUnitCap = other.m_nUnitCap;
-	m_nCaptureLimit = other.m_nCaptureLimit;
+	m_settings = other.m_settings;
 	m_nTurnCount = other.m_nTurnCount;
 	m_isFirstPlayerTurn = other.m_isFirstPlayerTurn;
 	m_fGameOver = other.m_fGameOver;
@@ -2355,7 +2490,6 @@ GameState::GameState(const GameState& other) noexcept :
 	m_terminalReason = other.m_terminalReason;
 	m_combatRngSeed = other.m_combatRngSeed;
 	m_combatRng = other.m_combatRng;
-	m_fHeuristicAutoResign = other.m_fHeuristicAutoResign;
 	m_weather = other.m_weather;
 	m_weatherTurnsRemaining = other.m_weatherTurnsRemaining;
 }
@@ -2373,8 +2507,7 @@ GameState& GameState::operator=(const GameState& other) noexcept {
 		m_arrPlayers = other.m_arrPlayers;
 		m_guid = other.m_guid;
 		m_spmap.reset(other.m_spmap->Clone(m_arrPlayers));
-		m_nUnitCap = other.m_nUnitCap;
-		m_nCaptureLimit = other.m_nCaptureLimit;
+		m_settings = other.m_settings;
 		m_nTurnCount = other.m_nTurnCount;
 		m_isFirstPlayerTurn = other.m_isFirstPlayerTurn;
 		m_fGameOver = other.m_fGameOver;
@@ -2382,7 +2515,6 @@ GameState& GameState::operator=(const GameState& other) noexcept {
 		m_terminalReason = other.m_terminalReason;
 		m_combatRngSeed = other.m_combatRngSeed;
 		m_combatRng = other.m_combatRng;
-		m_fHeuristicAutoResign = other.m_fHeuristicAutoResign;
 		m_weather = other.m_weather;
 		m_weatherTurnsRemaining = other.m_weatherTurnsRemaining;
 	}
@@ -2394,8 +2526,9 @@ void GameState::to_json(json& j, const GameState& gameState) {
 		{ "gameId", gameState.GetId()},
 		  { "map", *gameState.TryGetMap()},
 		  { "players", gameState.GetPlayers()},
-		  { "unit-cap", gameState.m_nUnitCap },
-		  { "cap-limit", gameState.m_nCaptureLimit},
+		  { "settings", GameSettingsToJson(gameState.m_settings) },
+		  { "unit-cap", gameState.m_settings.m_unitCap },
+		  { "cap-limit", gameState.m_settings.m_captureLimit},
 		  { "turn-count", gameState.m_nTurnCount},
 		  { "activePlayer", gameState.IsFirstPlayerTurn() ? 0 : 1 },
 		  { "game-over", gameState.m_fGameOver },
@@ -2406,7 +2539,7 @@ void GameState::to_json(json& j, const GameState& gameState) {
 		j["combat-rng-seed"] = gameState.m_combatRngSeed.value();
 	}
 
-	if (gameState.m_fHeuristicAutoResign) {
+	if (gameState.m_settings.m_heuristicAutoResign) {
 		j["heuristic-auto-resign"] = true;
 	}
 
@@ -2558,8 +2691,16 @@ void GameState::from_json(json& j, GameState& gameState) {
 	gameState.m_spmap.reset(new Map());
 	Map::from_test_json(gameState.m_arrPlayers, j.at("map"), *gameState.m_spmap);
 
-	j.at("unit-cap").get_to(gameState.m_nUnitCap);
-	j.at("cap-limit").get_to(gameState.m_nCaptureLimit);
+	gameState.m_settings = GameSettings{};
+	if (j.contains("settings")) {
+		gameState.m_settings = GameSettingsFromJson(j.at("settings"));
+	}
+	if (j.contains("unit-cap")) {
+		j.at("unit-cap").get_to(gameState.m_settings.m_unitCap);
+	}
+	if (j.contains("cap-limit")) {
+		j.at("cap-limit").get_to(gameState.m_settings.m_captureLimit);
+	}
 	j.at("turn-count").get_to(gameState.m_nTurnCount);
 	j.at("game-over").get_to(gameState.m_fGameOver);
 	j.at("winner").get_to(gameState.m_winningPlayer);
@@ -2583,10 +2724,7 @@ void GameState::from_json(json& j, GameState& gameState) {
 	}
 
 	if (j.contains("heuristic-auto-resign")) {
-		j.at("heuristic-auto-resign").get_to(gameState.m_fHeuristicAutoResign);
-	}
-	else {
-		gameState.m_fHeuristicAutoResign = false;
+		j.at("heuristic-auto-resign").get_to(gameState.m_settings.m_heuristicAutoResign);
 	}
 
 	if (j.contains("weather")) {

--- a/AdvanceWarsServer/src/RestApiContractTest.cpp
+++ b/AdvanceWarsServer/src/RestApiContractTest.cpp
@@ -799,6 +799,134 @@ bool RunNoHeuristicResignContract() {
 	return true;
 }
 
+bool RunCreateConfiguredStandardSettingsContract() {
+	RestGameService service;
+	json createPayload = StandardCreatePayload("mcts");
+	createPayload["settings"] = {
+		{ "unitCap", 7 },
+		{ "captureLimit", 4 },
+		{ "dayLimit", 2 },
+	};
+
+	ApiResponse create = service.CreateGame(createPayload.dump());
+	if (!Expect(create.status == 201, "create should accept configured Standard limits")) {
+		return false;
+	}
+	if (!Expect(create.body.at("settings").at("unitCap") == 7, "create should return configured unit cap")) {
+		return false;
+	}
+	if (!Expect(create.body.at("settings").at("captureLimit") == 4, "create should return configured capture limit")) {
+		return false;
+	}
+	if (!Expect(create.body.at("settings").at("dayLimit") == 2, "create should return configured day limit")) {
+		return false;
+	}
+	if (!Expect(create.body.at("unit-cap") == 7, "create should mirror configured unit cap in legacy field")) {
+		return false;
+	}
+	if (!Expect(create.body.at("cap-limit") == 4, "create should mirror configured capture limit in legacy field")) {
+		return false;
+	}
+
+	return true;
+}
+
+bool RunGameSettingsModelContract() {
+	json fixture = OneActionBeforeEndTurnGameState();
+	GameState gameState;
+	GameState::from_json(fixture, gameState);
+
+	json serialized;
+	GameState::to_json(serialized, gameState);
+	if (!Expect(serialized.contains("settings"), "serialized GameState should include resolved settings")) {
+		return false;
+	}
+
+	const json& settings = serialized.at("settings");
+	if (!Expect(settings.at("mode") == "standard", "default settings mode should be standard")) {
+		return false;
+	}
+	if (!Expect(settings.at("fog") == false, "default settings should disable fog")) {
+		return false;
+	}
+	if (!Expect(settings.at("weather") == "clear", "default settings weather should be clear")) {
+		return false;
+	}
+	if (!Expect(settings.at("coPowers") == true, "default settings should enable CO powers")) {
+		return false;
+	}
+	if (!Expect(settings.at("tags") == false, "default settings should disable tags")) {
+		return false;
+	}
+	if (!Expect(settings.at("startingFunds") == 0, "default settings should use 0 starting funds")) {
+		return false;
+	}
+	if (!Expect(settings.at("incomePerProperty") == 1000, "default settings should use 1000 income per property")) {
+		return false;
+	}
+	if (!Expect(settings.at("unitCap") == 50, "default settings should use unit cap 50")) {
+		return false;
+	}
+	if (!Expect(settings.at("captureLimit") == 21, "default settings should use capture limit 21")) {
+		return false;
+	}
+	if (!Expect(settings.contains("dayLimit") && settings.at("dayLimit").is_null(), "default settings should not configure a day limit")) {
+		return false;
+	}
+	if (!Expect(settings.at("bannedUnits") == json::array({ "blackbomb" }), "default settings should ban Black Bomb production")) {
+		return false;
+	}
+
+	json settingsOnlyFixture = OneActionBeforeEndTurnGameState();
+	settingsOnlyFixture.erase("unit-cap");
+	settingsOnlyFixture.erase("cap-limit");
+	settingsOnlyFixture["settings"] = {
+		{ "mode", "standard" },
+		{ "fog", false },
+		{ "weather", "clear" },
+		{ "coPowers", true },
+		{ "tags", false },
+		{ "startingFunds", 0 },
+		{ "incomePerProperty", 1000 },
+		{ "unitCap", 7 },
+		{ "captureLimit", 4 },
+		{ "dayLimit", 3 },
+		{ "bannedUnits", json::array() },
+		{ "heuristicAutoResign", false },
+	};
+
+	GameState settingsOnlyState;
+	try {
+		GameState::from_json(settingsOnlyFixture, settingsOnlyState);
+	}
+	catch (const std::exception& err) {
+		return Expect(false, std::string("settings-only fixture should parse: ") + err.what());
+	}
+
+	json settingsOnlySerialized;
+	GameState::to_json(settingsOnlySerialized, settingsOnlyState);
+	if (!Expect(settingsOnlySerialized.at("settings").at("unitCap") == 7, "settings-only fixture should set unit cap")) {
+		return false;
+	}
+	if (!Expect(settingsOnlySerialized.at("settings").at("captureLimit") == 4, "settings-only fixture should set capture limit")) {
+		return false;
+	}
+	if (!Expect(settingsOnlySerialized.at("settings").at("dayLimit") == 3, "settings-only fixture should set day limit")) {
+		return false;
+	}
+	if (!Expect(settingsOnlySerialized.at("settings").at("bannedUnits").empty(), "settings-only fixture should allow explicit empty unit bans")) {
+		return false;
+	}
+	if (!Expect(settingsOnlySerialized.at("unit-cap") == 7, "legacy unit-cap should mirror settings")) {
+		return false;
+	}
+	if (!Expect(settingsOnlySerialized.at("cap-limit") == 4, "legacy cap-limit should mirror settings")) {
+		return false;
+	}
+
+	return true;
+}
+
 bool RunTerminalContract() {
 	RestGameService service;
 
@@ -890,6 +1018,12 @@ int RunRestApiContractTests() {
 		return 1;
 	}
 	if (!RunNoHeuristicResignContract()) {
+		return 1;
+	}
+	if (!RunCreateConfiguredStandardSettingsContract()) {
+		return 1;
+	}
+	if (!RunGameSettingsModelContract()) {
 		return 1;
 	}
 	if (!RunTerminalContract()) {

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <initializer_list>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
@@ -31,7 +32,12 @@ constexpr std::array<MapTemplate, 2> MapTemplates{ {
 	{ "mcts", "res/AWBW/MapSources/MCTS.json" },
 } };
 
-json StandardSettingsJson(bool heuristicAutoResign = false) {
+json StandardSettingsJson(int unitCap = 50, int captureLimit = 21, std::optional<int> dayLimit = std::nullopt, bool heuristicAutoResign = false) {
+	json dayLimitJson = nullptr;
+	if (dayLimit.has_value()) {
+		dayLimitJson = dayLimit.value();
+	}
+
 	return {
 		{ "mode", "standard" },
 		{ "fog", false },
@@ -40,8 +46,9 @@ json StandardSettingsJson(bool heuristicAutoResign = false) {
 		{ "tags", false },
 		{ "startingFunds", 0 },
 		{ "incomePerProperty", 1000 },
-		{ "unitCap", 50 },
-		{ "captureLimit", 21 },
+		{ "unitCap", unitCap },
+		{ "captureLimit", captureLimit },
+		{ "dayLimit", dayLimitJson },
 		{ "bannedUnits", json::array({ "blackbomb" }) },
 		{ "heuristicAutoResign", heuristicAutoResign },
 	};
@@ -162,10 +169,13 @@ ApiResponse ValidateSettings(const json& request) {
 	}
 
 	std::string invalidField;
-	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "bannedUnits", "heuristicAutoResign" }, invalidField)) {
+	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "dayLimit", "bannedUnits", "heuristicAutoResign" }, invalidField)) {
 		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown settings field.", { { "field", "settings." + invalidField } });
 	}
 
+	int unitCap = 50;
+	int captureLimit = 21;
+	std::optional<int> dayLimit;
 	try {
 		if (settings.contains("mode") && (!settings.at("mode").is_string() || settings.at("mode").get<std::string>() != "standard")) {
 			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only standard mode is supported.", { { "field", "settings.mode" }, { "value", settings.at("mode") } });
@@ -188,11 +198,38 @@ ApiResponse ValidateSettings(const json& request) {
 		if (settings.contains("incomePerProperty") && (!settings.at("incomePerProperty").is_number_integer() || settings.at("incomePerProperty").get<int>() != 1000)) {
 			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only 1000 income per property is supported for standard games.", { { "field", "settings.incomePerProperty" }, { "value", settings.at("incomePerProperty") } });
 		}
-		if (settings.contains("unitCap") && (!settings.at("unitCap").is_number_integer() || settings.at("unitCap").get<int>() != 50)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only unit cap 50 is supported for standard games.", { { "field", "settings.unitCap" }, { "value", settings.at("unitCap") } });
+		if (settings.contains("unitCap")) {
+			if (!settings.at("unitCap").is_number_integer()) {
+				return ErrorResponse(HttpBadRequest, "invalid-field", "unitCap must be an integer.", { { "field", "settings.unitCap" } });
+			}
+			unitCap = settings.at("unitCap").get<int>();
+			if (unitCap <= 0) {
+				return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "unitCap must be positive for standard games.", { { "field", "settings.unitCap" }, { "value", settings.at("unitCap") } });
+			}
 		}
-		if (settings.contains("captureLimit") && (!settings.at("captureLimit").is_number_integer() || settings.at("captureLimit").get<int>() != 21)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only capture limit 21 is supported for standard games.", { { "field", "settings.captureLimit" }, { "value", settings.at("captureLimit") } });
+		if (settings.contains("captureLimit")) {
+			if (!settings.at("captureLimit").is_number_integer()) {
+				return ErrorResponse(HttpBadRequest, "invalid-field", "captureLimit must be an integer.", { { "field", "settings.captureLimit" } });
+			}
+			captureLimit = settings.at("captureLimit").get<int>();
+			if (captureLimit <= 0) {
+				return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "captureLimit must be positive for standard games.", { { "field", "settings.captureLimit" }, { "value", settings.at("captureLimit") } });
+			}
+		}
+		if (settings.contains("dayLimit")) {
+			if (settings.at("dayLimit").is_null()) {
+				dayLimit.reset();
+			}
+			else if (!settings.at("dayLimit").is_number_integer()) {
+				return ErrorResponse(HttpBadRequest, "invalid-field", "dayLimit must be an integer or null.", { { "field", "settings.dayLimit" } });
+			}
+			else {
+				const int parsedDayLimit = settings.at("dayLimit").get<int>();
+				if (parsedDayLimit <= 0) {
+					return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "dayLimit must be positive for standard games.", { { "field", "settings.dayLimit" }, { "value", settings.at("dayLimit") } });
+				}
+				dayLimit = parsedDayLimit;
+			}
 		}
 		if (settings.contains("bannedUnits") && !IsStandardBannedUnits(settings.at("bannedUnits"))) {
 			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only the standard blackbomb ban is supported.", { { "field", "settings.bannedUnits" }, { "value", settings.at("bannedUnits") } });
@@ -206,7 +243,7 @@ ApiResponse ValidateSettings(const json& request) {
 	}
 
 	const bool heuristicAutoResign = settings.contains("heuristicAutoResign") && settings.at("heuristicAutoResign").get<bool>();
-	return JsonResponse(HttpOk, StandardSettingsJson(heuristicAutoResign));
+	return JsonResponse(HttpOk, StandardSettingsJson(unitCap, captureLimit, dayLimit, heuristicAutoResign));
 }
 
 json SerializeGameForApi(const GameState& gameState) {
@@ -214,7 +251,6 @@ json SerializeGameForApi(const GameState& gameState) {
 	GameState::to_json(game, gameState);
 	game.erase("combat-rng-seed");
 	game.erase("heuristic-auto-resign");
-	game["settings"] = StandardSettingsJson(gameState.FHeuristicAutoResign());
 	if (gameState.GetTerminalReason().has_value()) {
 		game["terminalReason"] = gameState.GetTerminalReason().value();
 	}
@@ -420,8 +456,9 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 	json templateJson;
 	filestream >> templateJson;
 	templateJson["gameId"] = Platform::createUuid();
-	templateJson["unit-cap"] = 50;
-	templateJson["cap-limit"] = 21;
+	templateJson["settings"] = settingsValidation.body;
+	templateJson["unit-cap"] = settingsValidation.body.at("unitCap").get<int>();
+	templateJson["cap-limit"] = settingsValidation.body.at("captureLimit").get<int>();
 	templateJson["activePlayer"] = 0;
 	templateJson["turn-count"] = 0;
 	templateJson.erase("combat-rng-seed");
@@ -461,7 +498,7 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 		}
 
 		Player player(co.m_type, Player::armyTypefromString(armyType));
-		player.m_funds = 0;
+		player.m_funds = settingsValidation.body.at("startingFunds").get<int>();
 		json playerJson;
 		to_json(playerJson, player);
 		templateJson["players"][i] = std::move(playerJson);

--- a/AdvanceWarsServer/test/json/misc/day-limit-property-count-winner.json
+++ b/AdvanceWarsServer/test/json/misc/day-limit-property-count-winner.json
@@ -1,9 +1,9 @@
 {
   "initial-game-state": {
-    "activePlayer": 0,
+    "activePlayer": 1,
     "cap-limit": 21,
     "game-over": false,
-    "gameId": "airport-port-buy-actions",
+    "gameId": "day-limit-property-count-winner",
     "map": [
       [
         {
@@ -11,14 +11,21 @@
             "capture-points": 20,
             "owner": "orange-star"
           },
-          "terrain": 36
+          "terrain": 34
         },
         {
           "property": {
             "capture-points": 20,
             "owner": "orange-star"
           },
-          "terrain": 37
+          "terrain": 35
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 35
         }
       ]
     ],
@@ -26,7 +33,7 @@
       {
         "armyType": "orange-star",
         "co": "Andy",
-        "funds": 100000,
+        "funds": 0,
         "power-meter": {
           "charge": 0,
           "cop-stars": 3,
@@ -60,8 +67,8 @@
       "incomePerProperty": 1000,
       "unitCap": 50,
       "captureLimit": 21,
-      "dayLimit": null,
-      "bannedUnits": [],
+      "dayLimit": 1,
+      "bannedUnits": [ "blackbomb" ],
       "heuristicAutoResign": false
     },
     "turn-count": 1,
@@ -70,21 +77,14 @@
   },
   "actions": [
     {
-      "type": "buy",
-      "source": [ 0, 0 ],
-      "unit": "blackbomb"
-    },
-    {
-      "type": "buy",
-      "source": [ 1, 0 ],
-      "unit": "carrier"
+      "type": "end-turn"
     }
   ],
   "final-game-state": {
     "activePlayer": 0,
     "cap-limit": 21,
-    "game-over": false,
-    "gameId": "airport-port-buy-actions",
+    "game-over": true,
+    "gameId": "day-limit-property-count-winner",
     "map": [
       [
         {
@@ -92,32 +92,21 @@
             "capture-points": 20,
             "owner": "orange-star"
           },
-          "terrain": 36,
-          "unit": {
-            "ammo": 0,
-            "fuel": 45,
-            "health": 100,
-            "hidden": false,
-            "moved": true,
-            "owner": "orange-star",
-            "type": "blackbomb"
-          }
+          "terrain": 34
         },
         {
           "property": {
             "capture-points": 20,
             "owner": "orange-star"
           },
-          "terrain": 37,
-          "unit": {
-            "ammo": 9,
-            "fuel": 99,
-            "health": 100,
-            "hidden": false,
-            "moved": true,
-            "owner": "orange-star",
-            "type": "carrier"
-          }
+          "terrain": 35
+        },
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "blue-moon"
+          },
+          "terrain": 35
         }
       ]
     ],
@@ -125,7 +114,7 @@
       {
         "armyType": "orange-star",
         "co": "Andy",
-        "funds": 45000,
+        "funds": 0,
         "power-meter": {
           "charge": 0,
           "cop-stars": 3,
@@ -159,12 +148,12 @@
       "incomePerProperty": 1000,
       "unitCap": 50,
       "captureLimit": 21,
-      "dayLimit": null,
-      "bannedUnits": [],
+      "dayLimit": 1,
+      "bannedUnits": [ "blackbomb" ],
       "heuristicAutoResign": false
     },
-    "turn-count": 1,
+    "turn-count": 2,
     "unit-cap": 50,
-    "winner": -1
+    "winner": 0
   }
 }

--- a/AdvanceWarsServer/test/json/production/airport-port-valid-actions.json
+++ b/AdvanceWarsServer/test/json/production/airport-port-valid-actions.json
@@ -117,6 +117,20 @@
         "luck-policy": 2
       }
     ],
+    "settings": {
+      "mode": "standard",
+      "fog": false,
+      "weather": "clear",
+      "coPowers": true,
+      "tags": false,
+      "startingFunds": 0,
+      "incomePerProperty": 1000,
+      "unitCap": 50,
+      "captureLimit": 21,
+      "dayLimit": null,
+      "bannedUnits": [],
+      "heuristicAutoResign": false
+    },
     "turn-count": 1,
     "unit-cap": 50,
     "winner": -1

--- a/AdvanceWarsServer/test/json/production/buy-action-execution.json
+++ b/AdvanceWarsServer/test/json/production/buy-action-execution.json
@@ -204,6 +204,20 @@
         "luck-policy": 2
       }
     ],
+    "settings": {
+      "mode": "standard",
+      "fog": false,
+      "weather": "clear",
+      "coPowers": true,
+      "tags": false,
+      "startingFunds": 0,
+      "incomePerProperty": 1000,
+      "unitCap": 50,
+      "captureLimit": 21,
+      "dayLimit": null,
+      "bannedUnits": [],
+      "heuristicAutoResign": false
+    },
     "turn-count": 1,
     "unit-cap": 50,
     "winner": -1
@@ -751,6 +765,20 @@
         "luck-policy": 2
       }
     ],
+    "settings": {
+      "mode": "standard",
+      "fog": false,
+      "weather": "clear",
+      "coPowers": true,
+      "tags": false,
+      "startingFunds": 0,
+      "incomePerProperty": 1000,
+      "unitCap": 50,
+      "captureLimit": 21,
+      "dayLimit": null,
+      "bannedUnits": [],
+      "heuristicAutoResign": false
+    },
     "turn-count": 1,
     "unit-cap": 50,
     "winner": -1

--- a/AdvanceWarsServer/test/json/production/standard-blackbomb-ban.json
+++ b/AdvanceWarsServer/test/json/production/standard-blackbomb-ban.json
@@ -1,0 +1,89 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "standard-blackbomb-ban",
+    "map": [
+      [
+        {
+          "property": {
+            "capture-points": 20,
+            "owner": "orange-star"
+          },
+          "terrain": 36
+        }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 50000,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 3,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": {
+          "charge": 0,
+          "cop-stars": 2,
+          "scop-stars": 3,
+          "star-value": 9000
+        },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [ 0, 0 ],
+      "expected": [
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "bcopter"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "bomber"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "fighter"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "stealth"
+        },
+        {
+          "type": "buy",
+          "source": [ 0, 0 ],
+          "unit": "tcopter"
+        }
+      ]
+    }
+  ],
+  "failedActions": [
+    {
+      "type": "buy",
+      "source": [ 0, 0 ],
+      "unit": "blackbomb"
+    }
+  ]
+}

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -47,13 +47,13 @@ Explicitly deferred modes and options:
 | --- | --- | --- | --- | --- |
 | Player count | `GameState` is fixed to two players. | Standard is two-player. | Complete for Standard | #98 for non-Standard player counts |
 | Country identity | Player army identity supports Orange Star and Blue Moon only. | Any AWBW country identity used by two-player Standard maps should round-trip independently from CO choice. | Partial | #70 |
-| Game settings model | State has scattered fields, and REST create is hardcoded. | Serialize/create Standard settings: clear, no fog, powers on, tags off, 0 start funds, 1000 income, bans, limits, timers. | Partial | #65 |
-| Starting funds and income | Normal income exists; Sasha income modifier exists; configurable mode presets are incomplete. | 0 starting funds and 1000/property for Standard. | Partial | #65 |
+| Game settings model | `GameState` serializes resolved Standard settings and REST create accepts Standard setup metadata, including configurable unit/capture/day limits and the Standard Black Bomb ban. | Serialize/create Standard settings: clear, no fog, powers on, tags off, 0 start funds, 1000 income, bans, limits, timers. | Partial for timer metadata | #82 |
+| Starting funds and income | Standard create resolves 0 starting funds and 1000/property; fixtures can serialize explicit settings. Sasha income modifier exists. | 0 starting funds and 1000/property for Standard. | Complete for Standard | none |
 | High Funds | No preset. | 2000/property only in High Funds modes. | Deferred | #91 |
 | Unit cap | `unit-cap` serializes and production fixtures cover under-cap and at-cap behavior. | Enforce configured unit limit. | Complete for current model | none |
 | Capture limit | Capture-limit terminal path counts Cities, Bases, Airports, Ports, and HQs; Labs/Comm Towers are excluded. | Limit excludes Labs and Comm Towers. | Complete for current model | none |
-| Day limit | No day-limit terminal rule. | Configurable day limit with property-count winner/tie handling. | Partial | #74 |
-| Unit bans | No setup-level ban list. | Standard bans Black Bomb production. | Partial | #75 |
+| Day limit | Configured day limits resolve when the next day would begin; highest property count wins, ties draw. | Configurable day limit with property-count winner/tie handling. | Complete for current model | none |
+| Unit bans | Setup-level banned units are serialized and enforced for legal production and direct buy execution; Standard defaults ban Black Bomb production. | Standard bans Black Bomb production. | Complete for Standard | none |
 | Lab units | No setup-level lab-unit requirement. | Selected lab units require owned Lab access. | Partial | #76 |
 | Timers | No timer model or timeout terminal reason. | Standard timer metadata and optional enforcement story. | Partial | #82 |
 
@@ -80,12 +80,12 @@ Explicitly deferred modes and options:
 | Movement and wait | Covered broadly by JSON fixtures. | AWBW movement/fuel/path legality. | Partial because submitted invalid actions need atomic rejection | #67 |
 | Combat actions | Direct, indirect, counterattack, ammo, HP, terrain, and many CO/power cases are covered. Unit stat/data audit is documented in `docs/AWBW_UNIT_DATA_AUDIT.md`. | AWBW combat formula and data. | Partial | #147, #148, #149 |
 | Capture | Capture progress, interruption, HQ capture, Labs, Com Towers, Airports, Ports, Sami capture, and capture-limit counting have fixtures. | AWBW capture points and capture-limit counting. | Complete for current Standard coverage | none |
-| Buy | Production fixtures cover common buy legality, unit cap, and Piperunner production from Bases/Hachi Merchant Union cities. | Add setup bans, lab units, and ghosted blockers. | Partial | #75, #76, #78 |
+| Buy | Production fixtures cover common buy legality, unit cap, the Standard Black Bomb ban, and Piperunner production from Bases/Hachi Merchant Union cities. | Add lab units and ghosted blockers. | Partial | #76, #78 |
 | Load and unload | APC, T-Copter, Lander, Black Boat, Cruiser, Carrier, loaded-unit destruction, and many boundaries are covered. | AWBW free unload behavior and legal terrain/occupancy. | Partial because submitted invalid actions need atomic rejection | #67 |
 | Combine/join | Joining/refund/capture-preservation fixtures exist. | AWBW join/refund behavior. | Complete for current Standard coverage | none |
 | Black Boat repair action | Dedicated repair/resupply fixtures exist. | AWBW Black Boat repair and resupply. | Complete for current Standard coverage | none |
 | CO power actions | Power gates, spending, meter math, many direct effects, and mass effects are covered. | Full CO behavior. | Partial | #83, #84, #86, #87, #88, #89, #99, #100, #101, #102, #103 |
-| Black Bomb explode | Black Bomb movement/fuel/no-weapon fixtures exist; explosion action is absent. | Black Bomb explosion if predeployed/custom games need it; production banned in Standard. | Deferred from production, incomplete as unit behavior | #33, #75 |
+| Black Bomb explode | Black Bomb movement/fuel/no-weapon fixtures exist; explosion action is absent. | Black Bomb explosion if predeployed/custom games need it; production banned in Standard. | Deferred from production, incomplete as unit behavior | #33 |
 | Missile silo launch | Terrain exists, but launch behavior is incomplete. | Launch action, empty silo state, damage area, legal action generation. | Partial | #42 |
 | Resign/delete | Explicit player actions do not exist yet. | Explicit resign and delete-unit actions if AWBW permits delete. | Partial | #77 |
 | Heuristic auto-resign | Canonical Standard/API and MCTS-style `applyAction` paths call the army-value resign heuristic only when `heuristicAutoResign` is explicitly enabled; it defaults off. | Standard terminal logic should not auto-resign except through explicit/tracked rules. | Complete | none |
@@ -113,7 +113,7 @@ The unit fixture manifest lives at `AdvanceWarsServer/test/json/units/README.md`
 | Area | Current implementation | Standard target | Status | Issue |
 | --- | --- | --- | --- | --- |
 | Core terrain movement | JSON fixtures cover many terrain, weather, air, land, sea, and Sturm all-terrain movement cases. | AWBW movement tables. | Partial where Piperunner/Teleport remain | #35, #93 |
-| Properties and income | Cities/Bases/Airports/Ports/HQ income behavior exists; Labs/Com Towers no-income fixtures exist. | AWBW fund-producing properties only. | Complete for normal income, configurable settings partial | #65 |
+| Properties and income | Cities/Bases/Airports/Ports/HQ income behavior exists; Labs/Com Towers no-income fixtures exist; Standard income comes from settings. | AWBW fund-producing properties only. | Complete for Standard income | none |
 | Property repair/resupply | Begin-turn property service is gated by owner, property type, and unit class; Labs and Com Towers do not repair or resupply. | Land on City/Base/HQ, air on Airport, sea on Port; owner only. | Complete for normal property service | none |
 | Rachel property repair | Rachel repairs +1 extra displayed HP on compatible owned properties, with affordable partial repair and no off-class service. | Rachel repairs +1 extra displayed HP on compatible properties. | Complete | none |
 | APC/Cruiser/Carrier resupply | Dedicated transport and loaded-resupply fixtures exist. | AWBW logistics order and compatible cargo. | Complete for current Standard coverage | none |
@@ -184,8 +184,6 @@ Standard API, settings, and terminal behavior:
 - #67: Validate and atomically reject illegal submitted actions.
 - #68: Make REST action stepping explicit and remove implicit auto-end-turn.
 - #70: Support AWBW map imports with all two-player country identities.
-- #74: Implement day-limit victory and draw resolution.
-- #75: Add game setup support for unit bans and the Standard Black Bomb ban.
 - #76: Add lab-unit production requirements from game setup.
 - #77: Add explicit resign and delete-unit actions.
 - #82: Add timer settings and timeout terminal state metadata.

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,7 +33,26 @@ Minimal request:
 }
 ```
 
-`settings` is optional. If present, `mode` belongs inside `settings`; v1 accepts only strict Standard values. `settings.heuristicAutoResign` is a training/early-stop option that defaults to `false`; when set to `true`, the existing army-value heuristic can end a game with `terminalReason: "heuristic-resign"` after a legal step. `seed` is optional and request-only: it enables deterministic combat RNG but is not returned in normal API game-state responses.
+`settings` is optional. If present, `mode` belongs inside `settings`; v1 accepts Standard-only gameplay settings. Fog, non-clear weather, CO powers off, tags, High Funds income, and non-Standard unit bans are rejected. `unitCap`, `captureLimit`, and `dayLimit` may be configured for Standard setup. `dayLimit` may be `null` or a positive integer; when reached, the highest property count wins and a tie is a draw. `settings.heuristicAutoResign` is a training/early-stop option that defaults to `false`; when set to `true`, the existing army-value heuristic can end a game with `terminalReason: "heuristic-resign"` after a legal step. `seed` is optional and request-only: it enables deterministic combat RNG but is not returned in normal API game-state responses.
+
+Resolved default settings:
+
+```json
+{
+  "mode": "standard",
+  "fog": false,
+  "weather": "clear",
+  "coPowers": true,
+  "tags": false,
+  "startingFunds": 0,
+  "incomePerProperty": 1000,
+  "unitCap": 50,
+  "captureLimit": 21,
+  "dayLimit": null,
+  "bannedUnits": ["blackbomb"],
+  "heuristicAutoResign": false
+}
+```
 
 Supported v1 map ids are `lefty` and `mcts`.
 

--- a/docs/ISSUE_66_REST_CONTRACT_PLAN.md
+++ b/docs/ISSUE_66_REST_CONTRACT_PLAN.md
@@ -12,7 +12,7 @@ This file captures the issue #66 REST contract decisions from the design intervi
 - No `startingPlayer` override in v1; use the template/default initial active player.
 - Create CO ids use lowercase kebab-case, while existing state/action serialization stays as-is for now.
 - V1 accepts any CO id the engine can parse; remaining CO mechanic gaps stay tracked in focused follow-up issues.
-- Settings may be omitted; server fills strict Standard defaults and rejects unsupported non-Standard settings.
+- Settings may be omitted; server fills Standard defaults and rejects unsupported non-Standard modes/settings.
 - Resolved settings are serialized inside every returned `GameState`, including create, get, and step responses.
 - Optional `seed` is accepted for reproducible combat RNG; when omitted, combat RNG may be nondeterministic.
 - `seed` is request-only/debug metadata and is not serialized in normal state responses.
@@ -69,7 +69,7 @@ Minimal v1 request:
 }
 ```
 
-Settings may be omitted. If provided, `mode` belongs inside `settings`, not at the top level. The server resolves strict Standard defaults and serializes the resolved settings in returned game state.
+Settings may be omitted. If provided, `mode` belongs inside `settings`, not at the top level. The server resolves Standard defaults and serializes the resolved settings in returned game state.
 
 Resolved v1 settings:
 
@@ -85,19 +85,21 @@ Resolved v1 settings:
     "incomePerProperty": 1000,
     "unitCap": 50,
     "captureLimit": 21,
+    "dayLimit": null,
     "bannedUnits": ["blackbomb"],
     "heuristicAutoResign": false
   }
 }
 ```
 
+`unitCap`, `captureLimit`, and `dayLimit` may be configured for Standard setup. `dayLimit` accepts `null` or a positive integer.
+
 `heuristicAutoResign` defaults to `false`. It may be set to `true` for training/early-stop runs that intentionally want the army-value heuristic to produce `terminalReason: "heuristic-resign"` after legal steps.
 
-Do not include day limit, timer/live settings, lab units, High Funds, tag COs, random weather, or fog metadata in v1. Reject those if submitted.
+Do not include timer/live settings, lab units, High Funds, tag COs, random weather, or fog metadata in v1. Reject those if submitted.
 
 Deferred settings are already tracked by follow-up issues:
 
-- Day-limit terminal rules: #74.
 - Lab-unit production requirements: #76.
 - Timer/live enforcement and timeout metadata: #82.
 - Fog of War, visibility, and fog-only metadata: #90.


### PR DESCRIPTION
## Summary
- Add a serialized `GameSettings` model to `GameState` with Standard defaults for clear weather, fog off, CO powers on, tags off, 0 starting funds, 1000 income/property, unit/capture/day limits, and the Standard Black Bomb ban.
- Thread resolved Standard settings through REST create/get/step responses, while allowing configured Standard `unitCap`, `captureLimit`, and `dayLimit` values.
- Enforce banned units in legal production and direct buy execution, add day-limit terminal resolution by property count, and keep legacy `unit-cap`/`cap-limit` fields mirrored for existing clients/fixtures.
- Update production fixtures/docs so explicit non-Standard Black Bomb production tests opt out of bans through fixture settings.

## Root Cause
`GameState` previously kept setup behavior in scattered fields and REST-only response decoration. That meant Standard settings were not an engine-level model, Black Bomb production remained legal by default, and day-limit setup metadata had no terminal behavior.

## Tests
- Added `AdvanceWarsServer/test/json/production/standard-blackbomb-ban.json` and first observed it fail because Black Bomb was still generated as a legal buy and accepted by direct execution.
- Added `AdvanceWarsServer/test/json/misc/day-limit-property-count-winner.json` and first observed it fail because crossing the configured day limit paid income and left the game active.
- Added REST contract coverage for serialized settings defaults, settings-only fixture parsing, and configured Standard limits through `POST /games`.
- Ran `MSBuild AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`.
- Ran `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`.
- Ran `..\x64\Debug\AdvanceWarsServer.exe -test test/json`.
- Ran `git diff --cached --check`.

## Residual Risk
Timer metadata/enforcement and lab-unit requirements remain deferred to their separate tracked issues; this PR keeps those non-Standard or incomplete settings out of the v1 REST settings contract.

Closes #65