### PR TITLE
Implement hidden Sub and Stealth actions

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -17,12 +17,13 @@ class Map;
 
 struct Action {
 	enum class Type {
-		// TODO: Need action for "hide"/"unhide" unit
 		Invalid = -1,
 		Attack,
 		EndTurn,
 		MoveWait,
 		MoveAttack, // Requires direction
+		MoveHide,
+		MoveUnhide,
 		Unload, // Requires direction
 		MoveLoad,
 		MoveCapture,
@@ -74,6 +75,10 @@ struct Action {
 			return "end-turn";
 		case Type::MoveAttack:
 			return "move-attack";
+		case Type::MoveHide:
+			return "move-hide";
+		case Type::MoveUnhide:
+			return "move-unhide";
 		case Type::MoveCapture:
 			return "move-capture";
 		case Type::MoveCombine:
@@ -311,6 +316,7 @@ private:
 	Result DoAttackAction(int x, int y, const Action& action);
 	Result DoBuyAction(int x, int y, const Action& action);
 	Result DoMoveAction(int& x, int& y, const Action& action);
+	Result DoHideAction(int x, int y, bool hidden);
 	Result DoMoveCombineAction(int x, int y, const Action& action);
 	Result DoMoveLoadAction(int x, int y, const Action& action);
 	Result DoCaptureAction(int x, int y, const Action& action);
@@ -341,6 +347,7 @@ private:
 	int GetCOMovementBonus(const CommandingOfficier::Type& co, const Unit& unit) const noexcept;
 	int GetWeatherMovementCost(const Terrain& terrain, const Player& player, const Unit& unit) const noexcept;
 	int GetFuelCostPerDay(const Player& player, const Unit& unit) const noexcept;
+	bool FCanHideUnit(const Unit& unit) const noexcept;
 	void SetTemporaryWeather(WeatherType weather) noexcept;
 	void TickTemporaryWeather() noexcept;
 	void HealUnits(const Player& player, int health);

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -510,6 +510,20 @@ MoveNode* GameState::AddNewNodeToGraph(std::vector<Action>& vecActions, std::vec
 }
 
 bool GameState::CanUnitAttack(const Unit& attacker, const Unit& defender) const noexcept {
+	if (defender.IsHidden()) {
+		if (defender.m_properties.m_type == UnitProperties::Type::Stealth &&
+			attacker.m_properties.m_type != UnitProperties::Type::Fighter &&
+			attacker.m_properties.m_type != UnitProperties::Type::Stealth) {
+			return false;
+		}
+
+		if (defender.m_properties.m_type == UnitProperties::Type::Sub &&
+			attacker.m_properties.m_type != UnitProperties::Type::Crusier &&
+			attacker.m_properties.m_type != UnitProperties::Type::Sub) {
+			return false;
+		}
+	}
+
 	int baseDamage = -1;
 	if (defender.IsFootsoldier()) {
 		if (attacker.m_properties.m_primaryWeapon == UnitProperties::Weapon::MachineGun) {
@@ -707,6 +721,11 @@ int GameState::GetFuelCostPerDay(const Player& player, const Unit& unit) const n
 	}
 
 	return fuelCost;
+}
+
+bool GameState::FCanHideUnit(const Unit& unit) const noexcept {
+	return unit.m_properties.m_type == UnitProperties::Type::Stealth ||
+		unit.m_properties.m_type == UnitProperties::Type::Sub;
 }
 
 void GameState::SetTemporaryWeather(WeatherType weather) noexcept {
@@ -967,6 +986,10 @@ Result GameState::GetValidActions(int x, int y, std::vector<Action>& vecActions)
 				if (MapTile::IsProperty(pCurrentTile->GetTerrain().m_type) && pCurrentTile->m_spPropertyInfo->m_owner != &GetCurrentPlayer() && (pUnit->m_properties.m_type == UnitProperties::Type::Infantry || pUnit->m_properties.m_type == UnitProperties::Type::Mech)) {
 					vecActions.emplace_back(Action::Type::MoveCapture, x, y, pTop->m_x, pTop->m_y);
 				}
+
+				if (FCanHideUnit(*pUnit)) {
+					vecActions.emplace_back(pUnit->m_hidden ? Action::Type::MoveUnhide : Action::Type::MoveHide, x, y, pTop->m_x, pTop->m_y);
+				}
 			}
 			else {
 				// this should be true always.  If the unit wasn't owned by the same player we don't expect to visit
@@ -1132,6 +1155,12 @@ Result GameState::ExecuteAction(const Action& action) noexcept {
 	case Action::Type::MoveAttack:
 		IfFailedReturn(DoMoveAction(x, y, action));
 		return DoAttackAction(x, y, action);
+	case Action::Type::MoveHide:
+		IfFailedReturn(DoMoveAction(x, y, action));
+		return DoHideAction(x, y, true);
+	case Action::Type::MoveUnhide:
+		IfFailedReturn(DoMoveAction(x, y, action));
+		return DoHideAction(x, y, false);
 	case Action::Type::MoveCapture:
 		IfFailedReturn(DoMoveAction(x, y, action));
 		return DoCaptureAction(x, y, action);
@@ -2029,6 +2058,22 @@ Result GameState::DoMoveAction(int& x, int& y, const Action& action) {
 	return Result::Succeeded;
 }
 
+Result GameState::DoHideAction(int x, int y, bool hidden) {
+	MapTile* pTile = nullptr;
+	IfFailedReturn(m_spmap->TryGetTile(x, y, &pTile));
+
+	Unit* pUnit = pTile->TryGetUnit();
+	if (pUnit == nullptr ||
+		pUnit->m_owner != &GetCurrentPlayer() ||
+		!FCanHideUnit(*pUnit) ||
+		pUnit->m_hidden == hidden) {
+		return Result::Failed;
+	}
+
+	pUnit->m_hidden = hidden;
+	return Result::Succeeded;
+}
+
 void GameState::HealUnits(const Player& player, int health) {
 	for (int x = 0; x < m_spmap->GetCols(); ++x) {
 		for (int y = 0; y < m_spmap->GetRows(); ++y) {
@@ -2599,6 +2644,14 @@ void to_json(json& j, const Action& action) {
 
 	if (strType == "move-attack") {
 		return Action::Type::MoveAttack;
+	}
+
+	if (strType == "move-hide") {
+		return Action::Type::MoveHide;
+	}
+
+	if (strType == "move-unhide") {
+		return Action::Type::MoveUnhide;
 	}
 
 	if (strType == "move-capture") {

--- a/AdvanceWarsServer/test/json/units/stealth/hidden-attack-restrictions.json
+++ b/AdvanceWarsServer/test/json/units/stealth/hidden-attack-restrictions.json
@@ -1,0 +1,24 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-hidden-attack-restrictions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "stealth" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "anti-air" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "move-attack", "source": [1, 0], "target": [1, 0], "direction": "west" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/stealth/hidden-attack-retains-hide.json
+++ b/AdvanceWarsServer/test/json/units/stealth/hidden-attack-retains-hide.json
@@ -1,0 +1,45 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-hidden-attack-retains-hide",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "stealth" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 1, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "target": [0, 0], "direction": "east" }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-hidden-attack-retains-hide",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 5, "fuel": 60, "health": 100, "hidden": true, "moved": true, "owner": "orange-star", "type": "stealth" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 350, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 700, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/stealth/hide-action.json
+++ b/AdvanceWarsServer/test/json/units/stealth/hide-action.json
@@ -1,0 +1,41 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-hide-action",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "stealth" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-hide", "source": [0, 0], "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-hide-action",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": true, "owner": "orange-star", "type": "stealth" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/stealth/hide-valid-actions.json
+++ b/AdvanceWarsServer/test/json/units/stealth/hide-valid-actions.json
@@ -1,0 +1,29 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-hide-valid-actions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "stealth" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-hide", "source": [0, 0], "target": [0, 0] }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/stealth/invalid-hide-unhide.json
+++ b/AdvanceWarsServer/test/json/units/stealth/invalid-hide-unhide.json
@@ -1,0 +1,27 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-invalid-hide-unhide",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "stealth" } },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "stealth" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "move-unhide", "source": [0, 0], "target": [0, 0] },
+    { "type": "move-hide", "source": [1, 0], "target": [1, 0] },
+    { "type": "move-hide", "source": [2, 0], "target": [2, 0] }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/stealth/unhide-action.json
+++ b/AdvanceWarsServer/test/json/units/stealth/unhide-action.json
@@ -1,0 +1,41 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-unhide-action",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "stealth" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-unhide", "source": [0, 0], "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-unhide-action",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "stealth" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/stealth/unhide-valid-actions.json
+++ b/AdvanceWarsServer/test/json/units/stealth/unhide-valid-actions.json
@@ -1,0 +1,29 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "stealth-unhide-valid-actions",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "stealth" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-unhide", "source": [0, 0], "target": [0, 0] }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/sub/hidden-attack-restrictions.json
+++ b/AdvanceWarsServer/test/json/units/sub/hidden-attack-restrictions.json
@@ -1,0 +1,24 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hidden-attack-restrictions",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "sub" } },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "bomber" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "failedActions": [
+    { "type": "move-attack", "source": [1, 0], "target": [1, 0], "direction": "west" }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/sub/hidden-attack-retains-hide.json
+++ b/AdvanceWarsServer/test/json/units/sub/hidden-attack-retains-hide.json
@@ -1,0 +1,45 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hidden-attack-retains-hide",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "sub" } },
+        { "terrain": 28, "unit": { "ammo": 9, "fuel": 99, "health": 1, "hidden": false, "moved": false, "owner": "blue-moon", "type": "carrier" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-attack", "source": [0, 0], "target": [0, 0], "direction": "east" }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hidden-attack-retains-hide",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 5, "fuel": 60, "health": 100, "hidden": true, "moved": true, "owner": "orange-star", "type": "sub" } },
+        { "terrain": 28 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 1500, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 3000, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/sub/hidden-fuel-drain.json
+++ b/AdvanceWarsServer/test/json/units/sub/hidden-fuel-drain.json
@@ -1,0 +1,41 @@
+{
+  "initial-game-state": {
+    "activePlayer": 1,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hidden-fuel-drain",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 20, "health": 100, "hidden": true, "moved": true, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "end-turn" }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hidden-fuel-drain",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 15, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 2,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/sub/hide-action.json
+++ b/AdvanceWarsServer/test/json/units/sub/hide-action.json
@@ -1,0 +1,41 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hide-action",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-hide", "source": [0, 0], "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hide-action",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": true, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/sub/hide-valid-actions.json
+++ b/AdvanceWarsServer/test/json/units/sub/hide-valid-actions.json
@@ -1,0 +1,29 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-hide-valid-actions",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-hide", "source": [0, 0], "target": [0, 0] }
+      ]
+    }
+  ]
+}

--- a/AdvanceWarsServer/test/json/units/sub/unhide-action.json
+++ b/AdvanceWarsServer/test/json/units/sub/unhide-action.json
@@ -1,0 +1,41 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-unhide-action",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actions": [
+    { "type": "move-unhide", "source": [0, 0], "target": [0, 0] }
+  ],
+  "final-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-unhide-action",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": true, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  }
+}

--- a/AdvanceWarsServer/test/json/units/sub/unhide-valid-actions.json
+++ b/AdvanceWarsServer/test/json/units/sub/unhide-valid-actions.json
@@ -1,0 +1,29 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "sub-unhide-valid-actions",
+    "map": [
+      [
+        { "terrain": 28, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "sub" } }
+      ]
+    ],
+    "players": [
+      { "armyType": "orange-star", "co": "Andy", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 1 },
+      { "armyType": "blue-moon", "co": "Adder", "funds": 0, "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 }, "power-status": 0, "luck-policy": 2 }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "validActions": [
+    {
+      "source": [0, 0],
+      "expected": [
+        { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+        { "type": "move-unhide", "source": [0, 0], "target": [0, 0] }
+      ]
+    }
+  ]
+}

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -143,6 +143,8 @@ Action JSON is parsed by `from_json(json&, Action&)` in `GameState.cpp`. Existin
 - `attack`
 - `end-turn`
 - `move-wait`
+- `move-hide`
+- `move-unhide`
 - `move-attack`
 - `unload`
 - `move-load`

--- a/frontend/src/gameState/actionDisplay.test.ts
+++ b/frontend/src/gameState/actionDisplay.test.ts
@@ -59,6 +59,14 @@ describe("actionToSubmitFromBoardTarget", () => {
     expect(actionToSubmitFromBoardTarget([move])).toBe(move);
   });
 
+  it("confirms hidden-state move actions from a board target click", () => {
+    const hide: Action = { type: "move-hide", source: [1, 1], target: [2, 1] };
+    const unhide: Action = { type: "move-unhide", source: [1, 1], target: [1, 1] };
+
+    expect(actionToSubmitFromBoardTarget([hide])).toBe(hide);
+    expect(actionToSubmitFromBoardTarget([unhide])).toBe(unhide);
+  });
+
   it("leaves attack target clicks for the inspector", () => {
     const attack: Action = { type: "attack", source: [1, 1], target: [3, 1] };
 

--- a/frontend/src/gameState/actionDisplay.ts
+++ b/frontend/src/gameState/actionDisplay.ts
@@ -101,6 +101,8 @@ const unitOrderIndex = new Map(unitDisplayOrder.map((unit, index) => [unit, inde
 
 const boardClickConfirmActionTypes = new Set([
   "move-wait",
+  "move-hide",
+  "move-unhide",
   "move-capture",
   "move-load",
   "move-combine"

--- a/frontend/src/rendering/actions.test.ts
+++ b/frontend/src/rendering/actions.test.ts
@@ -77,6 +77,23 @@ describe("actionPreviewForTile", () => {
     });
   });
 
+  it("creates movement previews for hidden-state actions", () => {
+    expect(
+      actionPreviewForTile(
+        [{ type: "move-hide", source: [1, 4], target: [4, 2] }],
+        [1, 4],
+        [4, 2]
+      )
+    ).toEqual({
+      kind: "move",
+      path: [
+        [1, 4],
+        [1, 2],
+        [4, 2]
+      ]
+    });
+  });
+
   it("creates an attack preview for direct attacks", () => {
     expect(
       actionPreviewForTile(
@@ -200,6 +217,7 @@ describe("actionHighlightsForSource", () => {
     const highlights = actionHighlightsForSource(
       [
         { type: "move-wait", source: [1, 1], target: [2, 1] },
+        { type: "move-hide", source: [1, 1], target: [2, 1] },
         { type: "move-capture", source: [1, 1], target: [1, 2] },
         { type: "attack", source: [1, 1], target: [4, 1] },
         { type: "move-attack", source: [1, 1], target: [3, 1], direction: "east" },
@@ -208,7 +226,7 @@ describe("actionHighlightsForSource", () => {
       [1, 1]
     );
 
-    expect(highlights.moves.map((tile) => tile.key)).toEqual(["2,1", "1,2", "3,1"]);
+    expect(highlights.moves.map((tile) => tile.key)).toEqual(["2,1", "2,1", "1,2", "3,1"]);
     expect(highlights.attacks.map((tile) => tile.key)).toEqual(["4,1", "4,1"]);
     expect(highlights.actionsByTile.get("4,1")?.map((action) => action.type)).toEqual([
       "attack",

--- a/frontend/src/rendering/actions.ts
+++ b/frontend/src/rendering/actions.ts
@@ -28,6 +28,8 @@ export type ActionPreview =
 
 const moveActionTypes = new Set([
   "move-wait",
+  "move-hide",
+  "move-unhide",
   "move-capture",
   "move-load",
   "move-combine",
@@ -36,6 +38,8 @@ const moveActionTypes = new Set([
 
 const movementPreviewTypes = new Set([
   "move-wait",
+  "move-hide",
+  "move-unhide",
   "move-capture",
   "move-load",
   "move-combine"


### PR DESCRIPTION
## Summary
- Add `move-hide` and `move-unhide` actions for Sub and Stealth units.
- Enforce hidden-target combat restrictions: hidden Stealths can only be attacked by Fighters/Stealths, and submerged Subs by Cruisers/Subs.
- Add focused JSON fixtures for hide/unhide legality, invalid toggles, hidden fuel drain, hidden attacks, and attack immunity, plus frontend action helper coverage.

## Root Cause
Sub and Stealth could serialize a `hidden` state and pay hidden fuel upkeep, but the engine had no first-class actions to enter or leave that state and combat targeting ignored the hidden-state attack restrictions.

## Tests
- First failing focused run observed after adding fixtures: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/units/stealth` failed on missing `move-hide`/`move-unhide` and hidden Stealth attack immunity; `..\x64\Debug\AdvanceWarsServer.exe -test test/json/units/sub` failed on missing `move-hide`/`move-unhide`.
- `& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/units/stealth`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/units/sub`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `yarn test`
- `yarn typecheck`
- `yarn build`

## Residual Risk
Full fog-of-war player-perspective visibility and hidden-unit reveal behavior remain deferred to #90; this PR focuses on the issue #34 hidden-state mechanics that fit the current engine/action model.

Closes #34