### PR TITLE
Add Standard GL action encoding and legal masks

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -162,6 +162,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="src\ActionSpace.cpp" />
     <ClCompile Include="src\AdvanceWarsServer.cpp" />
     <ClCompile Include="src\CommandingOfficier.cpp" />
     <ClCompile Include="src\GameState.cpp" />
@@ -184,6 +185,7 @@
     <ClInclude Include="D:\Projects\via-httplib-main\via-httplib-main\include\via\http\request_router.hpp" />
     <ClInclude Include="D:\Projects\via-httplib-main\via-httplib-main\include\via\http_server.hpp" />
     <ClInclude Include="deps\json-develop\single_include\nlohmann\json.hpp" />
+    <ClInclude Include="inc\ActionSpace.h" />
     <ClInclude Include="inc\AdvanceWarsServer.h" />
     <ClInclude Include="inc\CommandingOfficier.h" />
     <ClInclude Include="inc\GameState.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="src\RestApiContractTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\ActionSpace.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\Map.h">
@@ -147,6 +150,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\RestGameService.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\ActionSpace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AdvanceWarsServer/inc/ActionSpace.h
+++ b/AdvanceWarsServer/inc/ActionSpace.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "GameState.h"
+#include "Result.h"
+
+class ActionSpace final {
+public:
+	static const char* Version() noexcept;
+	static int BoardWidth() noexcept;
+	static int BoardHeight() noexcept;
+	static int ActionCount() noexcept;
+
+	static Result EncodeAction(const Action& action, int& encodedAction) noexcept;
+	static Result DecodeAction(int encodedAction, Action& action) noexcept;
+	static Result GenerateLegalActionMask(const GameState& gameState, std::vector<std::uint8_t>& mask) noexcept;
+};

--- a/AdvanceWarsServer/inc/SubsystemTest.h
+++ b/AdvanceWarsServer/inc/SubsystemTest.h
@@ -12,6 +12,11 @@ struct JsonSubsystemTest {
 	std::vector<std::pair<std::pair<int, int>, std::vector<Action>>> vecValidActions;
 	bool fHasFinalGameState{ false };
 	bool fDeterministicReplay{ false };
+	json actionSpace;
+	json legalActionMask;
+	bool fHasActionSpace{ false };
+	bool fHasLegalActionMask{ false };
+	bool fLegalActionMaskShouldFail{ false };
 };
 
 void from_json(json& j, JsonSubsystemTest& test);

--- a/AdvanceWarsServer/src/ActionSpace.cpp
+++ b/AdvanceWarsServer/src/ActionSpace.cpp
@@ -1,0 +1,532 @@
+#include "ActionSpace.h"
+
+namespace {
+constexpr int kBoardWidth = 27;
+constexpr int kBoardHeight = 23;
+constexpr int kCellCount = kBoardWidth * kBoardHeight;
+
+constexpr int DiamondCount(int radius) {
+	return 2 * radius * (radius + 1) + 1;
+}
+
+constexpr int OffsetCount(int minDistance, int maxDistance) {
+	return DiamondCount(maxDistance) - (minDistance <= 0 ? 0 : DiamondCount(minDistance - 1));
+}
+
+constexpr int kMoveOffsetRadius = 11;
+constexpr int kAttackOffsetMinDistance = 2;
+constexpr int kAttackOffsetRadius = 11;
+constexpr int kCaptureOffsetRadius = 5;
+constexpr int kHideOffsetRadius = 8;
+
+constexpr int kMoveOffsetCount = OffsetCount(0, kMoveOffsetRadius);
+constexpr int kAttackOffsetCount = OffsetCount(kAttackOffsetMinDistance, kAttackOffsetRadius);
+constexpr int kCaptureOffsetCount = OffsetCount(0, kCaptureOffsetRadius);
+constexpr int kHideOffsetCount = OffsetCount(0, kHideOffsetRadius);
+constexpr int kDirectionCount = 4;
+constexpr int kUnloadIndexCount = 2;
+constexpr int kUnitTypeCount = static_cast<int>(UnitProperties::Type::Size);
+
+constexpr int kMoveWaitPlaneStart = 0;
+constexpr int kMoveAttackPlaneStart = kMoveWaitPlaneStart + kMoveOffsetCount;
+constexpr int kAttackPlaneStart = kMoveAttackPlaneStart + kMoveOffsetCount * kDirectionCount;
+constexpr int kMoveCapturePlaneStart = kAttackPlaneStart + kAttackOffsetCount;
+constexpr int kMoveCombinePlaneStart = kMoveCapturePlaneStart + kCaptureOffsetCount;
+constexpr int kMoveLoadPlaneStart = kMoveCombinePlaneStart + kMoveOffsetCount;
+constexpr int kMoveHidePlaneStart = kMoveLoadPlaneStart + kMoveOffsetCount;
+constexpr int kMoveUnhidePlaneStart = kMoveHidePlaneStart + kHideOffsetCount;
+constexpr int kRepairPlaneStart = kMoveUnhidePlaneStart + kHideOffsetCount;
+constexpr int kUnloadPlaneStart = kRepairPlaneStart + kDirectionCount;
+constexpr int kBuyPlaneStart = kUnloadPlaneStart + kDirectionCount * kUnloadIndexCount;
+constexpr int kCellPlaneCount = kBuyPlaneStart + kUnitTypeCount;
+constexpr int kGlobalActionStart = kCellPlaneCount * kCellCount;
+constexpr int kActionCount = kGlobalActionStart + 3;
+
+static_assert(kMoveOffsetCount == 265, "Unexpected move offset count");
+static_assert(kAttackOffsetCount == 260, "Unexpected attack offset count");
+static_assert(kCaptureOffsetCount == 61, "Unexpected capture offset count");
+static_assert(kHideOffsetCount == 145, "Unexpected hide offset count");
+static_assert(kCellPlaneCount == 2503, "Unexpected action plane count");
+static_assert(kActionCount == 1554366, "Unexpected action count");
+
+int Abs(int value) noexcept {
+	return value < 0 ? -value : value;
+}
+
+bool IsInBounds(int x, int y) noexcept {
+	return x >= 0 && x < kBoardWidth && y >= 0 && y < kBoardHeight;
+}
+
+bool TryGetSourceCell(const Action& action, int& x, int& y, int& cellIndex) noexcept {
+	if (!action.m_optSource.has_value()) {
+		return false;
+	}
+
+	x = action.m_optSource->first;
+	y = action.m_optSource->second;
+	if (!IsInBounds(x, y)) {
+		return false;
+	}
+
+	cellIndex = y * kBoardWidth + x;
+	return true;
+}
+
+bool TryGetTargetOffset(const Action& action, int sourceX, int sourceY, int& dx, int& dy) noexcept {
+	if (!action.m_optTarget.has_value()) {
+		return false;
+	}
+
+	const int targetX = action.m_optTarget->first;
+	const int targetY = action.m_optTarget->second;
+	if (!IsInBounds(targetX, targetY)) {
+		return false;
+	}
+
+	dx = targetX - sourceX;
+	dy = targetY - sourceY;
+	return true;
+}
+
+bool TryGetOffsetIndex(int dx, int dy, int minDistance, int maxDistance, int& offsetIndex) noexcept {
+	int index = 0;
+	for (int currentDy = -maxDistance; currentDy <= maxDistance; ++currentDy) {
+		for (int currentDx = -maxDistance; currentDx <= maxDistance; ++currentDx) {
+			const int distance = Abs(currentDx) + Abs(currentDy);
+			if (distance < minDistance || distance > maxDistance) {
+				continue;
+			}
+
+			if (currentDx == dx && currentDy == dy) {
+				offsetIndex = index;
+				return true;
+			}
+
+			++index;
+		}
+	}
+
+	return false;
+}
+
+bool TryGetOffsetAt(int offsetIndex, int minDistance, int maxDistance, int& dx, int& dy) noexcept {
+	if (offsetIndex < 0 || offsetIndex >= OffsetCount(minDistance, maxDistance)) {
+		return false;
+	}
+
+	int index = 0;
+	for (int currentDy = -maxDistance; currentDy <= maxDistance; ++currentDy) {
+		for (int currentDx = -maxDistance; currentDx <= maxDistance; ++currentDx) {
+			const int distance = Abs(currentDx) + Abs(currentDy);
+			if (distance < minDistance || distance > maxDistance) {
+				continue;
+			}
+
+			if (index == offsetIndex) {
+				dx = currentDx;
+				dy = currentDy;
+				return true;
+			}
+
+			++index;
+		}
+	}
+
+	return false;
+}
+
+bool TryGetDirectionIndex(Action::Direction direction, int& directionIndex) noexcept {
+	switch (direction) {
+	case Action::Direction::North:
+		directionIndex = 0;
+		return true;
+	case Action::Direction::East:
+		directionIndex = 1;
+		return true;
+	case Action::Direction::South:
+		directionIndex = 2;
+		return true;
+	case Action::Direction::West:
+		directionIndex = 3;
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool TryGetDirectionAt(int directionIndex, Action::Direction& direction) noexcept {
+	switch (directionIndex) {
+	case 0:
+		direction = Action::Direction::North;
+		return true;
+	case 1:
+		direction = Action::Direction::East;
+		return true;
+	case 2:
+		direction = Action::Direction::South;
+		return true;
+	case 3:
+		direction = Action::Direction::West;
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool HasNoExtraGlobalFields(const Action& action) noexcept {
+	return !action.m_optSource.has_value() &&
+		!action.m_optTarget.has_value() &&
+		!action.m_optDirection.has_value() &&
+		!action.m_optUnitType.has_value() &&
+		!action.m_optUnloadIndex.has_value();
+}
+
+Result EncodeTargetOffsetAction(const Action& action, int planeStart, int minDistance, int maxDistance, int& encodedAction) noexcept {
+	int sourceX = 0;
+	int sourceY = 0;
+	int cellIndex = 0;
+	if (!TryGetSourceCell(action, sourceX, sourceY, cellIndex)) {
+		return Result::Failed;
+	}
+
+	int dx = 0;
+	int dy = 0;
+	if (!TryGetTargetOffset(action, sourceX, sourceY, dx, dy)) {
+		return Result::Failed;
+	}
+
+	int offsetIndex = 0;
+	if (!TryGetOffsetIndex(dx, dy, minDistance, maxDistance, offsetIndex)) {
+		return Result::Failed;
+	}
+
+	encodedAction = (planeStart + offsetIndex) * kCellCount + cellIndex;
+	return Result::Succeeded;
+}
+
+Result DecodeTargetOffsetAction(int planeStart, int plane, int cellIndex, int minDistance, int maxDistance, Action::Type type, Action& action) noexcept {
+	const int offsetIndex = plane - planeStart;
+
+	int dx = 0;
+	int dy = 0;
+	if (!TryGetOffsetAt(offsetIndex, minDistance, maxDistance, dx, dy)) {
+		return Result::Failed;
+	}
+
+	const int sourceX = cellIndex % kBoardWidth;
+	const int sourceY = cellIndex / kBoardWidth;
+	const int targetX = sourceX + dx;
+	const int targetY = sourceY + dy;
+	if (!IsInBounds(targetX, targetY)) {
+		return Result::Failed;
+	}
+
+	action = Action(type, sourceX, sourceY, targetX, targetY);
+	return Result::Succeeded;
+}
+
+Result EncodeMoveAttackAction(const Action& action, int& encodedAction) noexcept {
+	int sourceX = 0;
+	int sourceY = 0;
+	int cellIndex = 0;
+	if (!TryGetSourceCell(action, sourceX, sourceY, cellIndex)) {
+		return Result::Failed;
+	}
+
+	int dx = 0;
+	int dy = 0;
+	if (!TryGetTargetOffset(action, sourceX, sourceY, dx, dy)) {
+		return Result::Failed;
+	}
+
+	int offsetIndex = 0;
+	if (!TryGetOffsetIndex(dx, dy, 0, kMoveOffsetRadius, offsetIndex)) {
+		return Result::Failed;
+	}
+
+	if (!action.m_optDirection.has_value()) {
+		return Result::Failed;
+	}
+
+	int directionIndex = 0;
+	if (!TryGetDirectionIndex(*action.m_optDirection, directionIndex)) {
+		return Result::Failed;
+	}
+
+	encodedAction = (kMoveAttackPlaneStart + offsetIndex * kDirectionCount + directionIndex) * kCellCount + cellIndex;
+	return Result::Succeeded;
+}
+
+Result DecodeMoveAttackAction(int plane, int cellIndex, Action& action) noexcept {
+	const int relativePlane = plane - kMoveAttackPlaneStart;
+	const int offsetIndex = relativePlane / kDirectionCount;
+	const int directionIndex = relativePlane % kDirectionCount;
+
+	int dx = 0;
+	int dy = 0;
+	if (!TryGetOffsetAt(offsetIndex, 0, kMoveOffsetRadius, dx, dy)) {
+		return Result::Failed;
+	}
+
+	Action::Direction direction = Action::Direction::Invalid;
+	if (!TryGetDirectionAt(directionIndex, direction)) {
+		return Result::Failed;
+	}
+
+	const int sourceX = cellIndex % kBoardWidth;
+	const int sourceY = cellIndex / kBoardWidth;
+	const int targetX = sourceX + dx;
+	const int targetY = sourceY + dy;
+	if (!IsInBounds(targetX, targetY)) {
+		return Result::Failed;
+	}
+
+	action = Action(Action::Type::MoveAttack, sourceX, sourceY, direction, targetX, targetY);
+	return Result::Succeeded;
+}
+
+Result EncodeRepairAction(const Action& action, int& encodedAction) noexcept {
+	int sourceX = 0;
+	int sourceY = 0;
+	int cellIndex = 0;
+	if (!TryGetSourceCell(action, sourceX, sourceY, cellIndex) || !action.m_optDirection.has_value()) {
+		return Result::Failed;
+	}
+
+	int directionIndex = 0;
+	if (!TryGetDirectionIndex(*action.m_optDirection, directionIndex)) {
+		return Result::Failed;
+	}
+
+	encodedAction = (kRepairPlaneStart + directionIndex) * kCellCount + cellIndex;
+	return Result::Succeeded;
+}
+
+Result DecodeRepairAction(int plane, int cellIndex, Action& action) noexcept {
+	Action::Direction direction = Action::Direction::Invalid;
+	if (!TryGetDirectionAt(plane - kRepairPlaneStart, direction)) {
+		return Result::Failed;
+	}
+
+	action = Action(Action::Type::Repair, cellIndex % kBoardWidth, cellIndex / kBoardWidth, direction);
+	return Result::Succeeded;
+}
+
+Result EncodeUnloadAction(const Action& action, int& encodedAction) noexcept {
+	int sourceX = 0;
+	int sourceY = 0;
+	int cellIndex = 0;
+	if (!TryGetSourceCell(action, sourceX, sourceY, cellIndex) ||
+		!action.m_optDirection.has_value() ||
+		!action.m_optUnloadIndex.has_value()) {
+		return Result::Failed;
+	}
+
+	int directionIndex = 0;
+	if (!TryGetDirectionIndex(*action.m_optDirection, directionIndex)) {
+		return Result::Failed;
+	}
+
+	const int unloadIndex = *action.m_optUnloadIndex;
+	if (unloadIndex < 0 || unloadIndex >= kUnloadIndexCount) {
+		return Result::Failed;
+	}
+
+	encodedAction = (kUnloadPlaneStart + directionIndex * kUnloadIndexCount + unloadIndex) * kCellCount + cellIndex;
+	return Result::Succeeded;
+}
+
+Result DecodeUnloadAction(int plane, int cellIndex, Action& action) noexcept {
+	const int relativePlane = plane - kUnloadPlaneStart;
+	const int directionIndex = relativePlane / kUnloadIndexCount;
+	const int unloadIndex = relativePlane % kUnloadIndexCount;
+
+	Action::Direction direction = Action::Direction::Invalid;
+	if (!TryGetDirectionAt(directionIndex, direction)) {
+		return Result::Failed;
+	}
+
+	action = Action(Action::Type::Unload, cellIndex % kBoardWidth, cellIndex / kBoardWidth, direction, unloadIndex);
+	return Result::Succeeded;
+}
+
+Result EncodeBuyAction(const Action& action, int& encodedAction) noexcept {
+	int sourceX = 0;
+	int sourceY = 0;
+	int cellIndex = 0;
+	if (!TryGetSourceCell(action, sourceX, sourceY, cellIndex) || !action.m_optUnitType.has_value()) {
+		return Result::Failed;
+	}
+
+	const int unitTypeIndex = static_cast<int>(*action.m_optUnitType);
+	if (unitTypeIndex < 0 || unitTypeIndex >= kUnitTypeCount) {
+		return Result::Failed;
+	}
+
+	encodedAction = (kBuyPlaneStart + unitTypeIndex) * kCellCount + cellIndex;
+	return Result::Succeeded;
+}
+
+Result DecodeBuyAction(int plane, int cellIndex, Action& action) noexcept {
+	const int unitTypeIndex = plane - kBuyPlaneStart;
+	if (unitTypeIndex < 0 || unitTypeIndex >= kUnitTypeCount) {
+		return Result::Failed;
+	}
+
+	action = Action(Action::Type::Buy, cellIndex % kBoardWidth, cellIndex / kBoardWidth, static_cast<UnitProperties::Type>(unitTypeIndex));
+	return Result::Succeeded;
+}
+}
+
+const char* ActionSpace::Version() noexcept {
+	return "standard-gl-v1";
+}
+
+int ActionSpace::BoardWidth() noexcept {
+	return kBoardWidth;
+}
+
+int ActionSpace::BoardHeight() noexcept {
+	return kBoardHeight;
+}
+
+int ActionSpace::ActionCount() noexcept {
+	return kActionCount;
+}
+
+Result ActionSpace::EncodeAction(const Action& action, int& encodedAction) noexcept {
+	if (HasNoExtraGlobalFields(action)) {
+		switch (action.m_type) {
+		case Action::Type::EndTurn:
+			encodedAction = kGlobalActionStart;
+			return Result::Succeeded;
+		case Action::Type::COPower:
+			encodedAction = kGlobalActionStart + 1;
+			return Result::Succeeded;
+		case Action::Type::SCOPower:
+			encodedAction = kGlobalActionStart + 2;
+			return Result::Succeeded;
+		default:
+			break;
+		}
+	}
+
+	switch (action.m_type) {
+	case Action::Type::MoveWait:
+		return EncodeTargetOffsetAction(action, kMoveWaitPlaneStart, 0, kMoveOffsetRadius, encodedAction);
+	case Action::Type::MoveAttack:
+		return EncodeMoveAttackAction(action, encodedAction);
+	case Action::Type::Attack:
+		return EncodeTargetOffsetAction(action, kAttackPlaneStart, kAttackOffsetMinDistance, kAttackOffsetRadius, encodedAction);
+	case Action::Type::MoveCapture:
+		return EncodeTargetOffsetAction(action, kMoveCapturePlaneStart, 0, kCaptureOffsetRadius, encodedAction);
+	case Action::Type::MoveCombine:
+		return EncodeTargetOffsetAction(action, kMoveCombinePlaneStart, 0, kMoveOffsetRadius, encodedAction);
+	case Action::Type::MoveLoad:
+		return EncodeTargetOffsetAction(action, kMoveLoadPlaneStart, 0, kMoveOffsetRadius, encodedAction);
+	case Action::Type::MoveHide:
+		return EncodeTargetOffsetAction(action, kMoveHidePlaneStart, 0, kHideOffsetRadius, encodedAction);
+	case Action::Type::MoveUnhide:
+		return EncodeTargetOffsetAction(action, kMoveUnhidePlaneStart, 0, kHideOffsetRadius, encodedAction);
+	case Action::Type::Repair:
+		return EncodeRepairAction(action, encodedAction);
+	case Action::Type::Unload:
+		return EncodeUnloadAction(action, encodedAction);
+	case Action::Type::Buy:
+		return EncodeBuyAction(action, encodedAction);
+	default:
+		break;
+	}
+
+	return Result::Failed;
+}
+
+Result ActionSpace::DecodeAction(int encodedAction, Action& action) noexcept {
+	if (encodedAction < 0 || encodedAction >= kActionCount) {
+		return Result::Failed;
+	}
+
+	if (encodedAction >= kGlobalActionStart) {
+		switch (encodedAction - kGlobalActionStart) {
+		case 0:
+			action = Action(Action::Type::EndTurn);
+			return Result::Succeeded;
+		case 1:
+			action = Action(Action::Type::COPower);
+			return Result::Succeeded;
+		case 2:
+			action = Action(Action::Type::SCOPower);
+			return Result::Succeeded;
+		default:
+			return Result::Failed;
+		}
+	}
+
+	const int plane = encodedAction / kCellCount;
+	const int cellIndex = encodedAction % kCellCount;
+
+	if (plane >= kMoveWaitPlaneStart && plane < kMoveAttackPlaneStart) {
+		return DecodeTargetOffsetAction(kMoveWaitPlaneStart, plane, cellIndex, 0, kMoveOffsetRadius, Action::Type::MoveWait, action);
+	}
+
+	if (plane >= kMoveAttackPlaneStart && plane < kAttackPlaneStart) {
+		return DecodeMoveAttackAction(plane, cellIndex, action);
+	}
+
+	if (plane >= kAttackPlaneStart && plane < kMoveCapturePlaneStart) {
+		return DecodeTargetOffsetAction(kAttackPlaneStart, plane, cellIndex, kAttackOffsetMinDistance, kAttackOffsetRadius, Action::Type::Attack, action);
+	}
+
+	if (plane >= kMoveCapturePlaneStart && plane < kMoveCombinePlaneStart) {
+		return DecodeTargetOffsetAction(kMoveCapturePlaneStart, plane, cellIndex, 0, kCaptureOffsetRadius, Action::Type::MoveCapture, action);
+	}
+
+	if (plane >= kMoveCombinePlaneStart && plane < kMoveLoadPlaneStart) {
+		return DecodeTargetOffsetAction(kMoveCombinePlaneStart, plane, cellIndex, 0, kMoveOffsetRadius, Action::Type::MoveCombine, action);
+	}
+
+	if (plane >= kMoveLoadPlaneStart && plane < kMoveHidePlaneStart) {
+		return DecodeTargetOffsetAction(kMoveLoadPlaneStart, plane, cellIndex, 0, kMoveOffsetRadius, Action::Type::MoveLoad, action);
+	}
+
+	if (plane >= kMoveHidePlaneStart && plane < kMoveUnhidePlaneStart) {
+		return DecodeTargetOffsetAction(kMoveHidePlaneStart, plane, cellIndex, 0, kHideOffsetRadius, Action::Type::MoveHide, action);
+	}
+
+	if (plane >= kMoveUnhidePlaneStart && plane < kRepairPlaneStart) {
+		return DecodeTargetOffsetAction(kMoveUnhidePlaneStart, plane, cellIndex, 0, kHideOffsetRadius, Action::Type::MoveUnhide, action);
+	}
+
+	if (plane >= kRepairPlaneStart && plane < kUnloadPlaneStart) {
+		return DecodeRepairAction(plane, cellIndex, action);
+	}
+
+	if (plane >= kUnloadPlaneStart && plane < kBuyPlaneStart) {
+		return DecodeUnloadAction(plane, cellIndex, action);
+	}
+
+	if (plane >= kBuyPlaneStart && plane < kCellPlaneCount) {
+		return DecodeBuyAction(plane, cellIndex, action);
+	}
+
+	return Result::Failed;
+}
+
+Result ActionSpace::GenerateLegalActionMask(const GameState& gameState, std::vector<std::uint8_t>& mask) noexcept {
+	const Map* map = gameState.TryGetMap();
+	if (map == nullptr || map->GetCols() > kBoardWidth || map->GetRows() > kBoardHeight) {
+		return Result::Failed;
+	}
+
+	mask.assign(kActionCount, 0U);
+
+	std::vector<Action> legalActions;
+	IfFailedReturn(gameState.GetValidActions(legalActions));
+	for (const Action& action : legalActions) {
+		int encodedAction = -1;
+		IfFailedReturn(EncodeAction(action, encodedAction));
+		mask[encodedAction] = 1U;
+	}
+
+	return Result::Succeeded;
+}

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -3,7 +3,9 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <unordered_set>
 
+#include "ActionSpace.h"
 #include "GameState.h"
 
 namespace {
@@ -114,6 +116,211 @@ Result BuildActionTrace(GameState gameState, const std::vector<Action>& actions,
 	traceDump = trace.dump();
 	return Result::Succeeded;
 }
+
+Result ExpectJsonValue(const json& actualJson, const json& expectedJson, const std::string& label, std::string& expected, std::string& actual) {
+	expected = label + ": " + expectedJson.dump();
+	actual = actualJson.dump();
+	if (actualJson != expectedJson) {
+		return Result::Failed;
+	}
+
+	return Result::Succeeded;
+}
+
+Result RunActionSpaceAssertions(const json& actionSpace, std::string& expected, std::string& actual) {
+	if (actionSpace.contains("version")) {
+		json actualVersion = ActionSpace::Version();
+		IfFailedReturn(ExpectJsonValue(actualVersion, actionSpace.at("version"), "action-space version", expected, actual));
+	}
+
+	if (actionSpace.contains("width")) {
+		json actualWidth = ActionSpace::BoardWidth();
+		IfFailedReturn(ExpectJsonValue(actualWidth, actionSpace.at("width"), "action-space width", expected, actual));
+	}
+
+	if (actionSpace.contains("height")) {
+		json actualHeight = ActionSpace::BoardHeight();
+		IfFailedReturn(ExpectJsonValue(actualHeight, actionSpace.at("height"), "action-space height", expected, actual));
+	}
+
+	if (actionSpace.contains("action-count")) {
+		json actualActionCount = ActionSpace::ActionCount();
+		IfFailedReturn(ExpectJsonValue(actualActionCount, actionSpace.at("action-count"), "action-space action-count", expected, actual));
+	}
+
+	if (actionSpace.contains("encodedActions")) {
+		for (const json& encodedActionJson : actionSpace.at("encodedActions")) {
+			Action action;
+			json actionJson = encodedActionJson.at("action");
+			from_json(actionJson, action);
+
+			int encodedAction = -1;
+			if (ActionSpace::EncodeAction(action, encodedAction) == Result::Failed) {
+				json jAction;
+				to_json(jAction, action);
+				SetMismatch(expected, actual, "action should encode", jAction.dump(), "encode failed");
+				return Result::Failed;
+			}
+
+			if (encodedActionJson.contains("index") && encodedAction != encodedActionJson.at("index").get<int>()) {
+				json jAction;
+				to_json(jAction, action);
+				SetMismatch(expected, actual, "encoded index for " + jAction.dump(), encodedActionJson.at("index").dump(), std::to_string(encodedAction));
+				return Result::Failed;
+			}
+
+			Action decodedAction;
+			if (ActionSpace::DecodeAction(encodedAction, decodedAction) == Result::Failed) {
+				SetMismatch(expected, actual, "encoded action should decode", std::to_string(encodedAction), "decode failed");
+				return Result::Failed;
+			}
+
+			if (!(decodedAction == action)) {
+				json jExpected;
+				json jActual;
+				to_json(jExpected, action);
+				to_json(jActual, decodedAction);
+				expected = jExpected.dump();
+				actual = jActual.dump();
+				return Result::Failed;
+			}
+		}
+	}
+
+	if (actionSpace.contains("invalidEncodedActions")) {
+		for (const json& actionJsonSource : actionSpace.at("invalidEncodedActions")) {
+			Action action;
+			json actionJson = actionJsonSource;
+			from_json(actionJson, action);
+
+			int encodedAction = -1;
+			if (ActionSpace::EncodeAction(action, encodedAction) == Result::Succeeded) {
+				json jAction;
+				to_json(jAction, action);
+				SetMismatch(expected, actual, "action should fail to encode", jAction.dump(), std::to_string(encodedAction));
+				return Result::Failed;
+			}
+		}
+	}
+
+	if (actionSpace.contains("decodedActions")) {
+		for (const json& decodedActionJson : actionSpace.at("decodedActions")) {
+			Action actualAction;
+			int encodedAction = decodedActionJson.at("index").get<int>();
+			if (ActionSpace::DecodeAction(encodedAction, actualAction) == Result::Failed) {
+				SetMismatch(expected, actual, "index should decode", std::to_string(encodedAction), "decode failed");
+				return Result::Failed;
+			}
+
+			Action expectedAction;
+			json expectedActionJson = decodedActionJson.at("action");
+			from_json(expectedActionJson, expectedAction);
+			if (!(actualAction == expectedAction)) {
+				json jExpected;
+				json jActual;
+				to_json(jExpected, expectedAction);
+				to_json(jActual, actualAction);
+				expected = jExpected.dump();
+				actual = jActual.dump();
+				return Result::Failed;
+			}
+		}
+	}
+
+	if (actionSpace.contains("invalidIndices")) {
+		for (const json& indexJson : actionSpace.at("invalidIndices")) {
+			Action action;
+			int encodedAction = indexJson.get<int>();
+			if (ActionSpace::DecodeAction(encodedAction, action) == Result::Succeeded) {
+				json jAction;
+				to_json(jAction, action);
+				SetMismatch(expected, actual, "index should fail to decode", std::to_string(encodedAction), jAction.dump());
+				return Result::Failed;
+			}
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+Result RunLegalActionMaskAssertions(const GameState& gameState, const json& legalActionMask, bool shouldFail, std::string& expected, std::string& actual) {
+	std::vector<std::uint8_t> mask;
+	Result result = ActionSpace::GenerateLegalActionMask(gameState, mask);
+	if (shouldFail) {
+		if (result == Result::Succeeded) {
+			SetMismatch(expected, actual, "legal action mask generation should fail", "failed", "succeeded");
+			return Result::Failed;
+		}
+
+		return Result::Succeeded;
+	}
+
+	if (result == Result::Failed) {
+		SetMismatch(expected, actual, "legal action mask generation should succeed", "succeeded", "failed");
+		return Result::Failed;
+	}
+
+	if (mask.size() != static_cast<std::size_t>(ActionSpace::ActionCount())) {
+		SetMismatch(expected, actual, "mask size", std::to_string(ActionSpace::ActionCount()), std::to_string(mask.size()));
+		return Result::Failed;
+	}
+
+	std::vector<Action> legalActions;
+	IfFailedReturn(gameState.GetValidActions(legalActions));
+
+	std::unordered_set<int> uniqueLegalActionIndices;
+	for (const Action& legalAction : legalActions) {
+		int encodedAction = -1;
+		IfFailedReturn(ActionSpace::EncodeAction(legalAction, encodedAction));
+		uniqueLegalActionIndices.insert(encodedAction);
+	}
+
+	std::size_t actualMaskCount = 0;
+	for (std::uint8_t maskValue : mask) {
+		if (maskValue != 0U) {
+			++actualMaskCount;
+		}
+	}
+
+	if (actualMaskCount != uniqueLegalActionIndices.size()) {
+		SetMismatch(expected, actual, "mask legal action count", std::to_string(uniqueLegalActionIndices.size()), std::to_string(actualMaskCount));
+		return Result::Failed;
+	}
+
+	if (legalActionMask.contains("expectedLegalActions")) {
+		for (const json& actionJsonSource : legalActionMask.at("expectedLegalActions")) {
+			Action action;
+			json actionJson = actionJsonSource;
+			from_json(actionJson, action);
+			int encodedAction = -1;
+			IfFailedReturn(ActionSpace::EncodeAction(action, encodedAction));
+			if (mask[encodedAction] == 0U) {
+				json jAction;
+				to_json(jAction, action);
+				SetMismatch(expected, actual, "expected legal action mask bit", jAction.dump(), "0");
+				return Result::Failed;
+			}
+		}
+	}
+
+	if (legalActionMask.contains("expectedIllegalActions")) {
+		for (const json& actionJsonSource : legalActionMask.at("expectedIllegalActions")) {
+			Action action;
+			json actionJson = actionJsonSource;
+			from_json(actionJson, action);
+			int encodedAction = -1;
+			IfFailedReturn(ActionSpace::EncodeAction(action, encodedAction));
+			if (mask[encodedAction] != 0U) {
+				json jAction;
+				to_json(jAction, action);
+				SetMismatch(expected, actual, "expected illegal action mask bit", jAction.dump(), "1");
+				return Result::Failed;
+			}
+		}
+	}
+
+	return Result::Succeeded;
+}
 }
 
 void from_json(json& j, JsonSubsystemTest& test) {
@@ -157,6 +364,21 @@ void from_json(json& j, JsonSubsystemTest& test) {
 
 	if (j.contains("deterministic-replay")) {
 		j.at("deterministic-replay").get_to(test.fDeterministicReplay);
+	}
+
+	if (j.contains("actionSpace")) {
+		test.actionSpace = j.at("actionSpace");
+		test.fHasActionSpace = true;
+	}
+
+	if (j.contains("legalActionMask")) {
+		test.legalActionMask = j.at("legalActionMask");
+		test.fHasLegalActionMask = true;
+	}
+
+	if (j.contains("legalActionMaskShouldFail")) {
+		j.at("legalActionMaskShouldFail").get_to(test.fLegalActionMaskShouldFail);
+		test.fHasLegalActionMask = true;
 	}
 }
 
@@ -266,6 +488,14 @@ Result JsonTestRunner::run() {
 				return Result::Failed;
 			}
 		}
+	}
+
+	if (test.fHasActionSpace) {
+		IfFailedReturn(RunActionSpaceAssertions(test.actionSpace, m_strExpected, m_strActual));
+	}
+
+	if (test.fHasLegalActionMask) {
+		IfFailedReturn(RunLegalActionMaskAssertions(test.initialGameState, test.legalActionMask, test.fLegalActionMaskShouldFail, m_strExpected, m_strActual));
 	}
 
 

--- a/AdvanceWarsServer/test/json/action-space/encoding-and-mask.json
+++ b/AdvanceWarsServer/test/json/action-space/encoding-and-mask.json
@@ -1,0 +1,127 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "action-space-encoding-and-mask",
+    "map": [
+      [
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "artillery" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 9, "fuel": 70, "health": 100, "hidden": false, "moved": false, "owner": "blue-moon", "type": "tank" } },
+        { "property": { "capture-points": 20, "owner": "neutral" }, "terrain": 34, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 90, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15 },
+        { "property": { "capture-points": 20, "owner": "orange-star" }, "terrain": 35 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 12, "health": 90, "hidden": false, "moved": false, "owner": "orange-star", "type": "tank" } },
+        { "terrain": 29, "unit": { "ammo": 0, "fuel": 50, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "blackboat" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 60, "health": 100, "hidden": false, "loaded-units": [{ "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" }], "moved": false, "owner": "orange-star", "type": "apc" } },
+        { "terrain": 15 },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" } },
+        { "terrain": 15, "unit": { "ammo": 0, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "apc" } },
+        { "terrain": 15, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "stealth" } },
+        { "terrain": 29, "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "orange-star", "type": "sub" } },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ],
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 300000,
+        "power-meter": { "charge": 54000, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "actionSpace": {
+    "version": "standard-gl-v1",
+    "width": 27,
+    "height": 23,
+    "action-count": 1554366,
+    "encodedActions": [
+      { "action": { "type": "move-wait", "source": [0, 11], "target": [0, 0] }, "index": 297 },
+      { "action": { "type": "move-wait", "source": [0, 0], "target": [0, 0] }, "index": 81972 },
+      { "action": { "type": "move-attack", "source": [1, 1], "target": [1, 1], "direction": "east" }, "index": 493102 },
+      { "action": { "type": "attack", "source": [0, 0], "target": [2, 0] }, "index": 903555 },
+      { "action": { "type": "move-capture", "source": [0, 0], "target": [0, 0] }, "index": 1002915 },
+      { "action": { "type": "move-combine", "source": [0, 0], "target": [0, 0] }, "index": 1104138 },
+      { "action": { "type": "move-load", "source": [1, 0], "target": [2, 0] }, "index": 1269325 },
+      { "action": { "type": "move-hide", "source": [0, 0], "target": [0, 0] }, "index": 1396008 },
+      { "action": { "type": "move-unhide", "source": [0, 0], "target": [0, 0] }, "index": 1486053 },
+      { "action": { "type": "repair", "source": [1, 0], "direction": "west" }, "index": 1533250 },
+      { "action": { "type": "unload", "source": [2, 0], "direction": "west", "unloadIndex": 0 }, "index": 1537598 },
+      { "action": { "type": "buy", "source": [0, 0], "unit": "anti-air" }, "index": 1538838 },
+      { "action": { "type": "buy", "source": [26, 22], "unit": "tank" }, "index": 1554362 },
+      { "action": { "type": "end-turn" }, "index": 1554363 },
+      { "action": { "type": "co-power" }, "index": 1554364 },
+      { "action": { "type": "super-co-power" }, "index": 1554365 }
+    ],
+    "invalidEncodedActions": [
+      { "type": "move-wait", "source": [27, 0], "target": [27, 0] },
+      { "type": "move-wait", "source": [0, 0], "target": [12, 0] },
+      { "type": "attack", "source": [0, 0], "target": [1, 0] },
+      { "type": "move-capture", "source": [0, 0], "target": [6, 0] },
+      { "type": "unload", "source": [0, 0], "direction": "north", "unloadIndex": 2 }
+    ],
+    "invalidIndices": [ -1, 0, 1554366 ]
+  },
+  "legalActionMask": {
+    "expectedLegalActions": [
+      { "type": "move-wait", "source": [0, 0], "target": [0, 0] },
+      { "type": "move-attack", "source": [0, 0], "target": [1, 0], "direction": "east" },
+      { "type": "attack", "source": [3, 0], "target": [5, 0] },
+      { "type": "move-capture", "source": [6, 0], "target": [6, 0] },
+      { "type": "move-combine", "source": [7, 0], "target": [8, 0] },
+      { "type": "move-load", "source": [4, 1], "target": [5, 1] },
+      { "type": "move-hide", "source": [6, 1], "target": [6, 1] },
+      { "type": "move-unhide", "source": [7, 1], "target": [7, 1] },
+      { "type": "repair", "source": [1, 1], "direction": "west" },
+      { "type": "unload", "source": [2, 1], "direction": "east", "unloadIndex": 0 },
+      { "type": "buy", "source": [10, 0], "unit": "infantry" },
+      { "type": "co-power" },
+      { "type": "super-co-power" },
+      { "type": "end-turn" }
+    ],
+    "expectedIllegalActions": [
+      { "type": "buy", "source": [11, 0], "unit": "infantry" },
+      { "type": "move-wait", "source": [0, 0], "target": [11, 0] }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/action-space/map-too-large-mask-fails.json
+++ b/AdvanceWarsServer/test/json/action-space/map-too-large-mask-fails.json
@@ -1,0 +1,62 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "action-space-map-too-large-mask-fails",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "legalActionMaskShouldFail": true
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [STANDARD_ENGINE_COMPLETENESS.md](STANDARD_ENGINE_COMPLETENESS.md) for the c
 | `CO_SUPPORT.md` | Implemented CO behavior and focused CO follow-up issues. |
 | `TRAINING_LOOP_WORK_ITEMS.md` | Self-play, MCTS, tensor, model, and training-loop roadmap. |
 | `docs/API.md` | Current and target REST/API contract notes. |
+| `docs/TRAINING_DESIGN.md` | Recommended self-play training architecture and data flow. |
 | `docs/JSON_FIXTURES.md` | JSON regression fixture format and authoring guide. |
 
 ## Quick Start

--- a/docs/ACTION_SPACE.md
+++ b/docs/ACTION_SPACE.md
@@ -1,0 +1,58 @@
+# Action Space Encoding
+
+The v1 policy/action encoding is `standard-gl-v1`. It is scoped to in-game actions for Standard GL self-play. Pregame CO choice is not an `Action`; it is tracked separately by issue #164.
+
+## Board Shape
+
+`standard-gl-v1` uses a fixed `27x23` board shape, matching the largest current Standard GL map checked during issue #4 design. Smaller maps are encoded in the top-left of that shape. Off-map source cells and impossible target offsets remain masked illegal.
+
+Mask generation fails if the current map is wider than 27 tiles or taller than 23 tiles. That failure is intentional so a new map pool cannot silently train against a clipped policy space.
+
+## Flat Index Layout
+
+Source-cell actions are arranged as action planes over the fixed board:
+
+```text
+cell = y * 27 + x
+index = plane * (27 * 23) + cell
+```
+
+There are `621` source cells. Global actions are appended after all source-cell planes.
+
+## Plane Order
+
+Offsets use Manhattan distance and are ordered by `dy`, then `dx`. Directions are ordered `north`, `east`, `south`, `west`. Unload indices are ordered `0`, then `1`. Buy unit planes follow `UnitProperties::Type` enum order.
+
+| Plane start | Plane count | Action family | Payload |
+| ---: | ---: | --- | --- |
+| 0 | 265 | `move-wait` | target offset, radius 11 |
+| 265 | 1060 | `move-attack` | target offset radius 11, then direction |
+| 1325 | 260 | `attack` | target offset distance 2 through 11 |
+| 1585 | 61 | `move-capture` | target offset, radius 5 |
+| 1646 | 265 | `move-combine` | target offset, radius 11 |
+| 1911 | 265 | `move-load` | target offset, radius 11 |
+| 2176 | 145 | `move-hide` | target offset, radius 8 |
+| 2321 | 145 | `move-unhide` | target offset, radius 8 |
+| 2466 | 4 | `repair` | direction |
+| 2470 | 8 | `unload` | direction, then unload index |
+| 2478 | 25 | `buy` | unit type |
+
+The source-cell plane count is `2503`.
+
+## Global Actions
+
+Global action indices are appended after the source-cell planes:
+
+| Index | Action |
+| ---: | --- |
+| 1554363 | `end-turn` |
+| 1554364 | `co-power` |
+| 1554365 | `super-co-power` |
+
+The total action count is `1,554,366`.
+
+## Decode And Masks
+
+`ActionSpace::DecodeAction` turns a structurally valid index into the candidate `Action` even if that action is not legal in a specific state. It fails for out-of-range indices and indices whose offset would leave the fixed `27x23` board.
+
+`ActionSpace::GenerateLegalActionMask` is the state-aware gate. It calls `GameState::GetValidActions`, encodes each legal action, and returns a `std::vector<std::uint8_t>` with `0/1` values.

--- a/docs/JSON_FIXTURES.md
+++ b/docs/JSON_FIXTURES.md
@@ -136,6 +136,41 @@ Use `invalid-co` to assert that an unknown CO string is rejected.
 
 Power-meter expectations are partial in CO contract fixtures: include only the fields relevant to the behavior under test. State-transition fixtures compare the full serialized game state, including `"charge"`, `"star-value"`, `"cop-threshold"`, `"scop-threshold"`, `"can-use-cop"`, and `"can-use-scop"` for each player.
 
+### Action Space Fixture
+
+Use `actionSpace` to assert the stable policy/action encoding contract, and `legalActionMask` to assert mask bits generated from `GameState::GetValidActions`.
+
+```json
+{
+  "initial-game-state": {
+  },
+  "actionSpace": {
+    "version": "standard-gl-v1",
+    "width": 27,
+    "height": 23,
+    "action-count": 1554366,
+    "encodedActions": [
+      {
+        "action": { "type": "end-turn" },
+        "index": 1554363
+      }
+    ],
+    "invalidEncodedActions": [
+    ],
+    "invalidIndices": [
+    ]
+  },
+  "legalActionMask": {
+    "expectedLegalActions": [
+    ],
+    "expectedIllegalActions": [
+    ]
+  }
+}
+```
+
+Use `"legalActionMaskShouldFail": true` for states whose map shape should be rejected by the action-space version.
+
 ## Action JSON
 
 Action JSON is parsed by `from_json(json&, Action&)` in `GameState.cpp`. Existing fixtures are the best source for exact spelling. Common action types include:

--- a/docs/TRAINING_DESIGN.md
+++ b/docs/TRAINING_DESIGN.md
@@ -1,0 +1,80 @@
+# Self-Play Training Design
+
+This document describes the recommended first training path for the Advance Wars self-play model. The goal is to train one policy/value model for normal Global League Standard games while keeping the engine as the source of truth for rules, state transitions, and legal actions.
+
+## Scope
+
+V1 targets Standard GL only. The in-game policy uses the `standard-gl-v1` action space from `docs/ACTION_SPACE.md`: a fixed `27x23` board, source-cell action planes, and three appended global actions for end turn and powers.
+
+The model should choose only in-game actions. Pregame CO selection should be handled outside this action space and trained/evaluated from matchup statistics later.
+
+## Environment Loop
+
+Self-play should run through an environment wrapper around `GameState`:
+
+1. Create a Standard GL game from a map, CO pair, settings, and deterministic seed.
+2. Encode the current state tensor from the current player's perspective.
+3. Ask the engine for legal actions and encode them as sparse action indices.
+4. Run MCTS using the current policy/value model.
+5. Pick an action from MCTS visit counts, then step the engine with that action.
+6. Record the training sample.
+7. Repeat until terminal, day limit, or an explicit training stop condition.
+
+The engine should reject illegal submitted actions. Training code should never reimplement rules or infer legality from tensors.
+
+## Model Shape
+
+Use a shared convolutional or residual trunk over the fixed board. The policy head should produce action planes over `27x23` plus the three global logits. It should not use a large fully connected classifier over all `1,554,366` actions.
+
+The value head should output the expected game result from the current player's perspective.
+
+Start small enough to fit comfortably on an 8 GB GPU:
+
+- mixed precision when CUDA is available
+- small batches such as 1, 2, 4, or 8
+- gradient accumulation if a larger effective batch helps stability
+- modest channel and block counts before scaling up
+
+Longer training with smaller batches is acceptable. The first priority is stable self-play and replay quality, not maximum GPU throughput.
+
+## Replay Format
+
+Replay data should be versioned and compact. Each sample should include:
+
+- action-space version
+- game/setup metadata, including map id, COs, seed, and rules settings
+- state tensor or enough serialized state data to rebuild it
+- current player
+- selected action index
+- sparse legal action indices
+- sparse MCTS visit counts for legal or visited actions
+- final outcome from the sampled player's perspective
+
+Do not store dense legal masks in replay. A dense mask for `standard-gl-v1` is about 1.55 MB per state, which grows too quickly. Materialize dense masks only for the active training batch if the loss implementation needs them.
+
+## Training Loop
+
+Training should sample replay positions, rebuild tensors, expand sparse legal indices for masking, and optimize two losses:
+
+- policy loss against the MCTS visit distribution
+- value loss against the final outcome
+
+Checkpoints should be evaluated against the current best checkpoint on fixed maps, fixed seeds, and a held-out map set. Promote a checkpoint only when it improves head-to-head results or clearly improves selected metrics.
+
+## Metrics
+
+Track at least:
+
+- win rate by checkpoint, map, side, and CO pair
+- game length in days and atomic actions
+- average legal action count
+- search time per move
+- policy loss and value loss
+- invalid action attempts
+- terminal reason
+
+CO matchup and pregame selection metrics should feed the later CO picker, not the in-game action model.
+
+## Recommended First Milestone
+
+The first useful milestone is a single-worker self-play runner that writes sparse replay shards from deterministic games on a small Standard GL map set. Once replay validation is reliable, add the neural trainer and only then scale to parallel self-play workers.


### PR DESCRIPTION
## Summary
- Add `ActionSpace` with stable `standard-gl-v1` encoding for Standard GL in-game actions.
- Use fixed 27x23 source-cell planes plus appended global actions, producing 1,554,366 action indices.
- Add legal action mask generation from `GameState::GetValidActions`, with explicit failure for maps larger than 27x23.
- Add JSON fixture support, focused action-space fixtures, and action-space docs.

## Scope decisions
- CO selection remains out of scope for this issue; tracked separately in #164.
- The v1 board cap follows the largest checked Standard GL map, 27x23.
- Decode is structural and legality remains mask/state driven.

## Tests
- TDD red check before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test test/json/action-space` failed on expected version `standard-gl-v1` vs empty stub.
- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/action-space`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`

Closes #4