### PR TITLE
Implement state tensor encoding

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -111,7 +111,7 @@
       <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)inc;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,7 +150,7 @@
       <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\torch\csrc\api\include;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)inc;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\torch\csrc\api\include;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -201,6 +201,7 @@
     <ClInclude Include="inc\Result.h" />
     <ClInclude Include="inc\RestGameService.h" />
     <ClInclude Include="inc\Reward.h" />
+    <ClInclude Include="inc\StateTensor.h" />
     <ClInclude Include="inc\SubsystemTest.h" />
     <ClInclude Include="inc\Terrain.h" />
     <ClInclude Include="inc\TerrainFileId.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -152,6 +152,9 @@
     <ClInclude Include="inc\Reward.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="inc\StateTensor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="inc\RestGameService.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -258,6 +258,11 @@ public:
 	const std::array<Player, 2>& GetPlayers() const noexcept;
 	std::array<Player, 2>& GetPlayers() noexcept { return m_arrPlayers; }
 	bool IsFirstPlayerTurn() const noexcept;
+	int GetTurnCount() const noexcept { return m_nTurnCount; }
+	WeatherType GetWeather() const noexcept { return m_weather; }
+	const std::optional<int>& GetWeatherTurnsRemaining() const noexcept { return m_weatherTurnsRemaining; }
+	int GetIncomeForPlayer(int playerIndex) const noexcept;
+	int CountCaptureLimitPropertiesForPlayer(int playerIndex) const noexcept;
 	Result GetValidActions(std::vector<Action>& vecActions) const noexcept;
 	Result GetValidActions(int x, int y, std::vector<Action>& vecActions) const noexcept;
 	bool AnyValidActions() const noexcept;

--- a/AdvanceWarsServer/inc/MapTile.h
+++ b/AdvanceWarsServer/inc/MapTile.h
@@ -7,7 +7,7 @@
 
 struct PropertyInfo{
 	int m_capturePoints = 20;
-	const Player* m_owner;
+	const Player* m_owner{ nullptr };
 };
 
 class MapTile final

--- a/AdvanceWarsServer/inc/StateTensor.h
+++ b/AdvanceWarsServer/inc/StateTensor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "GameState.h"
+#include "Result.h"
+
+class StateTensor final {
+public:
+	static const char* Version() noexcept;
+	static int BoardWidth() noexcept;
+	static int BoardHeight() noexcept;
+	static int ChannelCount() noexcept;
+	static const std::vector<std::string>& ChannelNames();
+	static Result ChannelIndex(const std::string& name, int& index) noexcept;
+	static Result Encode(const GameState& gameState, std::vector<float>& values) noexcept;
+	static Result Checksum(const std::vector<float>& values, std::uint64_t& checksum) noexcept;
+};

--- a/AdvanceWarsServer/inc/SubsystemTest.h
+++ b/AdvanceWarsServer/inc/SubsystemTest.h
@@ -14,9 +14,12 @@ struct JsonSubsystemTest {
 	bool fDeterministicReplay{ false };
 	json actionSpace;
 	json legalActionMask;
+	json stateTensor;
 	bool fHasActionSpace{ false };
 	bool fHasLegalActionMask{ false };
 	bool fLegalActionMaskShouldFail{ false };
+	bool fHasStateTensor{ false };
+	bool fStateTensorShouldFail{ false };
 };
 
 void from_json(json& j, JsonSubsystemTest& test);

--- a/AdvanceWarsServer/src/GameState.cpp
+++ b/AdvanceWarsServer/src/GameState.cpp
@@ -1931,6 +1931,54 @@ int GameState::CountOwnedProperties(const Player& player) const noexcept {
 	return properties;
 }
 
+int GameState::GetIncomeForPlayer(int playerIndex) const noexcept {
+	if (m_spmap == nullptr || playerIndex < 0 || playerIndex >= static_cast<int>(m_arrPlayers.size())) {
+		return 0;
+	}
+
+	int income = 0;
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			const MapTile* pTile = nullptr;
+			if (m_spmap->TryGetTile(x, y, &pTile) == Result::Failed || pTile == nullptr) {
+				continue;
+			}
+
+			if (pTile->m_spPropertyInfo != nullptr &&
+				pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[playerIndex] &&
+				FProducesIncome(pTile->GetTerrain().m_type)) {
+				income += GetCOIncomeForProperty(m_arrPlayers[playerIndex], pTile->GetTerrain().m_type);
+			}
+		}
+	}
+
+	return income;
+}
+
+int GameState::CountCaptureLimitPropertiesForPlayer(int playerIndex) const noexcept {
+	if (m_spmap == nullptr || playerIndex < 0 || playerIndex >= static_cast<int>(m_arrPlayers.size())) {
+		return 0;
+	}
+
+	int properties = 0;
+	for (int x = 0; x < m_spmap->GetCols(); ++x) {
+		for (int y = 0; y < m_spmap->GetRows(); ++y) {
+			const MapTile* pTile = nullptr;
+			if (m_spmap->TryGetTile(x, y, &pTile) == Result::Failed || pTile == nullptr) {
+				continue;
+			}
+
+			if (pTile->m_spPropertyInfo != nullptr &&
+				pTile->m_spPropertyInfo->m_owner == &m_arrPlayers[playerIndex] &&
+				FProducesIncome(pTile->GetTerrain().m_type)) {
+				++properties;
+			}
+		}
+	}
+
+	return properties;
+}
+
 int GameState::RollCombatLuck(int min, int max) {
 	std::uniform_int_distribution<int> distribution(min, max);
 	if (m_combatRng.has_value()) {

--- a/AdvanceWarsServer/src/JsonSubsystemTest.cpp
+++ b/AdvanceWarsServer/src/JsonSubsystemTest.cpp
@@ -1,12 +1,14 @@
 #include "SubsystemTest.h"
 
 #include <fstream>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <unordered_set>
 
 #include "ActionSpace.h"
 #include "GameState.h"
+#include "StateTensor.h"
 
 namespace {
 void SetMismatch(std::string& expected, std::string& actual, const std::string& message, const std::string& expectedValue, const std::string& actualValue) {
@@ -321,6 +323,97 @@ Result RunLegalActionMaskAssertions(const GameState& gameState, const json& lega
 
 	return Result::Succeeded;
 }
+
+Result RunStateTensorAssertions(const GameState& gameState, const json& stateTensor, bool shouldFail, std::string& expected, std::string& actual) {
+	std::vector<float> values;
+	Result result = StateTensor::Encode(gameState, values);
+	if (shouldFail) {
+		if (result == Result::Succeeded) {
+			SetMismatch(expected, actual, "state tensor encoding should fail", "failed", "succeeded");
+			return Result::Failed;
+		}
+
+		return Result::Succeeded;
+	}
+
+	if (result == Result::Failed) {
+		SetMismatch(expected, actual, "state tensor encoding should succeed", "succeeded", "failed");
+		return Result::Failed;
+	}
+
+	if (stateTensor.contains("version")) {
+		json actualVersion = StateTensor::Version();
+		IfFailedReturn(ExpectJsonValue(actualVersion, stateTensor.at("version"), "state tensor version", expected, actual));
+	}
+
+	if (stateTensor.contains("width")) {
+		json actualWidth = StateTensor::BoardWidth();
+		IfFailedReturn(ExpectJsonValue(actualWidth, stateTensor.at("width"), "state tensor width", expected, actual));
+	}
+
+	if (stateTensor.contains("height")) {
+		json actualHeight = StateTensor::BoardHeight();
+		IfFailedReturn(ExpectJsonValue(actualHeight, stateTensor.at("height"), "state tensor height", expected, actual));
+	}
+
+	if (stateTensor.contains("channels")) {
+		json actualChannels = StateTensor::ChannelCount();
+		IfFailedReturn(ExpectJsonValue(actualChannels, stateTensor.at("channels"), "state tensor channels", expected, actual));
+	}
+
+	const std::size_t expectedValueCount = static_cast<std::size_t>(StateTensor::ChannelCount() * StateTensor::BoardWidth() * StateTensor::BoardHeight());
+	if (values.size() != expectedValueCount) {
+		SetMismatch(expected, actual, "state tensor value count", std::to_string(expectedValueCount), std::to_string(values.size()));
+		return Result::Failed;
+	}
+
+	if (stateTensor.contains("channelIndices")) {
+		for (const json& channelIndexJson : stateTensor.at("channelIndices")) {
+			const std::string channel = channelIndexJson.at("channel").get<std::string>();
+			int channelIndex = -1;
+			if (StateTensor::ChannelIndex(channel, channelIndex) == Result::Failed) {
+				SetMismatch(expected, actual, "state tensor channel should exist", channel, "missing");
+				return Result::Failed;
+			}
+
+			const int expectedIndex = channelIndexJson.at("index").get<int>();
+			if (channelIndex != expectedIndex) {
+				SetMismatch(expected, actual, "state tensor channel index for " + channel, std::to_string(expectedIndex), std::to_string(channelIndex));
+				return Result::Failed;
+			}
+		}
+	}
+
+	const double tolerance = stateTensor.value("tolerance", 0.000001);
+	if (stateTensor.contains("values")) {
+		for (const json& valueJson : stateTensor.at("values")) {
+			const std::string channel = valueJson.at("channel").get<std::string>();
+			const int x = valueJson.at("at").at(0).get<int>();
+			const int y = valueJson.at("at").at(1).get<int>();
+			const double expectedValue = valueJson.at("value").get<double>();
+
+			int channelIndex = -1;
+			if (StateTensor::ChannelIndex(channel, channelIndex) == Result::Failed) {
+				SetMismatch(expected, actual, "state tensor channel should exist", channel, "missing");
+				return Result::Failed;
+			}
+
+			const int valueIndex = channelIndex * StateTensor::BoardWidth() * StateTensor::BoardHeight() + y * StateTensor::BoardWidth() + x;
+			if (valueIndex < 0 || valueIndex >= static_cast<int>(values.size())) {
+				SetMismatch(expected, actual, "state tensor coordinate should be in bounds", channel + " at " + std::to_string(x) + "," + std::to_string(y), "out of bounds");
+				return Result::Failed;
+			}
+
+			const double actualValue = values[valueIndex];
+			if (std::abs(actualValue - expectedValue) > tolerance) {
+				SetMismatch(expected, actual, "state tensor value for " + channel + " at " + std::to_string(x) + "," + std::to_string(y), std::to_string(expectedValue), std::to_string(actualValue));
+				return Result::Failed;
+			}
+		}
+	}
+
+	return Result::Succeeded;
+}
 }
 
 void from_json(json& j, JsonSubsystemTest& test) {
@@ -379,6 +472,16 @@ void from_json(json& j, JsonSubsystemTest& test) {
 	if (j.contains("legalActionMaskShouldFail")) {
 		j.at("legalActionMaskShouldFail").get_to(test.fLegalActionMaskShouldFail);
 		test.fHasLegalActionMask = true;
+	}
+
+	if (j.contains("stateTensor")) {
+		test.stateTensor = j.at("stateTensor");
+		test.fHasStateTensor = true;
+	}
+
+	if (j.contains("stateTensorShouldFail")) {
+		j.at("stateTensorShouldFail").get_to(test.fStateTensorShouldFail);
+		test.fHasStateTensor = true;
 	}
 }
 
@@ -498,6 +601,9 @@ Result JsonTestRunner::run() {
 		IfFailedReturn(RunLegalActionMaskAssertions(test.initialGameState, test.legalActionMask, test.fLegalActionMaskShouldFail, m_strExpected, m_strActual));
 	}
 
+	if (test.fHasStateTensor) {
+		IfFailedReturn(RunStateTensorAssertions(test.initialGameState, test.stateTensor, test.fStateTensorShouldFail, m_strExpected, m_strActual));
+	}
 
 	return Result::Succeeded;
 }

--- a/AdvanceWarsServer/src/Tensor.cpp
+++ b/AdvanceWarsServer/src/Tensor.cpp
@@ -1,0 +1,658 @@
+#include "StateTensor.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cctype>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "MapTile.h"
+#include "TerrainInfo.h"
+#include "UnitInfo.h"
+
+namespace {
+constexpr int kBoardWidth = 27;
+constexpr int kBoardHeight = 23;
+constexpr int kCellCount = kBoardWidth * kBoardHeight;
+constexpr int kTerrainCount = static_cast<int>(Terrain::Type::Size);
+constexpr int kUnitTypeCount = static_cast<int>(UnitProperties::Type::Size);
+constexpr int kCoCount = static_cast<int>(CommandingOfficier::Type::Size);
+
+constexpr int kInBoundsChannel = 0;
+constexpr int kTerrainStart = kInBoundsChannel + 1;
+constexpr int kPropertyStart = kTerrainStart + kTerrainCount;
+constexpr int kSelfUnitStart = kPropertyStart + 4;
+constexpr int kOpponentUnitStart = kSelfUnitStart + kUnitTypeCount;
+constexpr int kUnitAttributeStart = kOpponentUnitStart + kUnitTypeCount;
+constexpr int kLoadedStart = kUnitAttributeStart + 13;
+constexpr int kSelfLoadedTypeStart = kLoadedStart + 2;
+constexpr int kOpponentLoadedTypeStart = kSelfLoadedTypeStart + kUnitTypeCount;
+constexpr int kSelfLoadedHealth = kOpponentLoadedTypeStart + kUnitTypeCount;
+constexpr int kOpponentLoadedHealth = kSelfLoadedHealth + 1;
+constexpr int kEconomyStart = kOpponentLoadedHealth + 1;
+constexpr int kSelfCoStart = kEconomyStart + 10;
+constexpr int kOpponentCoStart = kSelfCoStart + kCoCount;
+constexpr int kPowerStart = kOpponentCoStart + kCoCount;
+constexpr int kTurnWeatherStart = kPowerStart + 8;
+constexpr int kChannelCount = kTurnWeatherStart + 5;
+static_assert(kChannelCount == 219, "Unexpected state tensor channel count");
+
+enum class RelativeOwner {
+	Self,
+	Opponent,
+	Neutral,
+	Invalid,
+};
+
+struct PlayerContext {
+	int activePlayer = 0;
+	int opponentPlayer = 1;
+	const Player* self = nullptr;
+	const Player* opponent = nullptr;
+};
+
+struct UnitAggregate {
+	int count = 0;
+	float armyValue = 0.0f;
+};
+
+float Clamp01(float value) noexcept {
+	if (!std::isfinite(value)) {
+		return 0.0f;
+	}
+
+	return std::max(0.0f, std::min(1.0f, value));
+}
+
+float Normalize(float value, float denominator) noexcept {
+	if (denominator <= 0.0f) {
+		return 0.0f;
+	}
+
+	return Clamp01(value / denominator);
+}
+
+int DisplayHpPips(int health) noexcept {
+	if (health <= 0) {
+		return 0;
+	}
+
+	return std::min(10, (health + 9) / 10);
+}
+
+float DisplayHealthValue(const Unit& unit) noexcept {
+	return Normalize(static_cast<float>(DisplayHpPips(unit.health)), 10.0f);
+}
+
+float UnitArmyValue(const Unit& unit) noexcept {
+	return static_cast<float>(DisplayHpPips(unit.health)) * static_cast<float>(Unit::GetUnitCost(unit.m_properties.m_type)) / 10.0f;
+}
+
+bool IsValidTerrainType(Terrain::Type type) noexcept {
+	const int terrainIndex = static_cast<int>(type);
+	return terrainIndex >= 0 && terrainIndex < kTerrainCount;
+}
+
+bool IsValidUnitType(UnitProperties::Type type) noexcept {
+	const int unitIndex = static_cast<int>(type);
+	return unitIndex >= 0 && unitIndex < kUnitTypeCount;
+}
+
+bool IsValidCoType(CommandingOfficier::Type type) noexcept {
+	const int coIndex = static_cast<int>(type);
+	return coIndex >= 0 && coIndex < kCoCount;
+}
+
+const char* TerrainName(Terrain::Type type) noexcept {
+	switch (type) {
+	case Terrain::Type::Plain:
+		return "plain";
+	case Terrain::Type::Mountain:
+		return "mountain";
+	case Terrain::Type::Forest:
+		return "forest";
+	case Terrain::Type::River:
+		return "river";
+	case Terrain::Type::Road:
+		return "road";
+	case Terrain::Type::Bridge:
+		return "bridge";
+	case Terrain::Type::Sea:
+		return "sea";
+	case Terrain::Type::Shoal:
+		return "shoal";
+	case Terrain::Type::Reef:
+		return "reef";
+	case Terrain::Type::City:
+		return "city";
+	case Terrain::Type::Base:
+		return "base";
+	case Terrain::Type::Airport:
+		return "airport";
+	case Terrain::Type::Port:
+		return "port";
+	case Terrain::Type::Headquarters:
+		return "headquarters";
+	case Terrain::Type::Pipe:
+		return "pipe";
+	case Terrain::Type::MissleSilo:
+		return "missile-silo";
+	case Terrain::Type::ComTower:
+		return "com-tower";
+	case Terrain::Type::Lab:
+		return "lab";
+	default:
+		return "";
+	}
+}
+
+std::string CoName(CommandingOfficier::Type type) {
+	CommandingOfficier co;
+	co.m_type = type;
+	std::string name = co.to_string();
+	std::transform(name.begin(), name.end(), name.begin(), [](unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	return name;
+}
+
+std::vector<std::string> BuildChannelNames() {
+	std::vector<std::string> channels;
+	channels.reserve(kChannelCount);
+
+	channels.emplace_back("in-bounds");
+
+	for (int i = 0; i < kTerrainCount; ++i) {
+		channels.emplace_back(std::string("terrain/") + TerrainName(static_cast<Terrain::Type>(i)));
+	}
+
+	channels.emplace_back("property-self");
+	channels.emplace_back("property-opponent");
+	channels.emplace_back("property-neutral");
+	channels.emplace_back("property-capture-points");
+
+	for (int i = 0; i < kUnitTypeCount; ++i) {
+		channels.emplace_back(std::string("self-unit/") + UnitProperties::getTypename(static_cast<UnitProperties::Type>(i)));
+	}
+
+	for (int i = 0; i < kUnitTypeCount; ++i) {
+		channels.emplace_back(std::string("opponent-unit/") + UnitProperties::getTypename(static_cast<UnitProperties::Type>(i)));
+	}
+
+	const std::array<const char*, 13> unitAttributes{ {
+		"self-health",
+		"self-ammo",
+		"self-fuel",
+		"self-moved",
+		"self-hidden",
+		"self-stunned",
+		"opponent-health",
+		"opponent-ammo",
+		"opponent-fuel",
+		"opponent-moved",
+		"opponent-hidden",
+		"opponent-stunned",
+		"opponent-health-known",
+	} };
+
+	for (const char* attribute : unitAttributes) {
+		channels.emplace_back(attribute);
+	}
+
+	channels.emplace_back("self-loaded-count");
+	channels.emplace_back("opponent-loaded-count");
+
+	for (int i = 0; i < kUnitTypeCount; ++i) {
+		channels.emplace_back(std::string("self-loaded/") + UnitProperties::getTypename(static_cast<UnitProperties::Type>(i)));
+	}
+
+	for (int i = 0; i < kUnitTypeCount; ++i) {
+		channels.emplace_back(std::string("opponent-loaded/") + UnitProperties::getTypename(static_cast<UnitProperties::Type>(i)));
+	}
+
+	channels.emplace_back("self-loaded-health");
+	channels.emplace_back("opponent-loaded-health");
+
+	const std::array<const char*, 10> economyChannels{ {
+		"self-funds",
+		"opponent-funds",
+		"self-income",
+		"opponent-income",
+		"self-unit-count",
+		"opponent-unit-count",
+		"self-army-value",
+		"opponent-army-value",
+		"self-capture-progress",
+		"opponent-capture-progress",
+	} };
+
+	for (const char* channel : economyChannels) {
+		channels.emplace_back(channel);
+	}
+
+	for (int i = 0; i < kCoCount; ++i) {
+		channels.emplace_back(std::string("self-co/") + CoName(static_cast<CommandingOfficier::Type>(i)));
+	}
+
+	for (int i = 0; i < kCoCount; ++i) {
+		channels.emplace_back(std::string("opponent-co/") + CoName(static_cast<CommandingOfficier::Type>(i)));
+	}
+
+	const std::array<const char*, 13> finalChannels{ {
+		"self-power-normal",
+		"self-power-cop-active",
+		"self-power-scop-active",
+		"self-power-charge",
+		"opponent-power-normal",
+		"opponent-power-cop-active",
+		"opponent-power-scop-active",
+		"opponent-power-charge",
+		"turn-count",
+		"weather-clear",
+		"weather-rain",
+		"weather-snow",
+		"weather-turns-remaining",
+	} };
+
+	for (const char* channel : finalChannels) {
+		channels.emplace_back(channel);
+	}
+
+	return channels;
+}
+
+RelativeOwner GetRelativeOwner(const Player* owner, const PlayerContext& context, bool neutralAllowed) noexcept {
+	if (owner == nullptr) {
+		return neutralAllowed ? RelativeOwner::Neutral : RelativeOwner::Invalid;
+	}
+
+	if (owner == context.self) {
+		return RelativeOwner::Self;
+	}
+
+	if (owner == context.opponent) {
+		return RelativeOwner::Opponent;
+	}
+
+	return RelativeOwner::Invalid;
+}
+
+bool TryGetTile(const Map& map, int x, int y, const MapTile** tile) noexcept {
+	if (x < 0 || y < 0 || x >= static_cast<int>(map.GetCols()) || y >= static_cast<int>(map.GetRows())) {
+		return false;
+	}
+
+	return map.TryGetTile(static_cast<unsigned int>(x), static_cast<unsigned int>(y), tile) == Result::Succeeded && *tile != nullptr;
+}
+
+bool OwnUnitAdjacent(const Map& map, int x, int y, const PlayerContext& context) noexcept {
+	const std::array<std::pair<int, int>, 4> offsets{ {
+		{ 0, -1 },
+		{ 1, 0 },
+		{ 0, 1 },
+		{ -1, 0 },
+	} };
+
+	for (const auto& offset : offsets) {
+		const MapTile* tile = nullptr;
+		if (!TryGetTile(map, x + offset.first, y + offset.second, &tile)) {
+			continue;
+		}
+
+		const Unit* unit = tile->TryGetUnit();
+		if (unit != nullptr && unit->m_owner == context.self) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool OnOwnProperty(const MapTile& tile, const PlayerContext& context) noexcept {
+	return tile.m_spPropertyInfo != nullptr && tile.m_spPropertyInfo->m_owner == context.self;
+}
+
+bool IsRedactedHiddenUnit(const Map& map, const MapTile& tile, const Unit& unit, int x, int y, RelativeOwner owner, const PlayerContext& context) noexcept {
+	if (owner != RelativeOwner::Opponent || !unit.m_hidden) {
+		return false;
+	}
+
+	const UnitProperties::Type type = unit.m_properties.m_type;
+	if (type != UnitProperties::Type::Stealth && type != UnitProperties::Type::Sub) {
+		return false;
+	}
+
+	return !OnOwnProperty(tile, context) && !OwnUnitAdjacent(map, x, y, context);
+}
+
+bool HealthKnown(RelativeOwner owner, const PlayerContext& context) noexcept {
+	return owner != RelativeOwner::Opponent || context.opponent->m_co.m_type != CommandingOfficier::Type::Sonja;
+}
+
+int CellIndex(int x, int y) noexcept {
+	return y * kBoardWidth + x;
+}
+
+void SetValue(std::vector<float>& values, int channel, int x, int y, float value) noexcept {
+	values[channel * kCellCount + CellIndex(x, y)] = Clamp01(value);
+}
+
+void Broadcast(std::vector<float>& values, const Map& map, int channel, float value) noexcept {
+	for (int y = 0; y < static_cast<int>(map.GetRows()); ++y) {
+		for (int x = 0; x < static_cast<int>(map.GetCols()); ++x) {
+			SetValue(values, channel, x, y, value);
+		}
+	}
+}
+
+void AddUnitAggregate(UnitAggregate& aggregate, const Unit& unit, bool healthKnown) noexcept {
+	++aggregate.count;
+	if (healthKnown) {
+		aggregate.armyValue += UnitArmyValue(unit);
+	}
+}
+
+int UnitTypeChannel(RelativeOwner owner, UnitProperties::Type type) noexcept {
+	const int unitIndex = static_cast<int>(type);
+	return (owner == RelativeOwner::Self ? kSelfUnitStart : kOpponentUnitStart) + unitIndex;
+}
+
+int LoadedTypeChannel(RelativeOwner owner, UnitProperties::Type type) noexcept {
+	const int unitIndex = static_cast<int>(type);
+	return (owner == RelativeOwner::Self ? kSelfLoadedTypeStart : kOpponentLoadedTypeStart) + unitIndex;
+}
+
+void SetUnitAttributes(std::vector<float>& values, const Unit& unit, RelativeOwner owner, bool healthKnown, int x, int y) noexcept {
+	const UnitProperties& maxProperties = GetUnitInfo(unit.m_properties.m_type);
+	const int start = kUnitAttributeStart + (owner == RelativeOwner::Self ? 0 : 6);
+
+	SetValue(values, start + 0, x, y, healthKnown ? DisplayHealthValue(unit) : 0.0f);
+	SetValue(values, start + 1, x, y, Normalize(static_cast<float>(unit.m_properties.m_ammo), static_cast<float>(maxProperties.m_ammo)));
+	SetValue(values, start + 2, x, y, Normalize(static_cast<float>(unit.m_properties.m_fuel), static_cast<float>(maxProperties.m_fuel)));
+	SetValue(values, start + 3, x, y, unit.m_moved ? 1.0f : 0.0f);
+	SetValue(values, start + 4, x, y, unit.m_hidden ? 1.0f : 0.0f);
+	SetValue(values, start + 5, x, y, unit.m_stunned ? 1.0f : 0.0f);
+
+	if (owner == RelativeOwner::Opponent) {
+		SetValue(values, kUnitAttributeStart + 12, x, y, healthKnown ? 1.0f : 0.0f);
+	}
+}
+
+Result EncodeLoadedUnits(std::vector<float>& values, const Unit& transport, const PlayerContext& context, UnitAggregate& selfAggregate, UnitAggregate& opponentAggregate, int x, int y) noexcept {
+	std::array<int, kUnitTypeCount> selfLoadedTypes{};
+	std::array<int, kUnitTypeCount> opponentLoadedTypes{};
+	int selfLoadedCount = 0;
+	int opponentLoadedCount = 0;
+	float selfLoadedHealth = 0.0f;
+	float opponentLoadedHealth = 0.0f;
+
+	for (int i = 0; i < transport.CLoadedUnits(); ++i) {
+		const Unit* loadedUnit = transport.GetLoadedUnit(i);
+		if (loadedUnit == nullptr || !IsValidUnitType(loadedUnit->m_properties.m_type)) {
+			return Result::Failed;
+		}
+
+		const RelativeOwner owner = GetRelativeOwner(loadedUnit->m_owner, context, false);
+		if (owner != RelativeOwner::Self && owner != RelativeOwner::Opponent) {
+			return Result::Failed;
+		}
+
+		const bool knownHealth = HealthKnown(owner, context);
+		if (owner == RelativeOwner::Self) {
+			++selfLoadedCount;
+			++selfLoadedTypes[static_cast<int>(loadedUnit->m_properties.m_type)];
+			if (knownHealth) {
+				selfLoadedHealth += static_cast<float>(DisplayHpPips(loadedUnit->health));
+			}
+			AddUnitAggregate(selfAggregate, *loadedUnit, knownHealth);
+		}
+		else {
+			++opponentLoadedCount;
+			++opponentLoadedTypes[static_cast<int>(loadedUnit->m_properties.m_type)];
+			if (knownHealth) {
+				opponentLoadedHealth += static_cast<float>(DisplayHpPips(loadedUnit->health));
+			}
+			AddUnitAggregate(opponentAggregate, *loadedUnit, knownHealth);
+		}
+	}
+
+	if (selfLoadedCount > 0) {
+		SetValue(values, kLoadedStart, x, y, Normalize(static_cast<float>(selfLoadedCount), 2.0f));
+		SetValue(values, kSelfLoadedHealth, x, y, Normalize(selfLoadedHealth, 20.0f));
+		for (int unitType = 0; unitType < kUnitTypeCount; ++unitType) {
+			if (selfLoadedTypes[unitType] > 0) {
+				SetValue(values, kSelfLoadedTypeStart + unitType, x, y, Normalize(static_cast<float>(selfLoadedTypes[unitType]), 2.0f));
+			}
+		}
+	}
+
+	if (opponentLoadedCount > 0) {
+		SetValue(values, kLoadedStart + 1, x, y, Normalize(static_cast<float>(opponentLoadedCount), 2.0f));
+		SetValue(values, kOpponentLoadedHealth, x, y, Normalize(opponentLoadedHealth, 20.0f));
+		for (int unitType = 0; unitType < kUnitTypeCount; ++unitType) {
+			if (opponentLoadedTypes[unitType] > 0) {
+				SetValue(values, kOpponentLoadedTypeStart + unitType, x, y, Normalize(static_cast<float>(opponentLoadedTypes[unitType]), 2.0f));
+			}
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+Result ValidateTensorValues(const std::vector<float>& values) noexcept {
+	for (float value : values) {
+		if (!std::isfinite(value) || value < 0.0f || value > 1.0f) {
+			return Result::Failed;
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+void HashBytes(std::uint64_t& hash, const void* data, std::size_t size) noexcept {
+	const unsigned char* bytes = static_cast<const unsigned char*>(data);
+	for (std::size_t i = 0; i < size; ++i) {
+		hash ^= static_cast<std::uint64_t>(bytes[i]);
+		hash *= 1099511628211ULL;
+	}
+}
+
+void HashString(std::uint64_t& hash, const std::string& value) noexcept {
+	HashBytes(hash, value.data(), value.size());
+	const char separator = '\0';
+	HashBytes(hash, &separator, sizeof(separator));
+}
+}
+
+const char* StateTensor::Version() noexcept {
+	return "standard-gl-v1-state";
+}
+
+int StateTensor::BoardWidth() noexcept {
+	return kBoardWidth;
+}
+
+int StateTensor::BoardHeight() noexcept {
+	return kBoardHeight;
+}
+
+int StateTensor::ChannelCount() noexcept {
+	return kChannelCount;
+}
+
+const std::vector<std::string>& StateTensor::ChannelNames() {
+	static const std::vector<std::string> channels = BuildChannelNames();
+	return channels;
+}
+
+Result StateTensor::ChannelIndex(const std::string& name, int& index) noexcept {
+	const std::vector<std::string>& channels = ChannelNames();
+	const auto it = std::find(channels.begin(), channels.end(), name);
+	if (it == channels.end()) {
+		return Result::Failed;
+	}
+
+	index = static_cast<int>(std::distance(channels.begin(), it));
+	return Result::Succeeded;
+}
+
+Result StateTensor::Encode(const GameState& gameState, std::vector<float>& values) noexcept {
+	const Map* map = gameState.TryGetMap();
+	if (map == nullptr || map->GetCols() > kBoardWidth || map->GetRows() > kBoardHeight) {
+		return Result::Failed;
+	}
+
+	const int activePlayer = gameState.IsFirstPlayerTurn() ? 0 : 1;
+	const int opponentPlayer = activePlayer == 0 ? 1 : 0;
+	const std::array<Player, 2>& players = gameState.GetPlayers();
+	if (!IsValidCoType(players[activePlayer].m_co.m_type) || !IsValidCoType(players[opponentPlayer].m_co.m_type)) {
+		return Result::Failed;
+	}
+
+	const PlayerContext context{ activePlayer, opponentPlayer, &players[activePlayer], &players[opponentPlayer] };
+	values.assign(static_cast<std::size_t>(kChannelCount * kCellCount), 0.0f);
+
+	UnitAggregate selfAggregate;
+	UnitAggregate opponentAggregate;
+
+	for (int y = 0; y < static_cast<int>(map->GetRows()); ++y) {
+		for (int x = 0; x < static_cast<int>(map->GetCols()); ++x) {
+			const MapTile* tile = nullptr;
+			if (!TryGetTile(*map, x, y, &tile)) {
+				return Result::Failed;
+			}
+
+			SetValue(values, kInBoundsChannel, x, y, 1.0f);
+
+			const Terrain::Type terrainType = tile->GetTerrain().m_type;
+			if (!IsValidTerrainType(terrainType)) {
+				return Result::Failed;
+			}
+			SetValue(values, kTerrainStart + static_cast<int>(terrainType), x, y, 1.0f);
+
+			if (MapTile::IsProperty(terrainType)) {
+				if (tile->m_spPropertyInfo == nullptr) {
+					return Result::Failed;
+				}
+
+				const RelativeOwner propertyOwner = GetRelativeOwner(tile->m_spPropertyInfo->m_owner, context, true);
+				switch (propertyOwner) {
+				case RelativeOwner::Self:
+					SetValue(values, kPropertyStart, x, y, 1.0f);
+					break;
+				case RelativeOwner::Opponent:
+					SetValue(values, kPropertyStart + 1, x, y, 1.0f);
+					break;
+				case RelativeOwner::Neutral:
+					SetValue(values, kPropertyStart + 2, x, y, 1.0f);
+					break;
+				default:
+					return Result::Failed;
+				}
+				SetValue(values, kPropertyStart + 3, x, y, Normalize(static_cast<float>(tile->m_spPropertyInfo->m_capturePoints), 20.0f));
+			}
+
+			const Unit* unit = tile->TryGetUnit();
+			if (unit == nullptr) {
+				continue;
+			}
+
+			if (!IsValidUnitType(unit->m_properties.m_type)) {
+				return Result::Failed;
+			}
+
+			const RelativeOwner unitOwner = GetRelativeOwner(unit->m_owner, context, false);
+			if (unitOwner != RelativeOwner::Self && unitOwner != RelativeOwner::Opponent) {
+				return Result::Failed;
+			}
+
+			if (IsRedactedHiddenUnit(*map, *tile, *unit, x, y, unitOwner, context)) {
+				continue;
+			}
+
+			const bool knownHealth = HealthKnown(unitOwner, context);
+			SetValue(values, UnitTypeChannel(unitOwner, unit->m_properties.m_type), x, y, 1.0f);
+			SetUnitAttributes(values, *unit, unitOwner, knownHealth, x, y);
+			if (unitOwner == RelativeOwner::Self) {
+				AddUnitAggregate(selfAggregate, *unit, knownHealth);
+			}
+			else {
+				AddUnitAggregate(opponentAggregate, *unit, knownHealth);
+			}
+
+			IfFailedReturn(EncodeLoadedUnits(values, *unit, context, selfAggregate, opponentAggregate, x, y));
+		}
+	}
+
+	Broadcast(values, *map, kEconomyStart, Normalize(static_cast<float>(context.self->m_funds), 50000.0f));
+	Broadcast(values, *map, kEconomyStart + 1, Normalize(static_cast<float>(context.opponent->m_funds), 50000.0f));
+	Broadcast(values, *map, kEconomyStart + 2, Normalize(static_cast<float>(gameState.GetIncomeForPlayer(activePlayer)), 50000.0f));
+	Broadcast(values, *map, kEconomyStart + 3, Normalize(static_cast<float>(gameState.GetIncomeForPlayer(opponentPlayer)), 50000.0f));
+	Broadcast(values, *map, kEconomyStart + 4, Normalize(static_cast<float>(selfAggregate.count), static_cast<float>(gameState.GetSettings().m_unitCap)));
+	Broadcast(values, *map, kEconomyStart + 5, Normalize(static_cast<float>(opponentAggregate.count), static_cast<float>(gameState.GetSettings().m_unitCap)));
+	Broadcast(values, *map, kEconomyStart + 6, Normalize(selfAggregate.armyValue, 200000.0f));
+	Broadcast(values, *map, kEconomyStart + 7, Normalize(opponentAggregate.armyValue, 200000.0f));
+	Broadcast(values, *map, kEconomyStart + 8, Normalize(static_cast<float>(gameState.CountCaptureLimitPropertiesForPlayer(activePlayer)), static_cast<float>(gameState.GetSettings().m_captureLimit)));
+	Broadcast(values, *map, kEconomyStart + 9, Normalize(static_cast<float>(gameState.CountCaptureLimitPropertiesForPlayer(opponentPlayer)), static_cast<float>(gameState.GetSettings().m_captureLimit)));
+
+	Broadcast(values, *map, kSelfCoStart + static_cast<int>(context.self->m_co.m_type), 1.0f);
+	Broadcast(values, *map, kOpponentCoStart + static_cast<int>(context.opponent->m_co.m_type), 1.0f);
+
+	const int selfPowerStatus = context.self->PowerStatus();
+	const int opponentPowerStatus = context.opponent->PowerStatus();
+	if (selfPowerStatus < 0 || selfPowerStatus > 2 || opponentPowerStatus < 0 || opponentPowerStatus > 2) {
+		return Result::Failed;
+	}
+
+	Broadcast(values, *map, kPowerStart + selfPowerStatus, 1.0f);
+	Broadcast(values, *map, kPowerStart + 3, Normalize(static_cast<float>(context.self->m_powerMeter.GetCharge()), static_cast<float>(context.self->m_powerMeter.GetScopThreshold())));
+	Broadcast(values, *map, kPowerStart + 4 + opponentPowerStatus, 1.0f);
+	Broadcast(values, *map, kPowerStart + 7, Normalize(static_cast<float>(context.opponent->m_powerMeter.GetCharge()), static_cast<float>(context.opponent->m_powerMeter.GetScopThreshold())));
+
+	Broadcast(values, *map, kTurnWeatherStart, Normalize(static_cast<float>(gameState.GetTurnCount()), 30.0f));
+	switch (gameState.GetWeather()) {
+	case GameState::WeatherType::Clear:
+		Broadcast(values, *map, kTurnWeatherStart + 1, 1.0f);
+		break;
+	case GameState::WeatherType::Rain:
+		Broadcast(values, *map, kTurnWeatherStart + 2, 1.0f);
+		break;
+	case GameState::WeatherType::Snow:
+		Broadcast(values, *map, kTurnWeatherStart + 3, 1.0f);
+		break;
+	default:
+		return Result::Failed;
+	}
+
+	if (gameState.GetWeatherTurnsRemaining().has_value()) {
+		Broadcast(values, *map, kTurnWeatherStart + 4, Normalize(static_cast<float>(gameState.GetWeatherTurnsRemaining().value()), 3.0f));
+	}
+
+	IfFailedReturn(ValidateTensorValues(values));
+	return Result::Succeeded;
+}
+
+Result StateTensor::Checksum(const std::vector<float>& values, std::uint64_t& checksum) noexcept {
+	if (values.size() != static_cast<std::size_t>(kChannelCount * kCellCount)) {
+		return Result::Failed;
+	}
+
+	std::uint64_t hash = 14695981039346656037ULL;
+	const std::string version = Version();
+	HashString(hash, version);
+
+	const std::array<int, 3> shape{ { kChannelCount, kBoardHeight, kBoardWidth } };
+	HashBytes(hash, shape.data(), sizeof(int) * shape.size());
+
+	for (const std::string& channel : ChannelNames()) {
+		HashString(hash, channel);
+	}
+
+	HashBytes(hash, values.data(), sizeof(float) * values.size());
+	checksum = hash;
+	return Result::Succeeded;
+}

--- a/AdvanceWarsServer/test/json/state-tensor/encoding.json
+++ b/AdvanceWarsServer/test/json/state-tensor/encoding.json
@@ -1,0 +1,131 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 10,
+    "game-over": false,
+    "gameId": "state-tensor-encoding",
+    "map": [
+      [
+        {
+          "property": { "capture-points": 15, "owner": "neutral" },
+          "terrain": 34,
+          "unit": { "ammo": 0, "fuel": 99, "health": 87, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" }
+        },
+        {
+          "terrain": 1,
+          "unit": { "ammo": 5, "fuel": 50, "health": 73, "hidden": false, "moved": true, "owner": "blue-moon", "type": "tank" }
+        },
+        { "property": { "capture-points": 20, "owner": "orange-star" }, "terrain": 38 },
+        { "property": { "capture-points": 20, "owner": "blue-moon" }, "terrain": 44 },
+        {
+          "terrain": 28,
+          "unit": { "ammo": 6, "fuel": 60, "health": 100, "hidden": true, "moved": false, "owner": "blue-moon", "type": "sub" }
+        }
+      ],
+      [
+        {
+          "terrain": 1,
+          "unit": {
+            "ammo": 0,
+            "fuel": 60,
+            "health": 100,
+            "hidden": false,
+            "loaded-units": [
+              { "ammo": 0, "fuel": 99, "health": 100, "hidden": false, "moved": false, "owner": "orange-star", "type": "infantry" },
+              { "ammo": 3, "fuel": 70, "health": 44, "hidden": false, "moved": false, "owner": "orange-star", "type": "mech" }
+            ],
+            "moved": false,
+            "owner": "orange-star",
+            "type": "apc"
+          }
+        },
+        { "terrain": 1 },
+        { "terrain": 1 },
+        { "terrain": 1 },
+        { "terrain": 1 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Sasha",
+        "funds": 25000,
+        "power-meter": { "charge": 27000, "cop-stars": 2, "scop-stars": 4, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Sonja",
+        "funds": 10000,
+        "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 2, "star-value": 9000 },
+        "power-status": 2,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 15,
+    "unit-cap": 50,
+    "weather": "rain",
+    "weather-turns-remaining": 2,
+    "winner": -1
+  },
+  "stateTensor": {
+    "version": "standard-gl-v1-state",
+    "width": 27,
+    "height": 23,
+    "channels": 219,
+    "channelIndices": [
+      { "channel": "in-bounds", "index": 0 },
+      { "channel": "self-unit/infantry", "index": 34 },
+      { "channel": "opponent-health-known", "index": 85 },
+      { "channel": "turn-count", "index": 214 },
+      { "channel": "weather-turns-remaining", "index": 218 }
+    ],
+    "values": [
+      { "channel": "in-bounds", "at": [0, 0], "value": 1.0 },
+      { "channel": "in-bounds", "at": [5, 0], "value": 0.0 },
+      { "channel": "terrain/city", "at": [0, 0], "value": 1.0 },
+      { "channel": "terrain/plain", "at": [1, 0], "value": 1.0 },
+      { "channel": "terrain/sea", "at": [4, 0], "value": 1.0 },
+      { "channel": "property-neutral", "at": [0, 0], "value": 1.0 },
+      { "channel": "property-capture-points", "at": [0, 0], "value": 0.75 },
+      { "channel": "property-self", "at": [2, 0], "value": 1.0 },
+      { "channel": "property-opponent", "at": [3, 0], "value": 1.0 },
+      { "channel": "self-unit/infantry", "at": [0, 0], "value": 1.0 },
+      { "channel": "self-health", "at": [0, 0], "value": 0.9 },
+      { "channel": "self-fuel", "at": [0, 0], "value": 1.0 },
+      { "channel": "opponent-unit/tank", "at": [1, 0], "value": 1.0 },
+      { "channel": "opponent-health", "at": [1, 0], "value": 0.0 },
+      { "channel": "opponent-health-known", "at": [1, 0], "value": 0.0 },
+      { "channel": "opponent-ammo", "at": [1, 0], "value": 0.5555555556 },
+      { "channel": "opponent-moved", "at": [1, 0], "value": 1.0 },
+      { "channel": "opponent-unit/sub", "at": [4, 0], "value": 0.0 },
+      { "channel": "opponent-hidden", "at": [4, 0], "value": 0.0 },
+      { "channel": "self-unit/apc", "at": [0, 1], "value": 1.0 },
+      { "channel": "self-loaded-count", "at": [0, 1], "value": 1.0 },
+      { "channel": "self-loaded/infantry", "at": [0, 1], "value": 0.5 },
+      { "channel": "self-loaded/mech", "at": [0, 1], "value": 0.5 },
+      { "channel": "self-loaded-health", "at": [0, 1], "value": 0.75 },
+      { "channel": "self-funds", "at": [0, 0], "value": 0.5 },
+      { "channel": "opponent-funds", "at": [0, 0], "value": 0.2 },
+      { "channel": "self-income", "at": [0, 0], "value": 0.022 },
+      { "channel": "opponent-income", "at": [0, 0], "value": 0.02 },
+      { "channel": "self-unit-count", "at": [0, 0], "value": 0.08 },
+      { "channel": "opponent-unit-count", "at": [0, 0], "value": 0.02 },
+      { "channel": "self-army-value", "at": [0, 0], "value": 0.0042 },
+      { "channel": "opponent-army-value", "at": [0, 0], "value": 0.0 },
+      { "channel": "self-capture-progress", "at": [0, 0], "value": 0.1 },
+      { "channel": "opponent-capture-progress", "at": [0, 0], "value": 0.1 },
+      { "channel": "self-co/sasha", "at": [0, 0], "value": 1.0 },
+      { "channel": "opponent-co/sonja", "at": [0, 0], "value": 1.0 },
+      { "channel": "self-power-normal", "at": [0, 0], "value": 1.0 },
+      { "channel": "self-power-charge", "at": [0, 0], "value": 0.5 },
+      { "channel": "opponent-power-scop-active", "at": [0, 0], "value": 1.0 },
+      { "channel": "turn-count", "at": [0, 0], "value": 0.5 },
+      { "channel": "weather-rain", "at": [0, 0], "value": 1.0 },
+      { "channel": "weather-clear", "at": [0, 0], "value": 0.0 },
+      { "channel": "weather-turns-remaining", "at": [0, 0], "value": 0.6666666667 },
+      { "channel": "self-funds", "at": [5, 0], "value": 0.0 }
+    ]
+  }
+}

--- a/AdvanceWarsServer/test/json/state-tensor/map-too-large-fails.json
+++ b/AdvanceWarsServer/test/json/state-tensor/map-too-large-fails.json
@@ -1,0 +1,62 @@
+{
+  "initial-game-state": {
+    "activePlayer": 0,
+    "cap-limit": 21,
+    "game-over": false,
+    "gameId": "state-tensor-map-too-large-fails",
+    "map": [
+      [
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 },
+        { "terrain": 15 }
+      ]
+    ],
+    "players": [
+      {
+        "armyType": "orange-star",
+        "co": "Andy",
+        "funds": 0,
+        "power-meter": { "charge": 0, "cop-stars": 3, "scop-stars": 3, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 1
+      },
+      {
+        "armyType": "blue-moon",
+        "co": "Adder",
+        "funds": 0,
+        "power-meter": { "charge": 0, "cop-stars": 2, "scop-stars": 3, "star-value": 9000 },
+        "power-status": 0,
+        "luck-policy": 2
+      }
+    ],
+    "turn-count": 1,
+    "unit-cap": 50,
+    "winner": -1
+  },
+  "stateTensorShouldFail": true
+}

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -1,6 +1,6 @@
 # Standard Engine Completeness Matrix
 
-Last reviewed: 2026-05-25
+Last reviewed: 2026-06-01
 
 This document tracks the simulator against the first playable target: normal Advance Wars By Web Global League Standard games that can be driven through a REST API or AI training loop. Local source code and JSON fixtures are the source of truth for current implementation behavior. The gameplay target is checked against the local report at `C:\Users\Roshan\Downloads\advance-wars-by-web-report.md` and the [Advance Wars By Web Wiki](https://awbw.fandom.com/wiki/Advance_Wars_By_Web_Wiki), especially [Metagame](https://awbw.fandom.com/wiki/Metagame), [AWBW Guide](https://awbw.fandom.com/wiki/AWBW_Guide), [Units](https://awbw.fandom.com/wiki/Units), [Properties](https://awbw.fandom.com/wiki/Properties), [Damage Formula](https://awbw.fandom.com/wiki/Damage_Formula), [CO](https://awbw.fandom.com/wiki/CO), and [Changes in AWBW](https://awbw.fandom.com/wiki/Changes_in_AWBW).
 
@@ -65,7 +65,7 @@ Explicitly deferred modes and options:
 | Submitted action validation | Legal actions are generated, but direct submitted actions can bypass some validation or mutate before failing. | Submitted actions are validated and rejected atomically. | Partial | #67 |
 | Step semantics | REST action application commits exactly the submitted action and can report an `EndTurn`-only legal-action list without advancing. | One submitted action causes exactly one committed action. | Complete | #68 |
 | Terminal reasons | HQ capture, lab win, rout/fuel-out behavior exist. Canonical Standard/API stepping does not auto-resign by heuristic army value unless `heuristicAutoResign` is explicitly enabled. | Terminal reason should be explicit: HQ, lab, rout, capture limit, day limit, timeout, resign, or opt-in heuristic resign. | Partial | #74, #77, #82 |
-| State tensor | `Tensor.cpp` exists as planned home. | Deterministic current-player-relative tensor. | Partial | #3 |
+| State tensor | `StateTensor` exposes the deterministic `standard-gl-v1-state` current-player-relative tensor with JSON fixture coverage. | Deterministic current-player-relative tensor. | Complete for v1 | none |
 | Action encoding and masks | `Action` variants and legal action generation exist. | Stable encoded action space plus mask. | Partial | #4 |
 | MCTS sequence handling | Existing MCTS needs action-level self-play cleanup. | Same-player action sequences backed up correctly until `EndTurn`. | Partial | #5 |
 | Replay writer | Not complete. | Versioned self-play samples and reconstructable action history. | Partial | #6 |
@@ -169,7 +169,6 @@ Detailed implementation notes live in `CO_SUPPORT.md`.
 
 Training loop:
 
-- #3: Implement state tensor encoding.
 - #4: Implement action encoding and legal action masks.
 - #5: Refactor MCTS for action-level self-play and same-player turn sequences.
 - #6: Add self-play replay writer.

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -34,7 +34,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] Add a small environment wrapper around `GameState`; the REST/self-play API contract is tracked by #66.
 - [ ] Expose `reset`, `legalActions`, `step`, `isTerminal`, `currentPlayer`, and `winner` operations.
 - [ ] Add stable state serialization for replay data.
-- [ ] Add state tensor encoding in `Tensor.cpp` (#3).
+- [x] Add state tensor encoding in `Tensor.cpp` (#3).
 - [ ] Add a stable action encoding scheme for every `Action` variant (#4).
 - [ ] Add legal action masks aligned with the action encoding (#4).
 - [ ] Add tests proving encode/decode preserves actions, including move-attack, unload, buy, powers, and end-turn.
@@ -62,7 +62,7 @@ The rules/API completeness target for the initial playable environment is normal
 
 ## Phase 4: Neural Network
 
-- [ ] Define model input planes for terrain, ownership, units, health, ammo, fuel, moved flags, capture points, funds, powers, turn/player context, and optional fog state.
+- [x] Define model input planes via `standard-gl-v1-state` in `docs/STATE_TENSOR.md`.
 - [ ] Define policy head output shape matching the action encoding.
 - [ ] Define value head output as win/loss value from the current player's perspective.
 - [ ] Add model save/load checkpoints.
@@ -89,7 +89,7 @@ The rules/API completeness target for the initial playable environment is normal
 ## Candidate GitHub Issues
 
 - [x] #2 Create deterministic combat RNG for self-play.
-- [ ] #3 Implement state tensor encoding.
+- [x] #3 Implement state tensor encoding.
 - [ ] #4 Implement action encoding and legal action masks.
 - [ ] #5 Refactor MCTS for action-level self-play and same-player turn sequences.
 - [ ] #6 Add self-play replay writer.

--- a/docs/STATE_TENSOR.md
+++ b/docs/STATE_TENSOR.md
@@ -1,0 +1,561 @@
+# State Tensor Encoding
+
+The v1 state tensor encoding is `standard-gl-v1-state`. It is scoped to normal Global League Standard self-play and is designed to pair with the `standard-gl-v1` action space in `docs/ACTION_SPACE.md`.
+
+The tensor is a stable, versioned ABI for model input, replay validation, and tests. It represents the current active player's observable position. It does not encode legal actions; callers should use `ActionSpace::GenerateLegalActionMask` separately.
+
+## Goals
+
+- Keep the game engine as the source of truth for rules and state transitions.
+- Encode the board from the active player's perspective.
+- Keep the tensor deterministic, testable, and independent of LibTorch.
+- Avoid training on information that would not be visible in real play.
+- Prefer a clear v1 contract over premature channel minimization.
+
+## Shape And Layout
+
+`standard-gl-v1-state` uses the same fixed board canvas as the action space:
+
+```text
+channels x height x width
+C x 23 x 27
+```
+
+Smaller maps are placed at the top-left of the canvas. Off-map cells are zero in every channel. Maps wider than 27 tiles or taller than 23 tiles fail encoding.
+
+The flat storage layout is channel-major:
+
+```text
+index = channel * 23 * 27 + y * 27 + x
+```
+
+Tensor values are `float`. All scalar values are finite and clipped to `[0, 1]`.
+
+## Public API Shape
+
+The public C++ surface mirrors `ActionSpace` while staying free of LibTorch:
+
+```cpp
+class StateTensor final {
+public:
+    static const char* Version() noexcept;
+    static int BoardWidth() noexcept;
+    static int BoardHeight() noexcept;
+    static int ChannelCount() noexcept;
+    static const std::vector<std::string>& ChannelNames();
+    static Result ChannelIndex(const std::string& name, int& index) noexcept;
+    static Result Encode(const GameState& gameState, std::vector<float>& values) noexcept;
+    static Result Checksum(const std::vector<float>& values, std::uint64_t& checksum) noexcept;
+};
+```
+
+The public header is `AdvanceWarsServer/inc/StateTensor.h`. The implementation uses the existing `AdvanceWarsServer/src/Tensor.cpp`.
+
+## Perspective
+
+All ownership features are relative to the active player:
+
+- `self` means the active player.
+- `opponent` means the other player.
+- `neutral` means no owner.
+
+The tensor does not encode absolute active-player identity, player index, or army color. Replay metadata may still store those values.
+
+The tensor preserves absolute board coordinates. It does not flip or rotate by active player.
+
+## Observation Rules
+
+The tensor avoids exposing hidden information that a real ladder player would not see.
+
+Health is encoded as displayed HP pips, not exact internal HP:
+
+```text
+displayHp = ceil(internalHp / 10.0)
+health = displayHp / 10.0
+```
+
+Ammo and fuel are visible exact values in the current Standard scope and are normalized by the unit type's maximum values from `GetUnitInfo`.
+
+Enemy hidden Stealth/Sub units are encoded only if revealed to the active player. A hidden enemy Stealth/Sub is revealed when it is adjacent to one of the active player's units or standing on one of the active player's properties. Otherwise, the unit and its cargo are omitted from all unit-related planes and aggregates.
+
+Enemy Sonja unit health is unknown to the active player. For visible enemy Sonja units, encode unit type, position, ammo, fuel, moved, hidden, stunned, and cargo presence as usual, but set opponent health to `0` and set `opponent-health-known` to `0`. For other visible opponent units, `opponent-health-known` is `1`.
+
+Unknown enemy Sonja HP contributes `0` to opponent army value.
+
+## Channel Order
+
+Channel order is part of the ABI. Tests assert channel count and representative channel names/indices.
+
+Channels are ordered by broad group, then by stable enum order inside enum-backed groups:
+
+1. metadata
+2. terrain
+3. properties
+4. board units
+5. unit attributes
+6. loaded units
+7. economy and global material
+8. CO identity
+9. CO power state
+10. turn and weather
+
+## Channels
+
+### Metadata
+
+```text
+in-bounds
+```
+
+`in-bounds` is `1` for real map cells and `0` for padded cells.
+
+### Terrain
+
+One binary plane per `Terrain::Type`, in enum order:
+
+```text
+terrain/plain
+terrain/mountain
+terrain/forest
+terrain/river
+terrain/road
+terrain/bridge
+terrain/sea
+terrain/shoal
+terrain/reef
+terrain/city
+terrain/base
+terrain/airport
+terrain/port
+terrain/headquarters
+terrain/pipe
+terrain/missile-silo
+terrain/com-tower
+terrain/lab
+```
+
+Terrain is categorical. There is no numeric terrain-id plane and no terrain-defense plane in v1.
+
+### Properties
+
+```text
+property-self
+property-opponent
+property-neutral
+property-capture-points
+```
+
+`property-capture-points` is remaining capture points divided by `20.0`. Non-property cells are `0`.
+
+Terrain planes identify the property type. Ownership planes identify who owns the property.
+
+### Board Unit Types
+
+One binary unit-type plane per side and per `UnitProperties::Type`, in enum order:
+
+```text
+self-unit/anti-air
+self-unit/apc
+self-unit/artillery
+self-unit/bcopter
+self-unit/battleship
+self-unit/blackboat
+self-unit/blackbomb
+self-unit/bomber
+self-unit/carrier
+self-unit/crusier
+self-unit/fighter
+self-unit/infantry
+self-unit/lander
+self-unit/medium-tank
+self-unit/mech
+self-unit/megatank
+self-unit/missile
+self-unit/neotank
+self-unit/piperunner
+self-unit/recon
+self-unit/rocket
+self-unit/stealth
+self-unit/sub
+self-unit/tcopter
+self-unit/tank
+opponent-unit/anti-air
+opponent-unit/apc
+opponent-unit/artillery
+opponent-unit/bcopter
+opponent-unit/battleship
+opponent-unit/blackboat
+opponent-unit/blackbomb
+opponent-unit/bomber
+opponent-unit/carrier
+opponent-unit/crusier
+opponent-unit/fighter
+opponent-unit/infantry
+opponent-unit/lander
+opponent-unit/medium-tank
+opponent-unit/mech
+opponent-unit/megatank
+opponent-unit/missile
+opponent-unit/neotank
+opponent-unit/piperunner
+opponent-unit/recon
+opponent-unit/rocket
+opponent-unit/stealth
+opponent-unit/sub
+opponent-unit/tcopter
+opponent-unit/tank
+```
+
+### Unit Attributes
+
+```text
+self-health
+self-ammo
+self-fuel
+self-moved
+self-hidden
+self-stunned
+opponent-health
+opponent-ammo
+opponent-fuel
+opponent-moved
+opponent-hidden
+opponent-stunned
+opponent-health-known
+```
+
+Health uses displayed HP pips. Ammo and fuel are normalized against each visible unit type's maximum. Units without ammo encode ammo as `0`.
+
+`moved` and `stunned` are separate. `moved` represents same-turn action availability. `stunned` represents Von Bolt's future-tempo effect before it is converted into `moved` at the stunned player's next turn.
+
+### Loaded Units
+
+Loaded units are encoded as aggregate cargo features on the transport's cell. Cargo slot order is not encoded.
+
+```text
+self-loaded-count
+opponent-loaded-count
+self-loaded/anti-air
+self-loaded/apc
+self-loaded/artillery
+self-loaded/bcopter
+self-loaded/battleship
+self-loaded/blackboat
+self-loaded/blackbomb
+self-loaded/bomber
+self-loaded/carrier
+self-loaded/crusier
+self-loaded/fighter
+self-loaded/infantry
+self-loaded/lander
+self-loaded/medium-tank
+self-loaded/mech
+self-loaded/megatank
+self-loaded/missile
+self-loaded/neotank
+self-loaded/piperunner
+self-loaded/recon
+self-loaded/rocket
+self-loaded/stealth
+self-loaded/sub
+self-loaded/tcopter
+self-loaded/tank
+opponent-loaded/anti-air
+opponent-loaded/apc
+opponent-loaded/artillery
+opponent-loaded/bcopter
+opponent-loaded/battleship
+opponent-loaded/blackboat
+opponent-loaded/blackbomb
+opponent-loaded/bomber
+opponent-loaded/carrier
+opponent-loaded/crusier
+opponent-loaded/fighter
+opponent-loaded/infantry
+opponent-loaded/lander
+opponent-loaded/medium-tank
+opponent-loaded/mech
+opponent-loaded/megatank
+opponent-loaded/missile
+opponent-loaded/neotank
+opponent-loaded/piperunner
+opponent-loaded/recon
+opponent-loaded/rocket
+opponent-loaded/stealth
+opponent-loaded/sub
+opponent-loaded/tcopter
+opponent-loaded/tank
+self-loaded-health
+opponent-loaded-health
+```
+
+`loaded-count` is cargo count divided by `2.0`.
+
+Loaded unit type planes encode count by type divided by `2.0`. For example, two loaded Infantry set `self-loaded/infantry` to `1.0`; one loaded Infantry sets it to `0.5`.
+
+Loaded health is total displayed cargo HP divided by `20.0`, since the maximum visible cargo is two full-health units.
+
+Cargo visibility follows transport visibility. If an enemy hidden transport is not observable, its cargo does not appear in loaded-unit planes or unit-related aggregates.
+
+### Economy And Global Material
+
+Broadcast over real in-bounds cells only:
+
+```text
+self-funds
+opponent-funds
+self-income
+opponent-income
+self-unit-count
+opponent-unit-count
+self-army-value
+opponent-army-value
+self-capture-progress
+opponent-capture-progress
+```
+
+Funds:
+
+```text
+min(funds, 50000) / 50000.0
+```
+
+Income uses actual engine income, including CO modifiers and non-income properties, then:
+
+```text
+min(actualIncome, 50000) / 50000.0
+```
+
+Unit count includes visible loaded units and is normalized by unit cap:
+
+```text
+min(visibleUnitCount, unitCap) / unitCap
+```
+
+Army value uses displayed HP, not exact internal HP:
+
+```text
+unitValue = displayHp / 10.0 * unitCost
+armyValue = min(sum(unitValue), 200000) / 200000.0
+```
+
+Capture progress uses properties counted by capture-limit rules, excluding Labs and Com Towers:
+
+```text
+min(ownedCaptureLimitProperties, captureLimit) / captureLimit
+```
+
+### CO Identity
+
+One broadcast binary plane per side and per `CommandingOfficier::Type`, in enum order:
+
+```text
+self-co/adder
+self-co/andy
+self-co/colin
+self-co/drake
+self-co/eagle
+self-co/flak
+self-co/grimm
+self-co/grit
+self-co/hachi
+self-co/hawke
+self-co/jake
+self-co/javier
+self-co/jess
+self-co/jugger
+self-co/kanbei
+self-co/kindle
+self-co/koal
+self-co/lash
+self-co/max
+self-co/nell
+self-co/olaf
+self-co/rachel
+self-co/sami
+self-co/sasha
+self-co/sensei
+self-co/sonja
+self-co/sturm
+self-co/vonbolt
+opponent-co/adder
+opponent-co/andy
+opponent-co/colin
+opponent-co/drake
+opponent-co/eagle
+opponent-co/flak
+opponent-co/grimm
+opponent-co/grit
+opponent-co/hachi
+opponent-co/hawke
+opponent-co/jake
+opponent-co/javier
+opponent-co/jess
+opponent-co/jugger
+opponent-co/kanbei
+opponent-co/kindle
+opponent-co/koal
+opponent-co/lash
+opponent-co/max
+opponent-co/nell
+opponent-co/olaf
+opponent-co/rachel
+opponent-co/sami
+opponent-co/sasha
+opponent-co/sensei
+opponent-co/sonja
+opponent-co/sturm
+opponent-co/vonbolt
+```
+
+CO choice is not an in-game action, but it is part of the state because it changes combat, economy, movement, powers, and strategy.
+
+### CO Power State
+
+Broadcast over real in-bounds cells only:
+
+```text
+self-power-normal
+self-power-cop-active
+self-power-scop-active
+self-power-charge
+opponent-power-normal
+opponent-power-cop-active
+opponent-power-scop-active
+opponent-power-charge
+```
+
+Power status is one-hot. Charge is normalized by that player's SCOP threshold:
+
+```text
+min(charge, scopThreshold) / scopThreshold
+```
+
+There are no `can-use-cop` or `can-use-scop` planes in v1. Power action legality comes from the legal action mask.
+
+### Turn And Weather
+
+Broadcast over real in-bounds cells only:
+
+```text
+turn-count
+weather-clear
+weather-rain
+weather-snow
+weather-turns-remaining
+```
+
+Turn count:
+
+```text
+min(turnCount, 30) / 30.0
+```
+
+Weather is one-hot. Temporary weather turns remaining:
+
+```text
+min(turnsRemaining, 3) / 3.0
+```
+
+When no temporary weather counter exists, `weather-turns-remaining` is `0`.
+
+## Channel Count And Memory Budget
+
+With the current enum sizes, the expected v1 channel budget is about 219 channels:
+
+```text
+1 metadata
+18 terrain
+4 property
+50 board unit type
+13 unit attributes
+54 loaded-unit aggregate
+10 economy and global material
+56 CO identity
+8 CO power
+5 turn and weather
+```
+
+For a `219 x 23 x 27` tensor:
+
+```text
+135,999 floats
+~0.52 MiB as float32
+~0.26 MiB as float16
+```
+
+The dense policy output for `standard-gl-v1` is larger:
+
+```text
+1,554,366 action logits
+~5.93 MiB as float32 per sample
+~2.96 MiB as float16 per sample
+```
+
+This channel count is acceptable for v1. The design favors clear, auditable planes over aggressive compression. Replay storage should not store dense tensor floats by default; store serialized state and tensor version, then regenerate tensors on load.
+
+## Validation And Tests
+
+Tensor encoding should fail when:
+
+- the map exceeds `27x23`
+- a terrain, unit type, or CO enum is invalid
+- a unit owner cannot be mapped to self or opponent
+- a property owner cannot be mapped to self, opponent, or neutral
+- a normalized value is NaN, Inf, or outside `[0, 1]`
+
+The JSON fixture runner supports a `stateTensor` assertion block, similar to `actionSpace` and `legalActionMask`:
+
+```json
+{
+  "stateTensor": {
+    "version": "standard-gl-v1-state",
+    "width": 27,
+    "height": 23,
+    "channels": 219,
+    "values": [
+      { "channel": "self-unit/infantry", "at": [0, 0], "value": 1.0 },
+      { "channel": "opponent-funds", "at": [0, 0], "value": 0.2 }
+    ]
+  }
+}
+```
+
+Tests compare floats with a small tolerance, such as `1e-6`.
+
+The implementation also includes a deterministic checksum helper over version, shape, channel names, and flat tensor values. The checksum is for replay validation and ABI drift detection, not gameplay logic.
+
+## Replay Guidance
+
+Replay samples should store:
+
+- tensor version
+- action-space version
+- serialized game state or enough state data to rebuild the tensor
+- current player
+- selected action index
+- sparse legal action indices
+- sparse MCTS visit counts
+- final outcome from the sampled player's perspective
+
+Do not store dense state tensors or dense legal action masks by default. Regenerate tensors and materialize dense masks only when loading a training batch.
+
+## V1 Non-Goals
+
+The following are intentionally omitted from `standard-gl-v1-state`:
+
+- legal action planes
+- map id planes
+- absolute player index or army-color planes
+- terrain defense scalar planes
+- production availability planes
+- unit-ban planes
+- fixed Standard settings planes
+- day-limit progress planes
+- hidden-unit memory or last-known-position planes
+- game-over, winner, or terminal-reason planes
+- luck policy or combat RNG seed planes
+- dense tensor storage in replay shards
+- LibTorch-specific tensor return types
+
+Future experiments may add some of these in a new tensor version if training data shows a need.


### PR DESCRIPTION
## Summary

- Adds `StateTensor` as the public v1 `standard-gl-v1-state` encoder backed by `Tensor.cpp`.
- Encodes a deterministic 219-channel, current-player-relative `C x 23 x 27` tensor covering terrain, properties, units, loaded units, economy/material, CO identity, power state, turn count, and weather.
- Applies the agreed observation rules: displayed HP only, hidden enemy Sub/Stealth redaction unless revealed, and Sonja enemy HP redaction with an `opponent-health-known` plane.
- Adds a `docs/STATE_TENSOR.md` contract/design note and updates the self-play/completeness roadmap docs.
- Extends JSON fixtures with `stateTensor` assertions, including channel-index checks, representative float values, and a map-too-large failure case.

## Notes

The implementation uses `std::vector<float>` metadata-style APIs rather than LibTorch tensors so replay/inference callers can decide their own tensor backend. It also adds small public `GameState` helpers for visible income, capture-limit progress, turn count, weather, and weather duration.

## Test-Driven Checkpoint

Added the JSON tensor contract fixtures before implementation. The initial build failed as expected because `StateTensor.h` did not exist yet; implementation then made the focused and broader suites pass.

## Verification

- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json/state-tensor`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test-mcts`
- `git diff --cached --check`

Build note: MSBuild still reports the existing `GameState.cpp(1725)` C4244 conversion warning.

Closes #3