### PR TITLE
Refactor MCTS for action-level self-play

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="src\Map.cpp" />
     <ClCompile Include="src\MapParser.cpp" />
     <ClCompile Include="src\MapTile.cpp" />
+    <ClCompile Include="src\MctsTest.cpp" />
     <ClCompile Include="src\Player.cpp" />
     <ClCompile Include="src\RestGameService.cpp" />
     <ClCompile Include="src\Tensor.cpp" />
@@ -192,6 +193,7 @@
     <ClInclude Include="inc\Map.h" />
     <ClInclude Include="inc\MapParser.h" />
     <ClInclude Include="inc\MapTile.h" />
+    <ClInclude Include="inc\MctsTest.h" />
     <ClInclude Include="inc\MonteCarloTreeSearch.h" />
     <ClInclude Include="inc\MovementTypes.h" />
     <ClInclude Include="inc\Platform.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="src\ActionSpace.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\MctsTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\Map.h">
@@ -153,6 +156,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\ActionSpace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\MctsTest.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AdvanceWarsServer/inc/MctsTest.h
+++ b/AdvanceWarsServer/inc/MctsTest.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int RunMctsTests();

--- a/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
+++ b/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
@@ -1,142 +1,260 @@
 #pragma once
 
-#include <string>
-#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
 #include <memory>
-#include "Reward.h"
+#include <optional>
+#include <random>
+#include <utility>
+#include <vector>
 
-// Node class for MCTS
-template <typename StateType, typename ActionType>
-class MCTSNode {
-public:
-	std::shared_ptr<MCTSNode> parent;
-	std::vector<std::shared_ptr<MCTSNode>> children;
-	std::vector<ActionType> legalActions;
-	ActionType action;
-	StateType state;
-	int visits;
-	double totalValue;
-
-	MCTSNode(const StateType& state, const ActionType& action, std::shared_ptr<MCTSNode> parent = nullptr)
-		: state(state), action(action), parent(parent), visits(0), totalValue(0.0) {
-		legalActions = state.getLegalActions();
-	}
-
-	bool isFullyExpanded() const {
-		return !children.empty() && children.size() == state.getLegalActions().size();
-	}
-
-	bool isLeaf() const {
-		return children.empty();
-	}
-
-	void detachNode(std::shared_ptr<MCTSNode> spNode) {
-		for (auto it = children.begin(); it != children.end(); ++it) {
-			if (it->get() == spNode.get()) {
-				children.erase(it);
-				return;
-			}
-		}
-	}
-
-	void freeMemory() {
-		if (children.empty()) {
-			parent.reset();
-			return;
-		}
-
-		for (auto& child : children) {
-			child->freeMemory();
-			child.reset();
-		}
-	}
+struct MCTSOptions {
+	int maxSimulations{ 1000 };
+	int maxNodes{ 10000 };
+	int maxRolloutActions{ 512 };
+	double explorationConstant{ std::sqrt(2.0) };
+	double temperature{ 0.0 };
+	std::uint32_t seed{ 0 };
 };
 
-// MCTS algorithm class
+template <typename ActionType>
+struct MCTSActionStats {
+	ActionType action;
+	int visits{ 0 };
+	double totalValue{ 0.0 };
+	double averageValue{ 0.0 };
+};
+
+template <typename ActionType>
+struct MCTSSearchResult {
+	std::optional<ActionType> selectedAction;
+	std::vector<MCTSActionStats<ActionType>> rootActionStats;
+	int simulationsRun{ 0 };
+	int nodesCreated{ 0 };
+};
+
+// StateType must provide:
+// - std::vector<ActionType> getLegalActions() const
+// - StateType applyAction(const ActionType&) const
+// - bool isTerminal() const
+// - int getCurrentPlayer() const
+// - double-compatible evaluate(int player) const
+// ActionType must be equality-comparable.
 template <typename StateType, typename ActionType>
 class MCTS {
 public:
-	std::shared_ptr<MCTSNode<StateType, ActionType>> run(std::shared_ptr<MCTSNode<StateType, ActionType>> root, int iterations) {
-		expand(root);
-		for (int i = 0; i < iterations; ++i) {
-			if ((i + 1) % 50 == 0) {
-				std::cout << "simmed iterations: " << i << std::endl;
-			}
+	MCTSSearchResult<ActionType> search(const StateType& rootState, const MCTSOptions& options = MCTSOptions()) {
+		std::mt19937 rng(options.seed);
+		SearchContext context{ std::max(1, options.maxNodes), 1 };
 
-			auto node = select(root);
-			if (!node->state.isTerminal()) {
-				expand(node);
-			}
+		Node root(rootState, std::nullopt, nullptr);
+		MCTSSearchResult<ActionType> result;
+		result.nodesCreated = context.nodesCreated;
 
-			Reward reward = simulate(node);
-			backpropagate(node, reward);
+		if (root.state.isTerminal() || root.legalActions.empty()) {
+			result.rootActionStats = BuildRootActionStats(root);
+			return result;
 		}
 
-		return bestChild(root, 0.0);
+		const int maxSimulations = std::max(0, options.maxSimulations);
+		for (int i = 0; i < maxSimulations; ++i) {
+			Node* selected = Select(root, options.explorationConstant, context.nodesCreated < context.maxNodes);
+			Node* simulationStart = selected;
+
+			if (!selected->state.isTerminal() &&
+				!selected->unexpandedActions.empty() &&
+				context.nodesCreated < context.maxNodes) {
+				simulationStart = ExpandOne(*selected, rng);
+				++context.nodesCreated;
+			}
+
+			bool reachedTerminal = false;
+			StateType rolloutState = Rollout(simulationStart->state, std::max(0, options.maxRolloutActions), rng, reachedTerminal);
+			Backpropagate(simulationStart, rolloutState, reachedTerminal);
+			++result.simulationsRun;
+		}
+
+		result.nodesCreated = context.nodesCreated;
+		result.rootActionStats = BuildRootActionStats(root);
+		result.selectedAction = SelectAction(result.rootActionStats, options.temperature, rng);
+		return result;
 	}
+
 private:
-	std::shared_ptr<MCTSNode<StateType, ActionType>> select(std::shared_ptr<MCTSNode<StateType, ActionType>> node) {
-		while (!node->isLeaf() && !node->state.isTerminal()) {
-			node = bestChild(node, sqrt(2.0));
+	struct Node {
+		StateType state;
+		std::optional<ActionType> action;
+		Node* parent{ nullptr };
+		std::vector<ActionType> legalActions;
+		std::vector<ActionType> unexpandedActions;
+		std::vector<std::unique_ptr<Node>> children;
+		int visits{ 0 };
+		double totalValue{ 0.0 };
+
+		Node(const StateType& state, std::optional<ActionType> action, Node* parent) :
+			state(state),
+			action(std::move(action)),
+			parent(parent) {
+			if (!this->state.isTerminal()) {
+				legalActions = this->state.getLegalActions();
+				unexpandedActions = legalActions;
+			}
+		}
+	};
+
+	struct SearchContext {
+		int maxNodes{ 1 };
+		int nodesCreated{ 1 };
+	};
+
+	Node* Select(Node& root, double explorationConstant, bool canExpand) {
+		Node* node = &root;
+		while (!node->state.isTerminal()) {
+			if (!node->unexpandedActions.empty() && (canExpand || node->children.empty())) {
+				return node;
+			}
+
+			if (node->children.empty()) {
+				return node;
+			}
+
+			node = BestChild(*node, explorationConstant);
 		}
 
 		return node;
 	}
 
-	void expand(std::shared_ptr<MCTSNode<StateType, ActionType>> node) {
-		if (node->isFullyExpanded()) {
-			return;
-		}
+	Node* ExpandOne(Node& node, std::mt19937& rng) {
+		std::uniform_int_distribution<int> distribution(0, static_cast<int>(node.unexpandedActions.size() - 1));
+		const int actionIndex = distribution(rng);
+		ActionType action = node.unexpandedActions[static_cast<std::size_t>(actionIndex)];
+		node.unexpandedActions.erase(node.unexpandedActions.begin() + actionIndex);
 
-		for (const auto& action : node->legalActions) {
-			auto newState = node->state.applyAction(action);
-			node->children.push_back(std::make_shared<MCTSNode<StateType, ActionType>>(newState, action, node));
-		}
+		StateType newState = node.state.applyAction(action);
+		node.children.push_back(std::make_unique<Node>(newState, action, &node));
+		return node.children.back().get();
 	}
 
-	Reward simulate(std::shared_ptr<MCTSNode<StateType, ActionType>> node) {
-		StateType state{ node->state };
-		int totalSimStates = 0;
-		time_point startTime = std::chrono::steady_clock::now();
-		while (!state.isTerminal()) {
-			auto actions = state.getLegalActions();
-			if (actions.empty()) break;
-			ActionType action = actions[rand() % actions.size()];
-			++totalSimStates;
-			state = state.applyAction(action);
-			if (totalSimStates > 100000) {
+	StateType Rollout(const StateType& startState, int maxRolloutActions, std::mt19937& rng, bool& reachedTerminal) {
+		StateType state(startState);
+		for (int i = 0; i < maxRolloutActions && !state.isTerminal(); ++i) {
+			std::vector<ActionType> actions = state.getLegalActions();
+			if (actions.empty()) {
 				break;
 			}
+
+			std::uniform_int_distribution<int> distribution(0, static_cast<int>(actions.size() - 1));
+			state = state.applyAction(actions[static_cast<std::size_t>(distribution(rng))]);
 		}
-		time_point endTime = std::chrono::steady_clock::now();
-		Reward reward = { state.getCurrentPlayer(), state.getEvaluationForCurrentPlayer() };
-		return reward;
+
+		reachedTerminal = state.isTerminal();
+		return state;
 	}
 
-	void backpropagate(std::shared_ptr<MCTSNode<StateType, ActionType>> node, Reward reward) {
+	void Backpropagate(Node* node, const StateType& rolloutState, bool reachedTerminal) {
 		while (node != nullptr) {
-			node->visits++;
-			bool invertReward = node->state.getCurrentPlayer() != reward.player;
-			if (node->action.m_type == Action::Type::EndTurn) {
-				invertReward = !invertReward;
-			}
-
-			if (!invertReward) {
-				node->totalValue += reward.value;
-			}
-			else {
-				node->totalValue += reward.value * -1;
-			}
-
+			++node->visits;
+			const double value = reachedTerminal ? static_cast<double>(rolloutState.evaluate(node->state.getCurrentPlayer())) : 0.0;
+			node->totalValue += value;
 			node = node->parent;
 		}
 	}
 
-	std::shared_ptr<MCTSNode<StateType, ActionType>> bestChild(std::shared_ptr<MCTSNode<StateType, ActionType>> node, double explorationFactor) {
-		return *std::max_element(node->children.begin(), node->children.end(), [explorationFactor](const auto& a, const auto& b) {
-			double uctA = (a->totalValue / (a->visits + 1e-6)) + explorationFactor * sqrt(log(a->parent->visits + 1) / (a->visits + 1e-6));
-			double uctB = (b->totalValue / (b->visits + 1e-6)) + explorationFactor * sqrt(log(b->parent->visits + 1) / (b->visits + 1e-6));
-			return uctA < uctB;
-		});
+	Node* BestChild(Node& node, double explorationConstant) {
+		return std::max_element(node.children.begin(), node.children.end(), [&](const std::unique_ptr<Node>& left, const std::unique_ptr<Node>& right) {
+			return UctValue(node, *left, explorationConstant) < UctValue(node, *right, explorationConstant);
+		})->get();
+	}
+
+	double UctValue(const Node& parent, const Node& child, double explorationConstant) const {
+		if (child.visits == 0) {
+			return std::numeric_limits<double>::infinity();
+		}
+
+		double averageValue = child.totalValue / child.visits;
+		if (child.state.getCurrentPlayer() != parent.state.getCurrentPlayer()) {
+			averageValue *= -1.0;
+		}
+
+		const double exploration = explorationConstant * std::sqrt(std::log(parent.visits + 1.0) / child.visits);
+		return averageValue + exploration;
+	}
+
+	std::vector<MCTSActionStats<ActionType>> BuildRootActionStats(const Node& root) const {
+		std::vector<MCTSActionStats<ActionType>> stats;
+		stats.reserve(root.legalActions.size());
+
+		for (const ActionType& action : root.legalActions) {
+			MCTSActionStats<ActionType> actionStats;
+			actionStats.action = action;
+
+			const Node* child = FindChild(root, action);
+			if (child != nullptr) {
+				actionStats.visits = child->visits;
+				actionStats.totalValue = child->totalValue;
+				if (child->state.getCurrentPlayer() != root.state.getCurrentPlayer()) {
+					actionStats.totalValue *= -1.0;
+				}
+				actionStats.averageValue = actionStats.visits == 0 ? 0.0 : actionStats.totalValue / actionStats.visits;
+			}
+
+			stats.push_back(actionStats);
+		}
+
+		return stats;
+	}
+
+	const Node* FindChild(const Node& node, const ActionType& action) const {
+		for (const std::unique_ptr<Node>& child : node.children) {
+			if (child->action.has_value() && child->action.value() == action) {
+				return child.get();
+			}
+		}
+
+		return nullptr;
+	}
+
+	std::optional<ActionType> SelectAction(const std::vector<MCTSActionStats<ActionType>>& stats, double temperature, std::mt19937& rng) const {
+		if (stats.empty()) {
+			return std::nullopt;
+		}
+
+		if (temperature <= 0.0) {
+			const MCTSActionStats<ActionType>* best = &stats.front();
+			for (const MCTSActionStats<ActionType>& actionStats : stats) {
+				if (actionStats.visits > best->visits) {
+					best = &actionStats;
+				}
+			}
+
+			return best->action;
+		}
+
+		bool hasPositiveVisits = false;
+		for (const MCTSActionStats<ActionType>& actionStats : stats) {
+			if (actionStats.visits > 0) {
+				hasPositiveVisits = true;
+				break;
+			}
+		}
+
+		std::vector<double> weights;
+		weights.reserve(stats.size());
+		for (const MCTSActionStats<ActionType>& actionStats : stats) {
+			if (!hasPositiveVisits) {
+				weights.push_back(1.0);
+			}
+			else if (actionStats.visits > 0) {
+				weights.push_back(std::pow(static_cast<double>(actionStats.visits), 1.0 / temperature));
+			}
+			else {
+				weights.push_back(0.0);
+			}
+		}
+
+		std::discrete_distribution<int> distribution(weights.begin(), weights.end());
+		return stats[static_cast<std::size_t>(distribution(rng))].action;
 	}
 };

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -7,6 +7,7 @@
 #include <future>
 #include "AdvanceWarsServer.h"
 #include "MonteCarloTreeSearch.h"
+#include "MctsTest.h"
 #include "SubsystemTest.h"
 #include "Platform.h"
 #include <torch/torch.h>
@@ -20,6 +21,7 @@ int main(int argc, char* argv[]) noexcept {
 			std::cerr << "Options:\n";
 			std::cerr << "  -sim-random-move-game [seed] : Simulate a random move game.\n";
 			std::cerr << "  -sim-mcts-game        : Simulate an MCTS game.\n";
+			std::cerr << "  -test-mcts            : Run focused MCTS tests.\n";
 			std::cerr << "  -server               : Act as game server.\n";
 			return 1; // Return an error code
 		}
@@ -214,26 +216,30 @@ int main(int argc, char* argv[]) noexcept {
 			json jstate;
 			GameState::to_json(jstate, rootState);
 			outFile << "Game State: " << jstate.dump() << std::endl;
-			auto root = std::make_shared<MCTSNode<GameState, Action>>(rootState, Action());
 			while (!rootState.isTerminal()) {
 				int player = rootState.IsFirstPlayerTurn() ? 0 : 1;
 				MCTS<GameState, Action> mcts;
+				MCTSOptions options;
+				options.maxSimulations = 50000;
+				options.maxNodes = 100000;
+				options.maxRolloutActions = 100000;
 				time_point startTimeTotalSim = std::chrono::steady_clock::now();
-				auto bestNode = mcts.run(root, 50000);
+				MCTSSearchResult<Action> result = mcts.search(rootState, options);
 				time_point endTimeTotalSim = std::chrono::steady_clock::now();
+				if (!result.selectedAction.has_value()) {
+					std::cerr << "MCTS did not select an action." << std::endl;
+					return -1;
+				}
+
 				std::cout << "\n\n\n\nTook to simulate: " << std::chrono::duration<double, std::milli>(endTimeTotalSim - startTimeTotalSim).count() << std::endl;
 				json jaction;
-				to_json(jaction, bestNode->action);
+				to_json(jaction, result.selectedAction.value());
 				outFile << "Player: " << player << ", Action picked: " << jaction.dump() << std::endl;
 				std::cout << "Player: " << player << ", Action picked: " << jaction.dump() << std::endl;
-				rootState = rootState.applyAction(bestNode->action);
+				rootState = rootState.applyAction(result.selectedAction.value());
 				GameState::to_json(jstate, rootState);
 				outFile << "Game State: " << jstate.dump() << std::endl;
 				std::cout << "Game State: " << jstate.dump() << std::endl;
-				bestNode->parent->detachNode(bestNode);
-				bestNode->parent->freeMemory();
-				bestNode->parent.reset();
-				root = bestNode;
 			}
 
 			outFile.close();
@@ -256,6 +262,9 @@ int main(int argc, char* argv[]) noexcept {
 		}
 		else if (argument == "-test-api-contract") {
 			return RunRestApiContractTests();
+		}
+		else if (argument == "-test-mcts") {
+			return RunMctsTests();
 		}
 		else if (argument == "-server") {
 			return AdvanceWarsServer::getInstance().run();

--- a/AdvanceWarsServer/src/MctsTest.cpp
+++ b/AdvanceWarsServer/src/MctsTest.cpp
@@ -1,0 +1,367 @@
+#include "MctsTest.h"
+
+#include "MonteCarloTreeSearch.h"
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+struct TestAction {
+	int id{ 0 };
+
+	bool operator==(const TestAction& other) const noexcept {
+		return id == other.id;
+	}
+};
+
+struct TestNodeDef {
+	int player{ 0 };
+	std::optional<int> winner;
+	std::vector<TestAction> legalActions;
+	std::vector<std::pair<TestAction, int>> transitions;
+};
+
+struct TestGraph {
+	std::vector<TestNodeDef> nodes;
+};
+
+class TestState {
+public:
+	TestState(std::shared_ptr<const TestGraph> graph, int nodeId) :
+		m_graph(std::move(graph)),
+		m_nodeId(nodeId) {
+	}
+
+	std::vector<TestAction> getLegalActions() const {
+		const TestNodeDef& node = GetNode();
+		if (node.winner.has_value()) {
+			return {};
+		}
+
+		return node.legalActions;
+	}
+
+	TestState applyAction(const TestAction& action) const {
+		for (const auto& transition : GetNode().transitions) {
+			if (transition.first == action) {
+				return TestState(m_graph, transition.second);
+			}
+		}
+
+		throw std::runtime_error("test action was not legal in scripted state");
+	}
+
+	bool isTerminal() const {
+		return GetNode().winner.has_value();
+	}
+
+	int getCurrentPlayer() const {
+		return GetNode().player;
+	}
+
+	double evaluate(int player) const {
+		const TestNodeDef& node = GetNode();
+		if (!node.winner.has_value() || *node.winner < 0) {
+			return 0.0;
+		}
+
+		return *node.winner == player ? 1.0 : -1.0;
+	}
+
+private:
+	const TestNodeDef& GetNode() const {
+		return m_graph->nodes.at(static_cast<std::size_t>(m_nodeId));
+	}
+
+	std::shared_ptr<const TestGraph> m_graph;
+	int m_nodeId{ 0 };
+};
+
+TestState MakeState(std::vector<TestNodeDef> nodes, int nodeId = 0) {
+	auto graph = std::make_shared<TestGraph>();
+	graph->nodes = std::move(nodes);
+	return TestState(graph, nodeId);
+}
+
+bool Expect(bool condition, const std::string& message) {
+	if (!condition) {
+		std::cerr << "MCTS test failed: " << message << std::endl;
+	}
+
+	return condition;
+}
+
+const MCTSActionStats<TestAction>* FindStats(const MCTSSearchResult<TestAction>& result, int actionId) {
+	for (const MCTSActionStats<TestAction>& stats : result.rootActionStats) {
+		if (stats.action.id == actionId) {
+			return &stats;
+		}
+	}
+
+	return nullptr;
+}
+
+int VisitsFor(const MCTSSearchResult<TestAction>& result, int actionId) {
+	const MCTSActionStats<TestAction>* stats = FindStats(result, actionId);
+	return stats == nullptr ? -1 : stats->visits;
+}
+
+double AverageFor(const MCTSSearchResult<TestAction>& result, int actionId) {
+	const MCTSActionStats<TestAction>* stats = FindStats(result, actionId);
+	return stats == nullptr ? 999.0 : stats->averageValue;
+}
+
+bool SelectedActionIs(const MCTSSearchResult<TestAction>& result, int actionId) {
+	return result.selectedAction.has_value() && result.selectedAction->id == actionId;
+}
+
+int CountVisitedRootActions(const MCTSSearchResult<TestAction>& result) {
+	int count = 0;
+	for (const MCTSActionStats<TestAction>& stats : result.rootActionStats) {
+		if (stats.visits > 0) {
+			++count;
+		}
+	}
+
+	return count;
+}
+
+int SumRootVisits(const MCTSSearchResult<TestAction>& result) {
+	int visits = 0;
+	for (const MCTSActionStats<TestAction>& stats : result.rootActionStats) {
+		visits += stats.visits;
+	}
+
+	return visits;
+}
+
+bool NearlyEqual(double left, double right) {
+	return std::fabs(left - right) < 1e-9;
+}
+
+bool ResultsEqual(const MCTSSearchResult<TestAction>& left, const MCTSSearchResult<TestAction>& right) {
+	if (left.selectedAction.has_value() != right.selectedAction.has_value() ||
+		left.simulationsRun != right.simulationsRun ||
+		left.nodesCreated != right.nodesCreated ||
+		left.rootActionStats.size() != right.rootActionStats.size()) {
+		return false;
+	}
+
+	if (left.selectedAction.has_value() && !(left.selectedAction.value() == right.selectedAction.value())) {
+		return false;
+	}
+
+	for (std::size_t i = 0; i < left.rootActionStats.size(); ++i) {
+		if (!(left.rootActionStats[i].action == right.rootActionStats[i].action) ||
+			left.rootActionStats[i].visits != right.rootActionStats[i].visits ||
+			!NearlyEqual(left.rootActionStats[i].totalValue, right.rootActionStats[i].totalValue) ||
+			!NearlyEqual(left.rootActionStats[i].averageValue, right.rootActionStats[i].averageValue)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+TestState MakeThreeTerminalActionState() {
+	return MakeState({
+		{ 0, std::nullopt, { { 1 }, { 2 }, { 3 } }, { { { 1 }, 1 }, { { 2 }, 2 }, { { 3 }, 3 } } },
+		{ 0, 0, {}, {} },
+		{ 0, 0, {}, {} },
+		{ 0, 0, {}, {} },
+	});
+}
+
+bool TestOneActionExpansionAndRootStats() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 1;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 0;
+	options.temperature = 0.0;
+	options.seed = 7;
+
+	MCTSSearchResult<TestAction> result = mcts.search(MakeThreeTerminalActionState(), options);
+
+	return Expect(result.simulationsRun == 1, "one simulation should run") &&
+		Expect(result.nodesCreated == 2, "root plus one child should be created") &&
+		Expect(result.rootActionStats.size() == 3, "all root legal actions should be present") &&
+		Expect(result.rootActionStats[0].action.id == 1 && result.rootActionStats[1].action.id == 2 && result.rootActionStats[2].action.id == 3, "root stats should preserve legal action order") &&
+		Expect(SumRootVisits(result) == 1, "only one root action should be visited") &&
+		Expect(CountVisitedRootActions(result) == 1, "only one root child should be expanded") &&
+		Expect(result.selectedAction.has_value(), "a selected action should be returned for non-empty root");
+}
+
+bool TestSeededSearchIsReproducible() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 12;
+	options.maxNodes = 20;
+	options.maxRolloutActions = 1;
+	options.temperature = 1.0;
+	options.seed = 42;
+
+	MCTSSearchResult<TestAction> first = mcts.search(MakeThreeTerminalActionState(), options);
+	MCTSSearchResult<TestAction> second = mcts.search(MakeThreeTerminalActionState(), options);
+
+	return Expect(ResultsEqual(first, second), "same seed and state should produce identical search results");
+}
+
+bool TestPlayerPerspectiveBackupHandlesSamePlayerAndSwitches() {
+	TestState root = MakeState({
+		{ 0, std::nullopt, { { 10 }, { 20 } }, { { { 10 }, 1 }, { { 20 }, 2 } } },
+		{ 0, std::nullopt, { { 11 } }, { { { 11 }, 3 } } },
+		{ 1, std::nullopt, { { 21 } }, { { { 21 }, 4 } } },
+		{ 0, 0, {}, {} },
+		{ 1, 1, {}, {} },
+	});
+
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 80;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 4;
+	options.temperature = 0.0;
+	options.seed = 5;
+
+	MCTSSearchResult<TestAction> result = mcts.search(root, options);
+
+	return Expect(NearlyEqual(AverageFor(result, 10), 1.0), "same-player winning chain should average +1 for root player") &&
+		Expect(NearlyEqual(AverageFor(result, 20), -1.0), "turn-switch opponent win should average -1 for root player") &&
+		Expect(VisitsFor(result, 10) > VisitsFor(result, 20), "UCT should prefer the action that wins for the root player") &&
+		Expect(SelectedActionIs(result, 10), "temperature zero should select the most visited winning root action");
+}
+
+bool TestRolloutCutoffBacksUpZero() {
+	TestState root = MakeState({
+		{ 0, std::nullopt, { { 1 } }, { { { 1 }, 1 } } },
+		{ 0, std::nullopt, { { 2 } }, { { { 2 }, 2 } } },
+		{ 0, 0, {}, {} },
+	});
+
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 1;
+	options.maxNodes = 3;
+	options.maxRolloutActions = 0;
+	options.temperature = 0.0;
+	options.seed = 0;
+
+	MCTSSearchResult<TestAction> result = mcts.search(root, options);
+
+	return Expect(VisitsFor(result, 1) == 1, "expanded action should receive one visit") &&
+		Expect(NearlyEqual(AverageFor(result, 1), 0.0), "non-terminal rollout cutoff should back up zero");
+}
+
+bool TestNodeLimitPreventsExpansion() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 3;
+	options.maxNodes = 0;
+	options.maxRolloutActions = 2;
+	options.temperature = 0.0;
+	options.seed = 0;
+
+	MCTSSearchResult<TestAction> result = mcts.search(MakeThreeTerminalActionState(), options);
+
+	return Expect(result.simulationsRun == 3, "simulations can still run from existing nodes") &&
+		Expect(result.nodesCreated == 1, "maxNodes should normalize to the root node") &&
+		Expect(SumRootVisits(result) == 0, "no root children should be visited when expansion is blocked") &&
+		Expect(SelectedActionIs(result, 1), "temperature zero fallback should select first legal action when all visits are zero");
+}
+
+bool TestNodeLimitReusesExistingChildrenWhenExpansionIsBlocked() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 5;
+	options.maxNodes = 2;
+	options.maxRolloutActions = 0;
+	options.temperature = 0.0;
+	options.seed = 0;
+
+	MCTSSearchResult<TestAction> result = mcts.search(MakeThreeTerminalActionState(), options);
+
+	return Expect(result.nodesCreated == 2, "node limit should allow only root plus one child") &&
+		Expect(result.simulationsRun == 5, "all requested simulations should still run") &&
+		Expect(CountVisitedRootActions(result) == 1, "only one root child should exist under maxNodes=2") &&
+		Expect(SumRootVisits(result) == 5, "existing child should keep receiving visits after expansion is blocked");
+}
+
+bool TestTerminalAndActionlessRootsReturnNoSelection() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 10;
+
+	MCTSSearchResult<TestAction> terminal = mcts.search(MakeState({
+		{ 0, 0, {}, {} },
+	}), options);
+
+	MCTSSearchResult<TestAction> actionless = mcts.search(MakeState({
+		{ 0, std::nullopt, {}, {} },
+	}), options);
+
+	return Expect(!terminal.selectedAction.has_value(), "terminal root should not select an action") &&
+		Expect(terminal.rootActionStats.empty(), "terminal root should have no action stats") &&
+		Expect(terminal.simulationsRun == 0, "terminal root should run no simulations") &&
+		Expect(terminal.nodesCreated == 1, "terminal root should still count the root node") &&
+		Expect(!actionless.selectedAction.has_value(), "actionless root should not select an action") &&
+		Expect(actionless.rootActionStats.empty(), "actionless root should have no action stats") &&
+		Expect(actionless.simulationsRun == 0, "actionless root should run no simulations") &&
+		Expect(actionless.nodesCreated == 1, "actionless root should still count the root node");
+}
+
+bool TestTemperatureZeroTieAndPositiveTemperatureSampling() {
+	MCTS<TestState, TestAction> mcts;
+
+	MCTSOptions tieOptions;
+	tieOptions.maxSimulations = 0;
+	tieOptions.temperature = 0.0;
+	tieOptions.seed = 3;
+
+	MCTSSearchResult<TestAction> tieResult = mcts.search(MakeThreeTerminalActionState(), tieOptions);
+
+	MCTSOptions sampledOptions;
+	sampledOptions.maxSimulations = 1;
+	sampledOptions.maxNodes = 10;
+	sampledOptions.maxRolloutActions = 0;
+	sampledOptions.temperature = 1.0;
+	sampledOptions.seed = 11;
+
+	MCTSSearchResult<TestAction> sampledResult = mcts.search(MakeThreeTerminalActionState(), sampledOptions);
+	int positiveVisitAction = -1;
+	for (const MCTSActionStats<TestAction>& stats : sampledResult.rootActionStats) {
+		if (stats.visits > 0) {
+			positiveVisitAction = stats.action.id;
+		}
+	}
+
+	return Expect(SelectedActionIs(tieResult, 1), "temperature zero should tie-break by legal action order") &&
+		Expect(sampledResult.selectedAction.has_value(), "positive temperature should select an action") &&
+		Expect(sampledResult.selectedAction->id == positiveVisitAction, "positive temperature should sample only positive-visit actions when any exist");
+}
+}
+
+int RunMctsTests() {
+	bool passed = true;
+	passed = TestOneActionExpansionAndRootStats() && passed;
+	passed = TestSeededSearchIsReproducible() && passed;
+	passed = TestPlayerPerspectiveBackupHandlesSamePlayerAndSwitches() && passed;
+	passed = TestRolloutCutoffBacksUpZero() && passed;
+	passed = TestNodeLimitPreventsExpansion() && passed;
+	passed = TestNodeLimitReusesExistingChildrenWhenExpansionIsBlocked() && passed;
+	passed = TestTerminalAndActionlessRootsReturnNoSelection() && passed;
+	passed = TestTemperatureZeroTieAndPositiveTemperatureSampling() && passed;
+
+	if (!passed) {
+		return 1;
+	}
+
+	std::cout << "MCTS tests passed" << std::endl;
+	return 0;
+}

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -31,6 +31,7 @@ Run tests from the `AdvanceWarsServer` project directory so the relative `test/j
 Set-Location .\AdvanceWarsServer
 ..\x64\Debug\AdvanceWarsServer.exe -test test/json
 ..\x64\Debug\AdvanceWarsServer.exe -test-api-contract
+..\x64\Debug\AdvanceWarsServer.exe -test-mcts
 ```
 
 Release:
@@ -54,6 +55,7 @@ The executable currently recognizes these development commands:
 | --- | --- | --- |
 | `-test [path]` | Run the recursive JSON fixture suite. | Defaults to `test/json`. Run from `AdvanceWarsServer/` so relative paths resolve. |
 | `-test-api-contract` | Run focused REST lifecycle/action contract tests. | Run from `AdvanceWarsServer/` so map templates and fixtures resolve. |
+| `-test-mcts` | Run focused MCTS contract tests. | Uses scripted fake states for deterministic search semantics. |
 | `-sim-random-move-game [seed]` | Run an experimental random-action simulation. | Uses local output paths that still need cleanup before general use. |
 | `-sim-mcts-game` | Run an experimental MCTS simulation. | Uses local output paths that still need cleanup before general use. |
 | `-server` | Run the current HTTP server on port 80. | Serves the canonical REST routes documented in `docs/API.md`. |

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -41,14 +41,14 @@ The rules/API completeness target for the initial playable environment is normal
 
 ## Phase 2: MCTS Improvements
 
-- [ ] Separate pure rollout MCTS from neural-network-guided MCTS.
-- [ ] Expand one child at a time or track unexpanded actions to avoid expanding every legal action immediately.
-- [ ] Replace `rand()` rollout action selection with a seeded RNG object.
-- [ ] Add PUCT selection using policy priors once a policy head exists.
-- [ ] Store visit counts per legal action for training targets.
-- [ ] Handle same-player action sequences explicitly in value backup. The player only changes on `EndTurn`.
-- [ ] Add temperature controls for early-game exploration and late-game exploitation.
-- [ ] Add MCTS search limits by simulations, wall-clock time, or node count.
+- [x] Separate pure rollout MCTS from neural-network-guided MCTS. Neural-guided PUCT is tracked by #166.
+- [x] Expand one child at a time or track unexpanded actions to avoid expanding every legal action immediately.
+- [x] Replace `rand()` rollout action selection with a seeded RNG object.
+- [ ] Add PUCT selection using policy priors once a policy head exists (#166).
+- [x] Store visit counts per legal action for training targets.
+- [x] Handle same-player action sequences explicitly in value backup.
+- [x] Add temperature controls for early-game exploration and late-game exploitation.
+- [x] Add MCTS search limits by simulation count, rollout action count, and node count. Wall-clock limits are tracked by #168.
 
 ## Phase 3: Self-Play Data Generation
 
@@ -96,6 +96,9 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] #7 Add policy/value network scaffold.
 - [ ] #8 Add training command-line entry point.
 - [ ] #9 Add checkpoint evaluation harness.
+- [ ] #166 Add neural-guided MCTS with PUCT.
+- [ ] #167 Add reusable MCTS search tree re-rooting.
+- [ ] #168 Add wall-clock MCTS search limits.
 - [ ] #65 Define and enforce normal Global League Standard game settings.
 - [ ] #66 Add REST game lifecycle and step API contract for self-play.
 - [ ] #67 Validate and atomically reject illegal submitted actions.


### PR DESCRIPTION
## Summary
- Replace the node-exposing MCTS API with `MCTSOptions`, `MCTSActionStats`, `MCTSSearchResult`, and fresh-root `search(state, options)`.
- Expand one random unexpanded legal action per simulation and use a seeded RNG for expansion, rollouts, and temperature sampling.
- Back up terminal rollout values from each ancestor node's current-player perspective, removing `EndTurn`-specific inversion logic.
- Return root legal action stats in legal-action order, including zero-visit actions, for future replay policy targets.
- Add deterministic MCTS contract tests using scripted fake states and wire them through `-test-mcts`.
- Update the experimental `-sim-mcts-game` command to use the new API.

## Scope / Follow-ups
- Neural-guided PUCT remains separate and is tracked by #166.
- Reusable tree re-rooting remains separate and is tracked by #167.
- Wall-clock search limits remain separate and are tracked by #168.

## Tests
- TDD red check before implementation: Debug x64 build failed because the new `MCTSOptions`, `MCTSSearchResult`, root stats, and `search()` API did not exist yet.
- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test-mcts`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `git diff --check`

Closes #5