### PR TITLE
Add self-play replay writer

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -173,6 +173,10 @@
     <ClCompile Include="src\MctsTest.cpp" />
     <ClCompile Include="src\Player.cpp" />
     <ClCompile Include="src\RestGameService.cpp" />
+    <ClCompile Include="src\SelfPlayReplay.cpp" />
+    <ClCompile Include="src\SelfPlayReplayTest.cpp" />
+    <ClCompile Include="src\SelfPlayRunner.cpp" />
+    <ClCompile Include="src\StandardGameSetup.cpp" />
     <ClCompile Include="src\Tensor.cpp" />
     <ClCompile Include="src\TerrainInfo.cpp" />
     <ClCompile Include="src\Unit.cpp" />
@@ -200,7 +204,11 @@
     <ClInclude Include="inc\Player.h" />
     <ClInclude Include="inc\Result.h" />
     <ClInclude Include="inc\RestGameService.h" />
+    <ClInclude Include="inc\SelfPlayReplay.h" />
+    <ClInclude Include="inc\SelfPlayReplayTest.h" />
+    <ClInclude Include="inc\SelfPlayRunner.h" />
     <ClInclude Include="inc\Reward.h" />
+    <ClInclude Include="inc\StandardGameSetup.h" />
     <ClInclude Include="inc\StateTensor.h" />
     <ClInclude Include="inc\SubsystemTest.h" />
     <ClInclude Include="inc\Terrain.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -78,6 +78,18 @@
     <ClCompile Include="src\MctsTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\SelfPlayReplayTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\SelfPlayReplay.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\SelfPlayRunner.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\StandardGameSetup.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\Map.h">
@@ -162,6 +174,18 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\MctsTest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\SelfPlayReplayTest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\SelfPlayReplay.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\SelfPlayRunner.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\StandardGameSetup.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AdvanceWarsServer/inc/SelfPlayReplay.h
+++ b/AdvanceWarsServer/inc/SelfPlayReplay.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "GameState.h"
+#include "Result.h"
+
+struct SelfPlayError {
+	std::string code;
+	std::string message;
+	int line{ 0 };
+	int gameIndex{ -1 };
+	int ply{ -1 };
+};
+
+struct SelfPlayReplayValidationSummary {
+	int games{ 0 };
+	int samples{ 0 };
+	int actions{ 0 };
+	int invalidActions{ 0 };
+};
+
+const char* SelfPlayReplayFormatVersion() noexcept;
+json SelfPlayVersionsJson();
+Result ValidateSelfPlayReplay(const std::filesystem::path& path, SelfPlayReplayValidationSummary& summary, SelfPlayError& error);
+Result ValidateSelfPlayReplayForAppend(const std::filesystem::path& path, const json& expectedHeader, SelfPlayReplayValidationSummary& summary, SelfPlayError& error);

--- a/AdvanceWarsServer/inc/SelfPlayReplayTest.h
+++ b/AdvanceWarsServer/inc/SelfPlayReplayTest.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int RunSelfPlayReplayTests();

--- a/AdvanceWarsServer/inc/SelfPlayRunner.h
+++ b/AdvanceWarsServer/inc/SelfPlayRunner.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+#include "MonteCarloTreeSearch.h"
+#include "Result.h"
+#include "SelfPlayReplay.h"
+
+struct SelfPlayRunnerOptions {
+	std::filesystem::path outputPath;
+	bool append{ false };
+	bool quiet{ false };
+	std::string mapId;
+	std::string player0CoId;
+	std::string player1CoId;
+	int games{ 1 };
+	int maxActions{ 1000 };
+	std::uint32_t baseSeed{ 0 };
+	int unitCap{ 50 };
+	int captureLimit{ 21 };
+	bool hasDayLimit{ false };
+	int dayLimit{ 0 };
+	bool heuristicAutoResign{ false };
+	MCTSOptions mctsOptions;
+};
+
+struct SelfPlayRunSummary {
+	int gamesWritten{ 0 };
+	int samplesWritten{ 0 };
+	int actionsWritten{ 0 };
+};
+
+Result RunSelfPlay(const SelfPlayRunnerOptions& options, SelfPlayRunSummary& summary, SelfPlayError& error);
+int RunSelfPlayCommand(int argc, char* argv[]) noexcept;
+int RunValidateReplayCommand(int argc, char* argv[]) noexcept;

--- a/AdvanceWarsServer/inc/StandardGameSetup.h
+++ b/AdvanceWarsServer/inc/StandardGameSetup.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "GameState.h"
+
+enum class StandardGameSetupErrorType {
+	BadRequest,
+	UnprocessableEntity,
+	Internal,
+};
+
+struct StandardGameSetupError {
+	StandardGameSetupErrorType type{ StandardGameSetupErrorType::BadRequest };
+	std::string code;
+	std::string message;
+	json details{ json::object() };
+};
+
+struct StandardGameSetupResult {
+	GameState gameState;
+	json resolvedSettings;
+	std::string mapId;
+	std::array<std::string, 2> playerCoIds;
+	std::array<std::string, 2> playerArmyTypes;
+	std::optional<std::uint32_t> seed;
+};
+
+json StandardSettingsJson(int unitCap = 50, int captureLimit = 21, std::optional<int> dayLimit = std::nullopt, bool heuristicAutoResign = false);
+json SupportedStandardMapIds();
+Result BuildStandardGameRequestFromSlots(
+	const std::string& mapId,
+	const std::string& player0CoId,
+	const std::string& player1CoId,
+	const json& settings,
+	std::optional<std::uint32_t> seed,
+	json& request,
+	StandardGameSetupError& error);
+Result CreateStandardGameFromRequest(const json& request, StandardGameSetupResult& result, StandardGameSetupError& error);
+json SerializeStandardGameForApi(const GameState& gameState);
+json SerializeGameStateForReplay(const GameState& gameState);

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -8,6 +8,8 @@
 #include "AdvanceWarsServer.h"
 #include "MonteCarloTreeSearch.h"
 #include "MctsTest.h"
+#include "SelfPlayReplayTest.h"
+#include "SelfPlayRunner.h"
 #include "SubsystemTest.h"
 #include "Platform.h"
 #include <torch/torch.h>
@@ -21,7 +23,10 @@ int main(int argc, char* argv[]) noexcept {
 			std::cerr << "Options:\n";
 			std::cerr << "  -sim-random-move-game [seed] : Simulate a random move game.\n";
 			std::cerr << "  -sim-mcts-game        : Simulate an MCTS game.\n";
+			std::cerr << "  -self-play [options]  : Generate validated self-play replay JSONL.\n";
+			std::cerr << "  -validate-replay <path> : Validate a self-play replay JSONL file.\n";
 			std::cerr << "  -test-mcts            : Run focused MCTS tests.\n";
+			std::cerr << "  -test-replay          : Run focused self-play replay tests.\n";
 			std::cerr << "  -server               : Act as game server.\n";
 			return 1; // Return an error code
 		}
@@ -265,6 +270,15 @@ int main(int argc, char* argv[]) noexcept {
 		}
 		else if (argument == "-test-mcts") {
 			return RunMctsTests();
+		}
+		else if (argument == "-test-replay") {
+			return RunSelfPlayReplayTests();
+		}
+		else if (argument == "-self-play") {
+			return RunSelfPlayCommand(argc - 2, argv + 2);
+		}
+		else if (argument == "-validate-replay") {
+			return RunValidateReplayCommand(argc - 2, argv + 2);
 		}
 		else if (argument == "-server") {
 			return AdvanceWarsServer::getInstance().run();

--- a/AdvanceWarsServer/src/RestGameService.cpp
+++ b/AdvanceWarsServer/src/RestGameService.cpp
@@ -1,17 +1,12 @@
 #include "RestGameService.h"
 
 #include <algorithm>
-#include <array>
-#include <cctype>
-#include <filesystem>
-#include <fstream>
 #include <initializer_list>
-#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
 
-#include "Platform.h"
+#include "StandardGameSetup.h"
 
 namespace {
 constexpr int HttpOk = 200;
@@ -21,55 +16,6 @@ constexpr int HttpNotFound = 404;
 constexpr int HttpConflict = 409;
 constexpr int HttpUnprocessableEntity = 422;
 constexpr int HttpInternalServerError = 500;
-
-struct MapTemplate {
-	const char* id;
-	const char* path;
-};
-
-constexpr std::array<MapTemplate, 2> MapTemplates{ {
-	{ "lefty", "res/AWBW/MapSources/Lefty.json" },
-	{ "mcts", "res/AWBW/MapSources/MCTS.json" },
-} };
-
-json StandardSettingsJson(int unitCap = 50, int captureLimit = 21, std::optional<int> dayLimit = std::nullopt, bool heuristicAutoResign = false) {
-	json dayLimitJson = nullptr;
-	if (dayLimit.has_value()) {
-		dayLimitJson = dayLimit.value();
-	}
-
-	return {
-		{ "mode", "standard" },
-		{ "fog", false },
-		{ "weather", "clear" },
-		{ "coPowers", true },
-		{ "tags", false },
-		{ "startingFunds", 0 },
-		{ "incomePerProperty", 1000 },
-		{ "unitCap", unitCap },
-		{ "captureLimit", captureLimit },
-		{ "dayLimit", dayLimitJson },
-		{ "bannedUnits", json::array({ "blackbomb" }) },
-		{ "heuristicAutoResign", heuristicAutoResign },
-	};
-}
-
-json SupportedMapIds() {
-	json supported = json::array();
-	for (const MapTemplate& mapTemplate : MapTemplates) {
-		supported.push_back(mapTemplate.id);
-	}
-	return supported;
-}
-
-const MapTemplate* FindMapTemplate(const std::string& mapId) {
-	for (const MapTemplate& mapTemplate : MapTemplates) {
-		if (mapId == mapTemplate.id) {
-			return &mapTemplate;
-		}
-	}
-	return nullptr;
-}
 
 ApiResponse JsonResponse(int status, json body) {
 	ApiResponse response;
@@ -119,147 +65,6 @@ bool ContainsOnlyFields(const json& object, const std::vector<std::string>& allo
 	return true;
 }
 
-std::string ToPascalNoHyphen(std::string value) {
-	std::string converted;
-	bool capitalizeNext = true;
-	for (char ch : value) {
-		if (ch == '-') {
-			capitalizeNext = true;
-			continue;
-		}
-
-		if (capitalizeNext) {
-			converted.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
-			capitalizeNext = false;
-		}
-		else {
-			converted.push_back(ch);
-		}
-	}
-	return converted;
-}
-
-bool TryParseCoId(const std::string& coId, CommandingOfficier& co, std::string& coJsonName) {
-	coJsonName = ToPascalNoHyphen(coId);
-	json coJson = coJsonName;
-	try {
-		from_json(coJson, co);
-		return co.m_type != CommandingOfficier::Type::Invalid;
-	}
-	catch (const std::exception&) {
-		return false;
-	}
-}
-
-bool IsStandardBannedUnits(const json& bannedUnits) {
-	return bannedUnits.is_array() &&
-		bannedUnits.size() == 1 &&
-		bannedUnits.at(0).is_string() &&
-		bannedUnits.at(0).get<std::string>() == "blackbomb";
-}
-
-ApiResponse ValidateSettings(const json& request) {
-	if (!request.contains("settings")) {
-		return JsonResponse(HttpOk, StandardSettingsJson());
-	}
-
-	const json& settings = request.at("settings");
-	if (!settings.is_object()) {
-		return ErrorResponse(HttpBadRequest, "invalid-field", "settings must be an object.", { { "field", "settings" } });
-	}
-
-	std::string invalidField;
-	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "dayLimit", "bannedUnits", "heuristicAutoResign" }, invalidField)) {
-		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown settings field.", { { "field", "settings." + invalidField } });
-	}
-
-	int unitCap = 50;
-	int captureLimit = 21;
-	std::optional<int> dayLimit;
-	try {
-		if (settings.contains("mode") && (!settings.at("mode").is_string() || settings.at("mode").get<std::string>() != "standard")) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only standard mode is supported.", { { "field", "settings.mode" }, { "value", settings.at("mode") } });
-		}
-		if (settings.contains("fog") && (!settings.at("fog").is_boolean() || settings.at("fog").get<bool>() != false)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Fog of War is not supported for standard games yet.", { { "field", "settings.fog" }, { "value", settings.at("fog") } });
-		}
-		if (settings.contains("weather") && (!settings.at("weather").is_string() || settings.at("weather").get<std::string>() != "clear")) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only clear weather is supported for standard games.", { { "field", "settings.weather" }, { "value", settings.at("weather") } });
-		}
-		if (settings.contains("coPowers") && (!settings.at("coPowers").is_boolean() || settings.at("coPowers").get<bool>() != true)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "CO powers must remain enabled for standard games.", { { "field", "settings.coPowers" }, { "value", settings.at("coPowers") } });
-		}
-		if (settings.contains("tags") && (!settings.at("tags").is_boolean() || settings.at("tags").get<bool>() != false)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Tag powers are not supported for standard games yet.", { { "field", "settings.tags" }, { "value", settings.at("tags") } });
-		}
-		if (settings.contains("startingFunds") && (!settings.at("startingFunds").is_number_integer() || settings.at("startingFunds").get<int>() != 0)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only 0 starting funds are supported for standard games.", { { "field", "settings.startingFunds" }, { "value", settings.at("startingFunds") } });
-		}
-		if (settings.contains("incomePerProperty") && (!settings.at("incomePerProperty").is_number_integer() || settings.at("incomePerProperty").get<int>() != 1000)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only 1000 income per property is supported for standard games.", { { "field", "settings.incomePerProperty" }, { "value", settings.at("incomePerProperty") } });
-		}
-		if (settings.contains("unitCap")) {
-			if (!settings.at("unitCap").is_number_integer()) {
-				return ErrorResponse(HttpBadRequest, "invalid-field", "unitCap must be an integer.", { { "field", "settings.unitCap" } });
-			}
-			unitCap = settings.at("unitCap").get<int>();
-			if (unitCap <= 0) {
-				return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "unitCap must be positive for standard games.", { { "field", "settings.unitCap" }, { "value", settings.at("unitCap") } });
-			}
-		}
-		if (settings.contains("captureLimit")) {
-			if (!settings.at("captureLimit").is_number_integer()) {
-				return ErrorResponse(HttpBadRequest, "invalid-field", "captureLimit must be an integer.", { { "field", "settings.captureLimit" } });
-			}
-			captureLimit = settings.at("captureLimit").get<int>();
-			if (captureLimit <= 0) {
-				return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "captureLimit must be positive for standard games.", { { "field", "settings.captureLimit" }, { "value", settings.at("captureLimit") } });
-			}
-		}
-		if (settings.contains("dayLimit")) {
-			if (settings.at("dayLimit").is_null()) {
-				dayLimit.reset();
-			}
-			else if (!settings.at("dayLimit").is_number_integer()) {
-				return ErrorResponse(HttpBadRequest, "invalid-field", "dayLimit must be an integer or null.", { { "field", "settings.dayLimit" } });
-			}
-			else {
-				const int parsedDayLimit = settings.at("dayLimit").get<int>();
-				if (parsedDayLimit <= 0) {
-					return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "dayLimit must be positive for standard games.", { { "field", "settings.dayLimit" }, { "value", settings.at("dayLimit") } });
-				}
-				dayLimit = parsedDayLimit;
-			}
-		}
-		if (settings.contains("bannedUnits") && !IsStandardBannedUnits(settings.at("bannedUnits"))) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-setting", "Only the standard blackbomb ban is supported.", { { "field", "settings.bannedUnits" }, { "value", settings.at("bannedUnits") } });
-		}
-		if (settings.contains("heuristicAutoResign") && !settings.at("heuristicAutoResign").is_boolean()) {
-			return ErrorResponse(HttpBadRequest, "invalid-field", "heuristicAutoResign must be a boolean.", { { "field", "settings.heuristicAutoResign" } });
-		}
-	}
-	catch (const std::exception&) {
-		return ErrorResponse(HttpBadRequest, "invalid-field", "settings contains a value with the wrong type.", { { "field", "settings" } });
-	}
-
-	const bool heuristicAutoResign = settings.contains("heuristicAutoResign") && settings.at("heuristicAutoResign").get<bool>();
-	return JsonResponse(HttpOk, StandardSettingsJson(unitCap, captureLimit, dayLimit, heuristicAutoResign));
-}
-
-json SerializeGameForApi(const GameState& gameState) {
-	json game;
-	GameState::to_json(game, gameState);
-	game.erase("combat-rng-seed");
-	game.erase("heuristic-auto-resign");
-	if (gameState.GetTerminalReason().has_value()) {
-		game["terminalReason"] = gameState.GetTerminalReason().value();
-	}
-	else {
-		game["terminalReason"] = nullptr;
-	}
-	return game;
-}
-
 void RedactSonjaHiddenHp(json& unit, const std::string& sonjaArmyType) {
 	if (!unit.is_object()) {
 		return;
@@ -296,6 +101,18 @@ void RedactHiddenHpForPerspective(json& game, int playerIndex) {
 
 ApiResponse UnknownGameResponse() {
 	return ErrorResponse(HttpNotFound, "unknown-game-id", "Game id was not found.");
+}
+
+int HttpStatusFromSetupError(StandardGameSetupErrorType type) {
+	switch (type) {
+	case StandardGameSetupErrorType::BadRequest:
+		return HttpBadRequest;
+	case StandardGameSetupErrorType::UnprocessableEntity:
+		return HttpUnprocessableEntity;
+	case StandardGameSetupErrorType::Internal:
+	default:
+		return HttpInternalServerError;
+	}
 }
 
 bool TryGetInteger(const std::string& value, int& parsed) {
@@ -419,116 +236,16 @@ ApiResponse RestGameService::CreateGame(const std::string& requestBody) {
 		return ErrorResponse(HttpBadRequest, "malformed-json", "Request body is not valid JSON.");
 	}
 
-	if (!request.is_object()) {
-		return ErrorResponse(HttpBadRequest, "invalid-field", "Create game payload must be an object.");
+	StandardGameSetupResult setupResult;
+	StandardGameSetupError setupError;
+	if (CreateStandardGameFromRequest(request, setupResult, setupError) == Result::Failed) {
+		return ErrorResponse(HttpStatusFromSetupError(setupError.type), setupError.code, setupError.message, setupError.details);
 	}
 
-	std::string invalidField;
-	if (!ContainsOnlyFields(request, { "mapId", "players", "settings", "seed" }, invalidField)) {
-		return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown create-game field.", { { "field", invalidField } });
-	}
+	const std::string gameId = setupResult.gameState.GetId();
+	m_games.emplace(gameId, std::unique_ptr<GameState>(new GameState(setupResult.gameState)));
 
-	if (!request.contains("mapId") || !request.at("mapId").is_string()) {
-		return ErrorResponse(HttpBadRequest, "missing-required-field", "mapId is required.", { { "field", "mapId" } });
-	}
-
-	const std::string mapId = request.at("mapId").get<std::string>();
-	const MapTemplate* mapTemplate = FindMapTemplate(mapId);
-	if (mapTemplate == nullptr) {
-		return ErrorResponse(HttpUnprocessableEntity, "unknown-map-id", "Map id is not supported.", { { "field", "mapId" }, { "value", mapId }, { "supportedMapIds", SupportedMapIds() } });
-	}
-
-	if (!request.contains("players") || !request.at("players").is_array() || request.at("players").size() != 2) {
-		return ErrorResponse(HttpBadRequest, "missing-required-field", "players must contain exactly two players.", { { "field", "players" } });
-	}
-
-	ApiResponse settingsValidation = ValidateSettings(request);
-	if (settingsValidation.status != HttpOk) {
-		return settingsValidation;
-	}
-	const bool heuristicAutoResign = settingsValidation.body.at("heuristicAutoResign").get<bool>();
-
-	std::fstream filestream(mapTemplate->path, std::ios::in);
-	if (filestream.fail() || filestream.eof()) {
-		return ErrorResponse(HttpInternalServerError, "map-template-unavailable", "Map template could not be loaded.", { { "mapId", mapId } });
-	}
-
-	json templateJson;
-	filestream >> templateJson;
-	templateJson["gameId"] = Platform::createUuid();
-	templateJson["settings"] = settingsValidation.body;
-	templateJson["unit-cap"] = settingsValidation.body.at("unitCap").get<int>();
-	templateJson["cap-limit"] = settingsValidation.body.at("captureLimit").get<int>();
-	templateJson["activePlayer"] = 0;
-	templateJson["turn-count"] = 0;
-	templateJson.erase("combat-rng-seed");
-
-	for (int i = 0; i < 2; ++i) {
-		const json& requestedPlayer = request.at("players").at(i);
-		if (!requestedPlayer.is_object()) {
-			return ErrorResponse(HttpBadRequest, "invalid-field", "Player setup must be an object.", { { "field", "players[" + std::to_string(i) + "]" } });
-		}
-
-		if (!ContainsOnlyFields(requestedPlayer, { "co", "armyType" }, invalidField)) {
-			return ErrorResponse(HttpBadRequest, "invalid-field", "Unknown player field.", { { "field", "players[" + std::to_string(i) + "]." + invalidField } });
-		}
-
-		if (!requestedPlayer.contains("co") || !requestedPlayer.at("co").is_string()) {
-			return ErrorResponse(HttpBadRequest, "missing-required-field", "Player co is required.", { { "field", "players[" + std::to_string(i) + "].co" } });
-		}
-
-		if (!requestedPlayer.contains("armyType") || !requestedPlayer.at("armyType").is_string()) {
-			return ErrorResponse(HttpBadRequest, "missing-required-field", "Player armyType is required.", { { "field", "players[" + std::to_string(i) + "].armyType" } });
-		}
-
-		const std::string armyType = requestedPlayer.at("armyType").get<std::string>();
-		const std::string templateArmyType = templateJson.at("players").at(i).at("armyType").get<std::string>();
-		if (armyType != templateArmyType || Player::armyTypefromString(armyType) == Player::ArmyType::Invalid) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-army", "Requested armyType must match the map template player slot.", {
-				{ "field", "players[" + std::to_string(i) + "].armyType" },
-				{ "value", armyType },
-				{ "templateArmyType", templateArmyType },
-			});
-		}
-
-		CommandingOfficier co;
-		std::string coJsonName;
-		if (!TryParseCoId(requestedPlayer.at("co").get<std::string>(), co, coJsonName)) {
-			return ErrorResponse(HttpUnprocessableEntity, "unsupported-co", "Commanding officer is not supported.", { { "field", "players[" + std::to_string(i) + "].co" }, { "value", requestedPlayer.at("co") } });
-		}
-
-		Player player(co.m_type, Player::armyTypefromString(armyType));
-		player.m_funds = settingsValidation.body.at("startingFunds").get<int>();
-		json playerJson;
-		to_json(playerJson, player);
-		templateJson["players"][i] = std::move(playerJson);
-	}
-
-	GameState gameState;
-	try {
-		GameState::from_json(templateJson, gameState);
-	}
-	catch (const std::exception& err) {
-		return ErrorResponse(HttpInternalServerError, "map-template-invalid", err.what(), { { "mapId", mapId } });
-	}
-
-	if (request.contains("seed")) {
-		if (!request.at("seed").is_number_unsigned() &&
-			(!request.at("seed").is_number_integer() || request.at("seed").get<std::int64_t>() < 0)) {
-			return ErrorResponse(HttpBadRequest, "invalid-field", "seed must be an integer.", { { "field", "seed" } });
-		}
-		gameState.SetCombatRngSeed(request.at("seed").get<std::uint32_t>());
-	}
-	gameState.SetHeuristicAutoResign(heuristicAutoResign);
-
-	if (gameState.StartFirstTurn() == Result::Failed) {
-		return ErrorResponse(HttpInternalServerError, "game-initialization-failed", "Game could not run the opening turn start.", { { "mapId", mapId } });
-	}
-
-	const std::string gameId = gameState.GetId();
-	m_games.emplace(gameId, std::unique_ptr<GameState>(new GameState(gameState)));
-
-	ApiResponse response = JsonResponse(HttpCreated, SerializeGameForApi(*m_games.at(gameId)));
+	ApiResponse response = JsonResponse(HttpCreated, SerializeStandardGameForApi(*m_games.at(gameId)));
 	response.headers.emplace("Location", "/games/" + gameId);
 	return response;
 }
@@ -552,7 +269,7 @@ ApiResponse RestGameService::GetGame(const std::string& gameId, const std::strin
 		}
 	}
 
-	json response = SerializeGameForApi(*game->second);
+	json response = SerializeStandardGameForApi(*game->second);
 	if (playerIndex != -1) {
 		RedactHiddenHpForPerspective(response, playerIndex);
 	}
@@ -602,7 +319,7 @@ ApiResponse RestGameService::SubmitAction(const std::string& gameId, const std::
 		return UnknownGameResponse();
 	}
 
-	json currentGame = SerializeGameForApi(*game->second);
+	json currentGame = SerializeStandardGameForApi(*game->second);
 	if (game->second->FGameOver()) {
 		return ErrorResponseWithGame(HttpConflict, "terminal-state", "Cannot apply an action to a terminal game.", currentGame);
 	}
@@ -627,7 +344,7 @@ ApiResponse RestGameService::SubmitAction(const std::string& gameId, const std::
 		game->second->CheckPlayerResigns();
 	}
 
-	return JsonResponse(HttpOk, SerializeGameForApi(*game->second));
+	return JsonResponse(HttpOk, SerializeStandardGameForApi(*game->second));
 }
 
 void RestGameService::StoreGameForTesting(GameState gameState) {

--- a/AdvanceWarsServer/src/SelfPlayReplay.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplay.cpp
@@ -1,0 +1,570 @@
+#include "SelfPlayReplay.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <set>
+#include <sstream>
+#include <vector>
+
+#include "ActionSpace.h"
+#include "StandardGameSetup.h"
+#include "StateTensor.h"
+
+namespace {
+constexpr double kMetricTolerance = 0.001;
+
+void SetError(SelfPlayError& error, const std::string& code, const std::string& message, int line = 0, int gameIndex = -1, int ply = -1) {
+	error.code = code;
+	error.message = message;
+	error.line = line;
+	error.gameIndex = gameIndex;
+	error.ply = ply;
+}
+
+bool ContainsOnlyFields(const json& object, const std::vector<std::string>& allowedFields, std::string& invalidField) {
+	if (!object.is_object()) {
+		invalidField.clear();
+		return false;
+	}
+
+	for (auto it = object.begin(); it != object.end(); ++it) {
+		if (std::find(allowedFields.begin(), allowedFields.end(), it.key()) == allowedFields.end()) {
+			invalidField = it.key();
+			return false;
+		}
+	}
+
+	return true;
+}
+
+Result RequireObjectWithFields(const json& value, const std::vector<std::string>& allowedFields, const std::string& label, SelfPlayError& error, int line, int gameIndex = -1, int ply = -1) {
+	if (!value.is_object()) {
+		SetError(error, "schema-error", label + " must be an object", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	std::string invalidField;
+	if (!ContainsOnlyFields(value, allowedFields, invalidField)) {
+		SetError(error, "schema-error", label + " has unknown or invalid field: " + invalidField, line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	for (const std::string& requiredField : allowedFields) {
+		if (!value.contains(requiredField)) {
+			SetError(error, "schema-error", label + " is missing required field: " + requiredField, line, gameIndex, ply);
+			return Result::Failed;
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+std::string ChecksumToHex(std::uint64_t checksum) {
+	std::ostringstream stream;
+	stream << std::hex << std::setw(16) << std::setfill('0') << checksum;
+	return stream.str();
+}
+
+Result StateTensorChecksumHex(const GameState& gameState, std::string& checksum, SelfPlayError& error, int line, int gameIndex, int ply) {
+	std::vector<float> values;
+	if (StateTensor::Encode(gameState, values) == Result::Failed) {
+		SetError(error, "state-tensor-failed", "state tensor encoding failed", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	std::uint64_t rawChecksum = 0;
+	if (StateTensor::Checksum(values, rawChecksum) == Result::Failed) {
+		SetError(error, "state-tensor-checksum-failed", "state tensor checksum failed", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	checksum = ChecksumToHex(rawChecksum);
+	return Result::Succeeded;
+}
+
+Result EncodeLegalActionIndices(const GameState& gameState, std::vector<Action>& legalActions, std::vector<int>& legalActionIndices, SelfPlayError& error, int line, int gameIndex, int ply) {
+	legalActions.clear();
+	legalActionIndices.clear();
+	if (gameState.GetValidActions(legalActions) == Result::Failed) {
+		SetError(error, "legal-actions-failed", "legal action generation failed", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	legalActionIndices.reserve(legalActions.size());
+	for (const Action& action : legalActions) {
+		int encodedAction = -1;
+		if (ActionSpace::EncodeAction(action, encodedAction) == Result::Failed) {
+			SetError(error, "action-encoding-failed", "legal action failed to encode", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		legalActionIndices.push_back(encodedAction);
+	}
+
+	std::sort(legalActionIndices.begin(), legalActionIndices.end());
+	legalActionIndices.erase(std::unique(legalActionIndices.begin(), legalActionIndices.end()), legalActionIndices.end());
+	return Result::Succeeded;
+}
+
+bool JsonIntArrayEquals(const json& value, const std::vector<int>& expected) {
+	if (!value.is_array() || value.size() != expected.size()) {
+		return false;
+	}
+
+	for (std::size_t i = 0; i < expected.size(); ++i) {
+		if (!value.at(i).is_number_integer() || value.at(i).get<int>() != expected[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool IsSortedUniqueInts(const json& value) {
+	if (!value.is_array()) {
+		return false;
+	}
+
+	int previous = -1;
+	bool hasPrevious = false;
+	for (const json& item : value) {
+		if (!item.is_number_integer()) {
+			return false;
+		}
+
+		const int current = item.get<int>();
+		if (hasPrevious && current <= previous) {
+			return false;
+		}
+		previous = current;
+		hasPrevious = true;
+	}
+
+	return true;
+}
+
+Result ValidateHeader(const json& header, const json* expectedHeader, SelfPlayError& error, int line) {
+	IfFailedReturn(RequireObjectWithFields(header, { "recordType", "replayFormatVersion", "createdAt", "versions", "config" }, "header", error, line));
+	if (header.at("recordType") != "header") {
+		SetError(error, "schema-error", "first record must be a header", line);
+		return Result::Failed;
+	}
+	if (header.at("replayFormatVersion") != SelfPlayReplayFormatVersion()) {
+		SetError(error, "version-mismatch", "replay format version is not supported", line);
+		return Result::Failed;
+	}
+	if (header.at("versions") != SelfPlayVersionsJson()) {
+		SetError(error, "version-mismatch", "state/action encoding versions do not match this binary", line);
+		return Result::Failed;
+	}
+	if (!header.at("createdAt").is_string()) {
+		SetError(error, "schema-error", "header createdAt must be a string", line);
+		return Result::Failed;
+	}
+	if (!header.at("config").is_object()) {
+		SetError(error, "schema-error", "header config must be an object", line);
+		return Result::Failed;
+	}
+
+	if (expectedHeader != nullptr) {
+		json actualComparable = header;
+		json expectedComparable = *expectedHeader;
+		actualComparable.erase("createdAt");
+		expectedComparable.erase("createdAt");
+		if (actualComparable != expectedComparable) {
+			SetError(error, "append-header-mismatch", "existing replay header is not compatible with requested append", line);
+			return Result::Failed;
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+bool IsNonnegativeNumber(const json& value) {
+	return (value.is_number_integer() && value.get<double>() >= 0.0) ||
+		(value.is_number_float() && value.get<double>() >= 0.0);
+}
+
+Result ValidateMctsBlock(const json& mcts, int& simulationsRun, int& nodesCreated, double& searchTimeMs, SelfPlayError& error, int line, int gameIndex, int ply) {
+	IfFailedReturn(RequireObjectWithFields(mcts, { "mctsSeed", "simulationsRun", "nodesCreated", "searchTimeMs" }, "sample.mcts", error, line, gameIndex, ply));
+	if (!mcts.at("mctsSeed").is_number_unsigned() && !mcts.at("mctsSeed").is_number_integer()) {
+		SetError(error, "schema-error", "mctsSeed must be an integer", line, gameIndex, ply);
+		return Result::Failed;
+	}
+	if (!mcts.at("simulationsRun").is_number_integer() || mcts.at("simulationsRun").get<int>() < 1) {
+		SetError(error, "schema-error", "simulationsRun must be at least 1", line, gameIndex, ply);
+		return Result::Failed;
+	}
+	if (!mcts.at("nodesCreated").is_number_integer() || mcts.at("nodesCreated").get<int>() < 1) {
+		SetError(error, "schema-error", "nodesCreated must be at least 1", line, gameIndex, ply);
+		return Result::Failed;
+	}
+	if (!IsNonnegativeNumber(mcts.at("searchTimeMs"))) {
+		SetError(error, "schema-error", "searchTimeMs must be nonnegative", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	simulationsRun = mcts.at("simulationsRun").get<int>();
+	nodesCreated = mcts.at("nodesCreated").get<int>();
+	searchTimeMs = mcts.at("searchTimeMs").get<double>();
+	return Result::Succeeded;
+}
+
+Result ValidateVisitCounts(const json& visitCounts, const std::vector<int>& legalActionIndices, int selectedActionIndex, int simulationsRun, SelfPlayError& error, int line, int gameIndex, int ply) {
+	if (!visitCounts.is_array()) {
+		SetError(error, "schema-error", "visitCounts must be an array", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	int previousActionIndex = -1;
+	int visitSum = 0;
+	bool selectedVisited = false;
+	for (const json& visit : visitCounts) {
+		IfFailedReturn(RequireObjectWithFields(visit, { "actionIndex", "visits" }, "visitCounts[]", error, line, gameIndex, ply));
+		if (!visit.at("actionIndex").is_number_integer() || !visit.at("visits").is_number_integer()) {
+			SetError(error, "schema-error", "visit count fields must be integers", line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		const int actionIndex = visit.at("actionIndex").get<int>();
+		const int visits = visit.at("visits").get<int>();
+		if (actionIndex <= previousActionIndex) {
+			SetError(error, "schema-error", "visitCounts must be sorted by actionIndex", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (visits <= 0) {
+			SetError(error, "schema-error", "visitCounts stores positive visits only", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (!std::binary_search(legalActionIndices.begin(), legalActionIndices.end(), actionIndex)) {
+			SetError(error, "visit-not-legal", "visited action is not legal", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (actionIndex == selectedActionIndex) {
+			selectedVisited = true;
+		}
+
+		previousActionIndex = actionIndex;
+		visitSum += visits;
+	}
+
+	if (!selectedVisited) {
+		SetError(error, "selected-action-unvisited", "selected action must have positive visits", line, gameIndex, ply);
+		return Result::Failed;
+	}
+	if (visitSum != simulationsRun) {
+		SetError(error, "visit-sum-mismatch", "sum of visit counts must equal simulationsRun", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	return Result::Succeeded;
+}
+
+int ExpectedOutcome(const json& winner, int currentPlayer) {
+	if (winner.is_null()) {
+		return 0;
+	}
+
+	const int winningPlayer = winner.get<int>();
+	if (winningPlayer < 0 || winningPlayer == 2) {
+		return 0;
+	}
+
+	return winningPlayer == currentPlayer ? 1 : -1;
+}
+
+Result ValidateMetrics(const json& game, int actionCount, int sampleCount, int turnCount, double totalSearchTimeMs, double averageBranchingFactor, SelfPlayReplayValidationSummary& summary, SelfPlayError& error, int line, int gameIndex) {
+	const json& metrics = game.at("metrics");
+	IfFailedReturn(RequireObjectWithFields(metrics, { "actionCount", "sampleCount", "turnCount", "resignations", "invalidActionCount", "averageBranchingFactor", "totalSearchTimeMs", "averageSearchTimeMs", "totalElapsedMs" }, "metrics", error, line, gameIndex));
+
+	if (!metrics.at("actionCount").is_number_integer() || metrics.at("actionCount").get<int>() != actionCount ||
+		!metrics.at("sampleCount").is_number_integer() || metrics.at("sampleCount").get<int>() != sampleCount ||
+		!metrics.at("turnCount").is_number_integer() || metrics.at("turnCount").get<int>() != turnCount) {
+		SetError(error, "metrics-mismatch", "action/sample/turn metrics do not match replay", line, gameIndex);
+		return Result::Failed;
+	}
+	if (!metrics.at("invalidActionCount").is_number_integer() || metrics.at("invalidActionCount").get<int>() != 0) {
+		SetError(error, "metrics-mismatch", "invalidActionCount must be 0", line, gameIndex);
+		return Result::Failed;
+	}
+	if (!metrics.at("resignations").is_number_integer() || metrics.at("resignations").get<int>() < 0) {
+		SetError(error, "schema-error", "resignations must be nonnegative", line, gameIndex);
+		return Result::Failed;
+	}
+	if (!IsNonnegativeNumber(metrics.at("averageBranchingFactor")) ||
+		!IsNonnegativeNumber(metrics.at("totalSearchTimeMs")) ||
+		!IsNonnegativeNumber(metrics.at("averageSearchTimeMs")) ||
+		!IsNonnegativeNumber(metrics.at("totalElapsedMs"))) {
+		SetError(error, "schema-error", "timing and average metrics must be nonnegative", line, gameIndex);
+		return Result::Failed;
+	}
+	if (std::fabs(metrics.at("averageBranchingFactor").get<double>() - averageBranchingFactor) > kMetricTolerance) {
+		SetError(error, "metrics-mismatch", "averageBranchingFactor does not match samples", line, gameIndex);
+		return Result::Failed;
+	}
+	if (std::fabs(metrics.at("totalSearchTimeMs").get<double>() - totalSearchTimeMs) > kMetricTolerance) {
+		SetError(error, "metrics-mismatch", "totalSearchTimeMs does not match samples", line, gameIndex);
+		return Result::Failed;
+	}
+
+	summary.invalidActions += metrics.at("invalidActionCount").get<int>();
+	return Result::Succeeded;
+}
+
+Result ValidateGameRecord(const json& game, SelfPlayReplayValidationSummary& summary, SelfPlayError& error, int line) {
+	IfFailedReturn(RequireObjectWithFields(game, { "recordType", "replayFormatVersion", "versions", "gameIndex", "config", "players", "settings", "initialState", "actions", "samples", "finalState", "terminalReason", "winner", "metrics" }, "game", error, line));
+	if (game.at("recordType") != "game") {
+		SetError(error, "schema-error", "non-header records must be game records", line);
+		return Result::Failed;
+	}
+	if (game.at("replayFormatVersion") != SelfPlayReplayFormatVersion() || game.at("versions") != SelfPlayVersionsJson()) {
+		SetError(error, "version-mismatch", "game record versions do not match this binary", line);
+		return Result::Failed;
+	}
+	if (!game.at("gameIndex").is_number_integer()) {
+		SetError(error, "schema-error", "gameIndex must be an integer", line);
+		return Result::Failed;
+	}
+
+	const int gameIndex = game.at("gameIndex").get<int>();
+	IfFailedReturn(RequireObjectWithFields(game.at("config"), { "mapId", "baseSeed", "combatSeed", "mctsSeed", "maxActions", "mctsOptions" }, "game.config", error, line, gameIndex));
+	IfFailedReturn(RequireObjectWithFields(game.at("config").at("mctsOptions"), { "maxSimulations", "maxNodes", "maxRolloutActions", "explorationConstant", "temperature" }, "game.config.mctsOptions", error, line, gameIndex));
+	if (!game.at("players").is_array() || game.at("players").size() != 2) {
+		SetError(error, "schema-error", "players must contain two entries", line, gameIndex);
+		return Result::Failed;
+	}
+	for (const json& player : game.at("players")) {
+		IfFailedReturn(RequireObjectWithFields(player, { "slot", "co", "armyType" }, "players[]", error, line, gameIndex));
+	}
+
+	if (!game.at("actions").is_array() || !game.at("samples").is_array()) {
+		SetError(error, "schema-error", "actions and samples must be arrays", line, gameIndex);
+		return Result::Failed;
+	}
+	if (!game.at("terminalReason").is_null() && !game.at("terminalReason").is_string()) {
+		SetError(error, "schema-error", "terminalReason must be a string or null", line, gameIndex);
+		return Result::Failed;
+	}
+	if (!game.at("winner").is_null() && !game.at("winner").is_number_integer()) {
+		SetError(error, "schema-error", "winner must be an integer or null", line, gameIndex);
+		return Result::Failed;
+	}
+	if (game.at("actions").size() != game.at("samples").size()) {
+		SetError(error, "schema-error", "actions and samples must have the same length", line, gameIndex);
+		return Result::Failed;
+	}
+
+	GameState replayState;
+	json initialState = game.at("initialState");
+	try {
+		GameState::from_json(initialState, replayState);
+	}
+	catch (const std::exception& err) {
+		SetError(error, "initial-state-invalid", err.what(), line, gameIndex);
+		return Result::Failed;
+	}
+
+	int legalActionTotal = 0;
+	double totalSearchTimeMs = 0.0;
+	for (std::size_t i = 0; i < game.at("samples").size(); ++i) {
+		const int ply = static_cast<int>(i);
+		const json& actionEntry = game.at("actions").at(i);
+		const json& sample = game.at("samples").at(i);
+
+		IfFailedReturn(RequireObjectWithFields(actionEntry, { "ply", "player", "actionIndex", "action" }, "actions[]", error, line, gameIndex, ply));
+		IfFailedReturn(RequireObjectWithFields(sample, { "ply", "currentPlayer", "stateTensorChecksum", "legalActionCount", "legalActionIndices", "visitCounts", "selectedActionIndex", "outcome", "mcts" }, "samples[]", error, line, gameIndex, ply));
+
+		if (actionEntry.at("ply") != ply || sample.at("ply") != ply) {
+			SetError(error, "ply-mismatch", "ply must match action/sample index", line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		const int currentPlayer = replayState.getCurrentPlayer();
+		if (actionEntry.at("player") != currentPlayer || sample.at("currentPlayer") != currentPlayer) {
+			SetError(error, "player-mismatch", "recorded player does not match replayed state", line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		std::string actualChecksum;
+		IfFailedReturn(StateTensorChecksumHex(replayState, actualChecksum, error, line, gameIndex, ply));
+		if (!sample.at("stateTensorChecksum").is_string() || sample.at("stateTensorChecksum").get<std::string>() != actualChecksum) {
+			SetError(error, "state-checksum-mismatch", "state tensor checksum does not match replayed state", line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		std::vector<Action> legalActions;
+		std::vector<int> legalActionIndices;
+		IfFailedReturn(EncodeLegalActionIndices(replayState, legalActions, legalActionIndices, error, line, gameIndex, ply));
+		if (!sample.at("legalActionCount").is_number_integer() || sample.at("legalActionCount").get<int>() != static_cast<int>(legalActionIndices.size())) {
+			SetError(error, "legal-action-count-mismatch", "legalActionCount does not match legalActionIndices", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (!IsSortedUniqueInts(sample.at("legalActionIndices")) || !JsonIntArrayEquals(sample.at("legalActionIndices"), legalActionIndices)) {
+			SetError(error, "legal-actions-mismatch", "legalActionIndices do not match engine legal actions", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		legalActionTotal += static_cast<int>(legalActionIndices.size());
+
+		Action action;
+		json actionJson = actionEntry.at("action");
+		try {
+			from_json(actionJson, action);
+		}
+		catch (const std::exception& err) {
+			SetError(error, "action-invalid", err.what(), line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		int actionIndex = -1;
+		if (ActionSpace::EncodeAction(action, actionIndex) == Result::Failed) {
+			SetError(error, "action-encoding-failed", "recorded action failed to encode", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (actionEntry.at("actionIndex") != actionIndex || sample.at("selectedActionIndex") != actionIndex) {
+			SetError(error, "selected-action-index-mismatch", "selected action index does not match action history", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (std::find(legalActions.begin(), legalActions.end(), action) == legalActions.end()) {
+			SetError(error, "selected-action-illegal", "selected action is not legal in replayed state", line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		int simulationsRun = 0;
+		int nodesCreated = 0;
+		double searchTimeMs = 0.0;
+		IfFailedReturn(ValidateMctsBlock(sample.at("mcts"), simulationsRun, nodesCreated, searchTimeMs, error, line, gameIndex, ply));
+		IfFailedReturn(ValidateVisitCounts(sample.at("visitCounts"), legalActionIndices, actionIndex, simulationsRun, error, line, gameIndex, ply));
+		totalSearchTimeMs += searchTimeMs;
+
+		if (!sample.at("outcome").is_number_integer() || sample.at("outcome").get<int>() != ExpectedOutcome(game.at("winner"), currentPlayer)) {
+			SetError(error, "outcome-mismatch", "sample outcome does not match winner/currentPlayer", line, gameIndex, ply);
+			return Result::Failed;
+		}
+
+		if (replayState.DoAction(action) == Result::Failed) {
+			SetError(error, "action-apply-failed", "recorded action failed during replay", line, gameIndex, ply);
+			return Result::Failed;
+		}
+		if (replayState.FHeuristicAutoResign()) {
+			replayState.CheckPlayerResigns();
+		}
+	}
+
+	json replayedFinalState = SerializeGameStateForReplay(replayState);
+	if (replayedFinalState != game.at("finalState")) {
+		SetError(error, "final-state-mismatch", "replayed final state does not match finalState", line, gameIndex);
+		return Result::Failed;
+	}
+
+	const std::string terminalReason = game.at("terminalReason").is_null() ? "" : game.at("terminalReason").get<std::string>();
+	if (terminalReason == "action-limit") {
+		if (!game.at("winner").is_null()) {
+			SetError(error, "winner-mismatch", "action-limit games must have null winner", line, gameIndex);
+			return Result::Failed;
+		}
+	}
+	else {
+		if (!replayState.FGameOver()) {
+			SetError(error, "terminal-mismatch", "non action-limit game must end in an engine terminal state", line, gameIndex);
+			return Result::Failed;
+		}
+		if (!game.at("winner").is_number_integer() || game.at("winner").get<int>() != replayState.getWinningPlayer()) {
+			SetError(error, "winner-mismatch", "winner does not match replayed final state", line, gameIndex);
+			return Result::Failed;
+		}
+		if (replayState.GetTerminalReason().has_value() && game.at("terminalReason") != replayState.GetTerminalReason().value()) {
+			SetError(error, "terminal-mismatch", "terminal reason does not match replayed final state", line, gameIndex);
+			return Result::Failed;
+		}
+	}
+
+	const int sampleCount = static_cast<int>(game.at("samples").size());
+	const double averageBranchingFactor = sampleCount == 0 ? 0.0 : static_cast<double>(legalActionTotal) / sampleCount;
+	IfFailedReturn(ValidateMetrics(game, static_cast<int>(game.at("actions").size()), sampleCount, replayState.GetTurnCount(), totalSearchTimeMs, averageBranchingFactor, summary, error, line, gameIndex));
+
+	++summary.games;
+	summary.samples += sampleCount;
+	summary.actions += static_cast<int>(game.at("actions").size());
+	return Result::Succeeded;
+}
+
+Result ValidateReplayStream(std::istream& input, const json* expectedHeader, SelfPlayReplayValidationSummary& summary, SelfPlayError& error) {
+	summary = SelfPlayReplayValidationSummary{};
+	std::string line;
+	int lineNumber = 0;
+	bool sawHeader = false;
+	while (std::getline(input, line)) {
+		++lineNumber;
+		if (line.empty()) {
+			SetError(error, "schema-error", "JSONL records must not be blank", lineNumber);
+			return Result::Failed;
+		}
+
+		json record;
+		try {
+			record = json::parse(line);
+		}
+		catch (const std::exception& err) {
+			SetError(error, "malformed-json", err.what(), lineNumber);
+			return Result::Failed;
+		}
+
+		if (!sawHeader) {
+			IfFailedReturn(ValidateHeader(record, expectedHeader, error, lineNumber));
+			sawHeader = true;
+			continue;
+		}
+
+		IfFailedReturn(ValidateGameRecord(record, summary, error, lineNumber));
+	}
+
+	if (!sawHeader) {
+		SetError(error, "empty-replay", "replay file does not contain a header");
+		return Result::Failed;
+	}
+
+	if (summary.games == 0) {
+		SetError(error, "empty-replay", "replay file does not contain any games");
+		return Result::Failed;
+	}
+
+	return Result::Succeeded;
+}
+}
+
+const char* SelfPlayReplayFormatVersion() noexcept {
+	return "standard-gl-self-play-replay-v1";
+}
+
+json SelfPlayVersionsJson() {
+	return {
+		{ "stateTensor", StateTensor::Version() },
+		{ "actionSpace", ActionSpace::Version() },
+	};
+}
+
+Result ValidateSelfPlayReplay(const std::filesystem::path& path, SelfPlayReplayValidationSummary& summary, SelfPlayError& error) {
+	std::ifstream input(path);
+	if (!input.is_open()) {
+		SetError(error, "open-failed", "could not open replay file: " + path.string());
+		return Result::Failed;
+	}
+
+	return ValidateReplayStream(input, nullptr, summary, error);
+}
+
+Result ValidateSelfPlayReplayForAppend(const std::filesystem::path& path, const json& expectedHeader, SelfPlayReplayValidationSummary& summary, SelfPlayError& error) {
+	std::ifstream input(path);
+	if (!input.is_open()) {
+		SetError(error, "open-failed", "could not open replay file for append validation: " + path.string());
+		return Result::Failed;
+	}
+
+	if (input.peek() == std::ifstream::traits_type::eof()) {
+		summary = SelfPlayReplayValidationSummary{};
+		return Result::Succeeded;
+	}
+
+	return ValidateReplayStream(input, &expectedHeader, summary, error);
+}

--- a/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
@@ -1,0 +1,282 @@
+#include "SelfPlayReplayTest.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "SelfPlayReplay.h"
+#include "SelfPlayRunner.h"
+
+namespace {
+bool Expect(bool condition, const std::string& message) {
+	if (!condition) {
+		std::cerr << "Self-play replay test failed: " << message << std::endl;
+		return false;
+	}
+
+	return true;
+}
+
+std::filesystem::path MakeTempReplayPath(const std::string& name) {
+	return std::filesystem::temp_directory_path() / ("advance-wars-" + name + ".jsonl");
+}
+
+json ReadJsonLine(const std::filesystem::path& path, int lineNumber) {
+	std::ifstream input(path);
+	std::string line;
+	for (int i = 1; i <= lineNumber && std::getline(input, line); ++i) {
+		if (i == lineNumber) {
+			return json::parse(line);
+		}
+	}
+
+	return json();
+}
+
+bool WriteCorruptedReplay(const std::filesystem::path& source, const std::filesystem::path& target) {
+	std::ifstream input(source);
+	std::ofstream output(target, std::ios::trunc);
+	if (!input.is_open() || !output.is_open()) {
+		return false;
+	}
+
+	std::string line;
+	int lineNumber = 0;
+	while (std::getline(input, line)) {
+		++lineNumber;
+		if (lineNumber == 2) {
+			json game = json::parse(line);
+			game["samples"][0]["selectedActionIndex"] = -1;
+			output << game.dump() << "\n";
+		}
+		else {
+			output << line << "\n";
+		}
+	}
+
+	return true;
+}
+
+bool WriteReplayMissingSampleField(const std::filesystem::path& source, const std::filesystem::path& target) {
+	std::ifstream input(source);
+	std::ofstream output(target, std::ios::trunc);
+	if (!input.is_open() || !output.is_open()) {
+		return false;
+	}
+
+	std::string line;
+	int lineNumber = 0;
+	while (std::getline(input, line)) {
+		++lineNumber;
+		if (lineNumber == 2) {
+			json game = json::parse(line);
+			game["samples"][0].erase("selectedActionIndex");
+			output << game.dump() << "\n";
+		}
+		else {
+			output << line << "\n";
+		}
+	}
+
+	return true;
+}
+
+bool GeneratedReplayValidatesAndUsesSparseSamples() {
+	const std::filesystem::path replayPath = MakeTempReplayPath("self-play-replay-test");
+	std::filesystem::remove(replayPath);
+
+	SelfPlayRunnerOptions options;
+	options.outputPath = replayPath;
+	options.mapId = "mcts";
+	options.player0CoId = "andy";
+	options.player1CoId = "adder";
+	options.games = 1;
+	options.maxActions = 2;
+	options.baseSeed = 17;
+	options.mctsOptions.maxSimulations = 1;
+	options.mctsOptions.maxNodes = 16;
+	options.mctsOptions.maxRolloutActions = 4;
+	options.mctsOptions.temperature = 0.0;
+	options.quiet = true;
+
+	SelfPlayRunSummary runSummary;
+	SelfPlayError error;
+	if (!Expect(RunSelfPlay(options, runSummary, error) == Result::Succeeded, "self-play run should write and validate a replay: " + error.message)) {
+		return false;
+	}
+
+	if (!Expect(std::filesystem::exists(replayPath), "replay file should exist after generation")) {
+		return false;
+	}
+
+	SelfPlayReplayValidationSummary validationSummary;
+	if (!Expect(ValidateSelfPlayReplay(replayPath, validationSummary, error) == Result::Succeeded, "written replay should validate: " + error.message)) {
+		return false;
+	}
+
+	if (!Expect(runSummary.gamesWritten == 1, "run should write one game")) {
+		return false;
+	}
+	if (!Expect(validationSummary.games == 1, "validator should read one game")) {
+		return false;
+	}
+	if (!Expect(validationSummary.samples == 2, "action-limit smoke run should contain two samples")) {
+		return false;
+	}
+
+	const json header = ReadJsonLine(replayPath, 1);
+	if (!Expect(header.at("recordType") == "header", "first JSONL line should be a header record")) {
+		return false;
+	}
+	if (!Expect(header.at("replayFormatVersion") == SelfPlayReplayFormatVersion(), "header should record replay format version")) {
+		return false;
+	}
+
+	const json game = ReadJsonLine(replayPath, 2);
+	if (!Expect(game.at("recordType") == "game", "second JSONL line should be a game record")) {
+		return false;
+	}
+	if (!Expect(game.at("terminalReason") == "action-limit", "short smoke run should stop by action limit")) {
+		return false;
+	}
+	if (!Expect(game.at("winner").is_null(), "action-limit game should not invent a winner")) {
+		return false;
+	}
+	if (!Expect(game.at("actions").size() == game.at("samples").size(), "actions and samples should stay one-to-one")) {
+		return false;
+	}
+	if (!Expect(game.at("samples")[0].contains("legalActionIndices"), "sample should contain sparse legal action indices")) {
+		return false;
+	}
+	if (!Expect(!game.at("samples")[0].contains("legalActionMask"), "sample should not store a dense legal action mask")) {
+		return false;
+	}
+
+	std::filesystem::remove(replayPath);
+	return true;
+}
+
+bool CorruptedReplayIsRejected() {
+	const std::filesystem::path replayPath = MakeTempReplayPath("self-play-replay-corrupt-source");
+	const std::filesystem::path corruptPath = MakeTempReplayPath("self-play-replay-corrupt");
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove(corruptPath);
+
+	SelfPlayRunnerOptions options;
+	options.outputPath = replayPath;
+	options.mapId = "mcts";
+	options.player0CoId = "andy";
+	options.player1CoId = "adder";
+	options.games = 1;
+	options.maxActions = 1;
+	options.baseSeed = 23;
+	options.mctsOptions.maxSimulations = 1;
+	options.mctsOptions.maxNodes = 16;
+	options.mctsOptions.maxRolloutActions = 4;
+	options.mctsOptions.temperature = 0.0;
+	options.quiet = true;
+
+	SelfPlayRunSummary runSummary;
+	SelfPlayError error;
+	if (!Expect(RunSelfPlay(options, runSummary, error) == Result::Succeeded, "self-play run should create corrupt-source replay: " + error.message)) {
+		return false;
+	}
+	if (!Expect(WriteCorruptedReplay(replayPath, corruptPath), "test should write a corrupted replay")) {
+		return false;
+	}
+
+	SelfPlayReplayValidationSummary validationSummary;
+	const Result result = ValidateSelfPlayReplay(corruptPath, validationSummary, error);
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove(corruptPath);
+
+	return Expect(result == Result::Failed, "validator should reject selected action index corruption");
+}
+
+bool MissingRequiredReplayFieldIsRejected() {
+	const std::filesystem::path replayPath = MakeTempReplayPath("self-play-replay-missing-source");
+	const std::filesystem::path corruptPath = MakeTempReplayPath("self-play-replay-missing-field");
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove(corruptPath);
+
+	SelfPlayRunnerOptions options;
+	options.outputPath = replayPath;
+	options.mapId = "mcts";
+	options.player0CoId = "andy";
+	options.player1CoId = "adder";
+	options.games = 1;
+	options.maxActions = 1;
+	options.baseSeed = 29;
+	options.mctsOptions.maxSimulations = 1;
+	options.mctsOptions.maxNodes = 16;
+	options.mctsOptions.maxRolloutActions = 4;
+	options.mctsOptions.temperature = 0.0;
+	options.quiet = true;
+
+	SelfPlayRunSummary runSummary;
+	SelfPlayError error;
+	if (!Expect(RunSelfPlay(options, runSummary, error) == Result::Succeeded, "self-play run should create missing-field source replay: " + error.message)) {
+		return false;
+	}
+	if (!Expect(WriteReplayMissingSampleField(replayPath, corruptPath), "test should write a replay missing a required sample field")) {
+		return false;
+	}
+
+	SelfPlayReplayValidationSummary validationSummary;
+	const Result result = ValidateSelfPlayReplay(corruptPath, validationSummary, error);
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove(corruptPath);
+
+	if (!Expect(result == Result::Failed, "validator should reject missing required replay fields")) {
+		return false;
+	}
+	return Expect(error.code == "schema-error", "missing field rejection should report a schema error");
+}
+
+bool InvalidSelfPlaySetupReportsError() {
+	SelfPlayRunnerOptions options;
+	options.outputPath = MakeTempReplayPath("self-play-invalid-setup");
+	options.mapId = "not-a-map";
+	options.player0CoId = "andy";
+	options.player1CoId = "adder";
+	options.games = 1;
+	options.maxActions = 1;
+	options.mctsOptions.maxSimulations = 1;
+	options.mctsOptions.maxNodes = 16;
+	options.mctsOptions.maxRolloutActions = 4;
+	options.quiet = true;
+	std::filesystem::remove(options.outputPath);
+
+	SelfPlayRunSummary runSummary;
+	SelfPlayError error;
+	const Result result = RunSelfPlay(options, runSummary, error);
+	std::filesystem::remove(options.outputPath);
+
+	if (!Expect(result == Result::Failed, "invalid self-play setup should fail")) {
+		return false;
+	}
+	return Expect(error.code == "unknown-map-id", "invalid setup should surface the setup error code");
+}
+}
+
+int RunSelfPlayReplayTests() {
+	if (!GeneratedReplayValidatesAndUsesSparseSamples()) {
+		return 1;
+	}
+
+	if (!CorruptedReplayIsRejected()) {
+		return 1;
+	}
+
+	if (!MissingRequiredReplayFieldIsRejected()) {
+		return 1;
+	}
+
+	if (!InvalidSelfPlaySetupReportsError()) {
+		return 1;
+	}
+
+	std::cout << "Self-play replay tests passed" << std::endl;
+	return 0;
+}

--- a/AdvanceWarsServer/src/SelfPlayRunner.cpp
+++ b/AdvanceWarsServer/src/SelfPlayRunner.cpp
@@ -1,0 +1,637 @@
+#include "SelfPlayRunner.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "ActionSpace.h"
+#include "StandardGameSetup.h"
+#include "StateTensor.h"
+
+namespace {
+void SetError(SelfPlayError& error, const std::string& code, const std::string& message, int gameIndex = -1, int ply = -1) {
+	error.code = code;
+	error.message = message;
+	error.gameIndex = gameIndex;
+	error.ply = ply;
+}
+
+std::string ChecksumToHex(std::uint64_t checksum) {
+	std::ostringstream stream;
+	stream << std::hex << std::setw(16) << std::setfill('0') << checksum;
+	return stream.str();
+}
+
+std::string CreatedAtUtc() {
+	const std::time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	std::tm utc{};
+	gmtime_s(&utc, &now);
+	std::ostringstream stream;
+	stream << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+	return stream.str();
+}
+
+std::uint32_t AddSeed(std::uint32_t seed, std::uint32_t delta) {
+	return static_cast<std::uint32_t>(seed + delta);
+}
+
+std::uint32_t DeriveActionSeed(std::uint32_t gameMctsSeed, int ply) {
+	std::uint32_t value = gameMctsSeed ^ (0x9e3779b9u + static_cast<std::uint32_t>(ply) * 0x85ebca6bu);
+	value ^= value >> 16;
+	value *= 0x7feb352du;
+	value ^= value >> 15;
+	value *= 0x846ca68bu;
+	value ^= value >> 16;
+	return value;
+}
+
+json MctsOptionsJson(const MCTSOptions& options) {
+	return {
+		{ "maxSimulations", options.maxSimulations },
+		{ "maxNodes", options.maxNodes },
+		{ "maxRolloutActions", options.maxRolloutActions },
+		{ "explorationConstant", options.explorationConstant },
+		{ "temperature", options.temperature },
+	};
+}
+
+json SettingsJsonFromOptions(const SelfPlayRunnerOptions& options) {
+	return StandardSettingsJson(
+		options.unitCap,
+		options.captureLimit,
+		options.hasDayLimit ? std::optional<int>(options.dayLimit) : std::nullopt,
+		options.heuristicAutoResign);
+}
+
+json BuildHeader(const SelfPlayRunnerOptions& options) {
+	return {
+		{ "recordType", "header" },
+		{ "replayFormatVersion", SelfPlayReplayFormatVersion() },
+		{ "createdAt", CreatedAtUtc() },
+		{ "versions", SelfPlayVersionsJson() },
+		{ "config", {
+			{ "mapId", options.mapId },
+			{ "player0Co", options.player0CoId },
+			{ "player1Co", options.player1CoId },
+			{ "baseSeed", options.baseSeed },
+			{ "maxActions", options.maxActions },
+			{ "settings", SettingsJsonFromOptions(options) },
+			{ "mctsOptions", MctsOptionsJson(options.mctsOptions) },
+		} },
+	};
+}
+
+Result StateTensorChecksumHex(const GameState& gameState, std::string& checksum, SelfPlayError& error, int gameIndex, int ply) {
+	std::vector<float> values;
+	if (StateTensor::Encode(gameState, values) == Result::Failed) {
+		SetError(error, "state-tensor-failed", "state tensor encoding failed; map may exceed standard-gl-v1 shape", gameIndex, ply);
+		return Result::Failed;
+	}
+
+	std::uint64_t rawChecksum = 0;
+	if (StateTensor::Checksum(values, rawChecksum) == Result::Failed) {
+		SetError(error, "state-tensor-checksum-failed", "state tensor checksum failed", gameIndex, ply);
+		return Result::Failed;
+	}
+
+	checksum = ChecksumToHex(rawChecksum);
+	return Result::Succeeded;
+}
+
+Result EncodeLegalActionIndices(const GameState& gameState, std::vector<Action>& legalActions, std::vector<int>& legalActionIndices, SelfPlayError& error, int gameIndex, int ply) {
+	legalActions.clear();
+	legalActionIndices.clear();
+	if (gameState.GetValidActions(legalActions) == Result::Failed) {
+		SetError(error, "legal-actions-failed", "legal action generation failed", gameIndex, ply);
+		return Result::Failed;
+	}
+
+	for (const Action& action : legalActions) {
+		int actionIndex = -1;
+		if (ActionSpace::EncodeAction(action, actionIndex) == Result::Failed) {
+			SetError(error, "action-encoding-failed", "legal action failed to encode", gameIndex, ply);
+			return Result::Failed;
+		}
+		legalActionIndices.push_back(actionIndex);
+	}
+
+	std::sort(legalActionIndices.begin(), legalActionIndices.end());
+	legalActionIndices.erase(std::unique(legalActionIndices.begin(), legalActionIndices.end()), legalActionIndices.end());
+	return Result::Succeeded;
+}
+
+json IntVectorJson(const std::vector<int>& values) {
+	json array = json::array();
+	for (int value : values) {
+		array.push_back(value);
+	}
+	return array;
+}
+
+Result BuildVisitCounts(const MCTSSearchResult<Action>& searchResult, int selectedActionIndex, json& visitCounts, SelfPlayError& error, int gameIndex, int ply) {
+	std::map<int, int> visitsByAction;
+	for (const MCTSActionStats<Action>& stats : searchResult.rootActionStats) {
+		if (stats.visits <= 0) {
+			continue;
+		}
+
+		int actionIndex = -1;
+		if (ActionSpace::EncodeAction(stats.action, actionIndex) == Result::Failed) {
+			SetError(error, "action-encoding-failed", "visited MCTS action failed to encode", gameIndex, ply);
+			return Result::Failed;
+		}
+		visitsByAction[actionIndex] += stats.visits;
+	}
+
+	int visitSum = 0;
+	bool selectedVisited = false;
+	visitCounts = json::array();
+	for (const auto& visits : visitsByAction) {
+		visitCounts.push_back({
+			{ "actionIndex", visits.first },
+			{ "visits", visits.second },
+		});
+		visitSum += visits.second;
+		if (visits.first == selectedActionIndex) {
+			selectedVisited = true;
+		}
+	}
+
+	if (!selectedVisited) {
+		SetError(error, "selected-action-unvisited", "selected MCTS action must have positive visits", gameIndex, ply);
+		return Result::Failed;
+	}
+	if (visitSum != searchResult.simulationsRun) {
+		SetError(error, "visit-sum-mismatch", "sum of root visits does not match simulationsRun", gameIndex, ply);
+		return Result::Failed;
+	}
+
+	return Result::Succeeded;
+}
+
+int OutcomeForPlayer(const json& winner, int player) {
+	if (winner.is_null()) {
+		return 0;
+	}
+
+	const int winningPlayer = winner.get<int>();
+	if (winningPlayer < 0 || winningPlayer == 2) {
+		return 0;
+	}
+
+	return winningPlayer == player ? 1 : -1;
+}
+
+json PlayersMetadata(const StandardGameSetupResult& setup) {
+	return json::array({
+		{
+			{ "slot", 0 },
+			{ "co", setup.playerCoIds[0] },
+			{ "armyType", setup.playerArmyTypes[0] },
+		},
+		{
+			{ "slot", 1 },
+			{ "co", setup.playerCoIds[1] },
+			{ "armyType", setup.playerArmyTypes[1] },
+		},
+	});
+}
+
+json GameConfigJson(const SelfPlayRunnerOptions& options, int gameIndex, std::uint32_t combatSeed, std::uint32_t mctsSeed) {
+	return {
+		{ "mapId", options.mapId },
+		{ "baseSeed", options.baseSeed },
+		{ "combatSeed", combatSeed },
+		{ "mctsSeed", mctsSeed },
+		{ "maxActions", options.maxActions },
+		{ "mctsOptions", MctsOptionsJson(options.mctsOptions) },
+	};
+}
+
+Result CreateGame(const SelfPlayRunnerOptions& options, int gameIndex, std::uint32_t combatSeed, StandardGameSetupResult& setup, SelfPlayError& error) {
+	json request;
+	StandardGameSetupError setupError;
+	if (BuildStandardGameRequestFromSlots(options.mapId, options.player0CoId, options.player1CoId, SettingsJsonFromOptions(options), combatSeed, request, setupError) == Result::Failed) {
+		SetError(error, setupError.code, setupError.message, gameIndex);
+		return Result::Failed;
+	}
+	if (CreateStandardGameFromRequest(request, setup, setupError) == Result::Failed) {
+		SetError(error, setupError.code, setupError.message, gameIndex);
+		return Result::Failed;
+	}
+
+	return Result::Succeeded;
+}
+
+Result BuildGameRecord(const SelfPlayRunnerOptions& options, int gameIndex, int outputGameIndex, json& gameRecord, SelfPlayRunSummary& summary, SelfPlayError& error) {
+	const std::uint32_t combatSeed = AddSeed(options.baseSeed, static_cast<std::uint32_t>(gameIndex));
+	const std::uint32_t mctsGameSeed = AddSeed(options.baseSeed, static_cast<std::uint32_t>(1000003u * (static_cast<std::uint32_t>(gameIndex) + 1u)));
+
+	StandardGameSetupResult setup;
+	IfFailedReturn(CreateGame(options, gameIndex, combatSeed, setup, error));
+
+	GameState gameState = setup.gameState;
+	const json initialState = SerializeGameStateForReplay(gameState);
+
+	json actions = json::array();
+	json samples = json::array();
+	int invalidActionCount = 0;
+	int legalActionTotal = 0;
+	double totalSearchTimeMs = 0.0;
+
+	const auto gameStart = std::chrono::steady_clock::now();
+	for (int ply = 0; ply < options.maxActions && !gameState.FGameOver(); ++ply) {
+		const int currentPlayer = gameState.getCurrentPlayer();
+
+		std::string checksum;
+		IfFailedReturn(StateTensorChecksumHex(gameState, checksum, error, gameIndex, ply));
+
+		std::vector<Action> legalActions;
+		std::vector<int> legalActionIndices;
+		IfFailedReturn(EncodeLegalActionIndices(gameState, legalActions, legalActionIndices, error, gameIndex, ply));
+		if (legalActions.empty()) {
+			SetError(error, "no-legal-actions", "non-terminal state has no legal actions", gameIndex, ply);
+			return Result::Failed;
+		}
+		legalActionTotal += static_cast<int>(legalActionIndices.size());
+
+		MCTS<GameState, Action> mcts;
+		MCTSOptions searchOptions = options.mctsOptions;
+		const std::uint32_t actionMctsSeed = DeriveActionSeed(mctsGameSeed, ply);
+		searchOptions.seed = actionMctsSeed;
+
+		const auto searchStart = std::chrono::steady_clock::now();
+		MCTSSearchResult<Action> searchResult = mcts.search(gameState, searchOptions);
+		const auto searchEnd = std::chrono::steady_clock::now();
+		const double searchTimeMs = std::chrono::duration<double, std::milli>(searchEnd - searchStart).count();
+		totalSearchTimeMs += searchTimeMs;
+
+		if (!searchResult.selectedAction.has_value()) {
+			SetError(error, "mcts-no-action", "MCTS did not select an action", gameIndex, ply);
+			return Result::Failed;
+		}
+
+		const Action selectedAction = searchResult.selectedAction.value();
+		if (std::find(legalActions.begin(), legalActions.end(), selectedAction) == legalActions.end()) {
+			++invalidActionCount;
+			SetError(error, "selected-action-illegal", "MCTS selected action is not legal", gameIndex, ply);
+			return Result::Failed;
+		}
+
+		int selectedActionIndex = -1;
+		if (ActionSpace::EncodeAction(selectedAction, selectedActionIndex) == Result::Failed) {
+			SetError(error, "action-encoding-failed", "selected action failed to encode", gameIndex, ply);
+			return Result::Failed;
+		}
+
+		json visitCounts;
+		IfFailedReturn(BuildVisitCounts(searchResult, selectedActionIndex, visitCounts, error, gameIndex, ply));
+
+		json actionJson;
+		to_json(actionJson, selectedAction);
+		actions.push_back({
+			{ "ply", ply },
+			{ "player", currentPlayer },
+			{ "actionIndex", selectedActionIndex },
+			{ "action", std::move(actionJson) },
+		});
+
+		samples.push_back({
+			{ "ply", ply },
+			{ "currentPlayer", currentPlayer },
+			{ "stateTensorChecksum", checksum },
+			{ "legalActionCount", static_cast<int>(legalActionIndices.size()) },
+			{ "legalActionIndices", IntVectorJson(legalActionIndices) },
+			{ "visitCounts", std::move(visitCounts) },
+			{ "selectedActionIndex", selectedActionIndex },
+			{ "outcome", 0 },
+			{ "mcts", {
+				{ "mctsSeed", actionMctsSeed },
+				{ "simulationsRun", searchResult.simulationsRun },
+				{ "nodesCreated", searchResult.nodesCreated },
+				{ "searchTimeMs", searchTimeMs },
+			} },
+		});
+
+		if (gameState.DoAction(selectedAction) == Result::Failed) {
+			++invalidActionCount;
+			SetError(error, "action-apply-failed", "selected action failed during execution", gameIndex, ply);
+			return Result::Failed;
+		}
+		if (gameState.FHeuristicAutoResign()) {
+			gameState.CheckPlayerResigns();
+		}
+	}
+
+	json terminalReason;
+	json winner;
+	if (gameState.FGameOver()) {
+		terminalReason = gameState.GetTerminalReason().has_value() ? json(gameState.GetTerminalReason().value()) : json(nullptr);
+		winner = gameState.getWinningPlayer();
+	}
+	else {
+		terminalReason = "action-limit";
+		winner = nullptr;
+	}
+
+	for (json& sample : samples) {
+		sample["outcome"] = OutcomeForPlayer(winner, sample.at("currentPlayer").get<int>());
+	}
+
+	const auto gameEnd = std::chrono::steady_clock::now();
+	const double totalElapsedMs = std::chrono::duration<double, std::milli>(gameEnd - gameStart).count();
+	const int sampleCount = static_cast<int>(samples.size());
+	const double averageBranchingFactor = sampleCount == 0 ? 0.0 : static_cast<double>(legalActionTotal) / sampleCount;
+	const double averageSearchTimeMs = sampleCount == 0 ? 0.0 : totalSearchTimeMs / sampleCount;
+	const int resignations = terminalReason.is_string() && terminalReason.get<std::string>() == "heuristic-resign" ? 1 : 0;
+
+	gameRecord = {
+		{ "recordType", "game" },
+		{ "replayFormatVersion", SelfPlayReplayFormatVersion() },
+		{ "versions", SelfPlayVersionsJson() },
+		{ "gameIndex", outputGameIndex },
+		{ "config", GameConfigJson(options, gameIndex, combatSeed, mctsGameSeed) },
+		{ "players", PlayersMetadata(setup) },
+		{ "settings", setup.resolvedSettings },
+		{ "initialState", initialState },
+		{ "actions", actions },
+		{ "samples", samples },
+		{ "finalState", SerializeGameStateForReplay(gameState) },
+		{ "terminalReason", terminalReason },
+		{ "winner", winner },
+		{ "metrics", {
+			{ "actionCount", static_cast<int>(actions.size()) },
+			{ "sampleCount", sampleCount },
+			{ "turnCount", gameState.GetTurnCount() },
+			{ "resignations", resignations },
+			{ "invalidActionCount", invalidActionCount },
+			{ "averageBranchingFactor", averageBranchingFactor },
+			{ "totalSearchTimeMs", totalSearchTimeMs },
+			{ "averageSearchTimeMs", averageSearchTimeMs },
+			{ "totalElapsedMs", totalElapsedMs },
+		} },
+	};
+
+	++summary.gamesWritten;
+	summary.samplesWritten += sampleCount;
+	summary.actionsWritten += static_cast<int>(actions.size());
+	return Result::Succeeded;
+}
+
+bool IsFileEmpty(const std::filesystem::path& path) {
+	if (!std::filesystem::exists(path)) {
+		return true;
+	}
+	return std::filesystem::file_size(path) == 0;
+}
+
+Result PrepareOutputFile(const SelfPlayRunnerOptions& options, const json& header, int& existingGames, SelfPlayError& error) {
+	existingGames = 0;
+	const std::filesystem::path parent = options.outputPath.parent_path();
+	if (!parent.empty()) {
+		std::error_code ec;
+		std::filesystem::create_directories(parent, ec);
+		if (ec) {
+			SetError(error, "mkdir-failed", "could not create output directory: " + parent.string());
+			return Result::Failed;
+		}
+	}
+
+	if (std::filesystem::exists(options.outputPath)) {
+		if (!options.append) {
+			SetError(error, "output-exists", "output file already exists; pass --append to add games");
+			return Result::Failed;
+		}
+
+		if (!IsFileEmpty(options.outputPath)) {
+			SelfPlayReplayValidationSummary appendSummary;
+			IfFailedReturn(ValidateSelfPlayReplayForAppend(options.outputPath, header, appendSummary, error));
+			existingGames = appendSummary.games;
+		}
+	}
+
+	return Result::Succeeded;
+}
+
+Result ValidateOptions(const SelfPlayRunnerOptions& options, SelfPlayError& error) {
+	if (options.outputPath.empty()) {
+		SetError(error, "missing-out", "--out is required");
+		return Result::Failed;
+	}
+	if (options.mapId.empty()) {
+		SetError(error, "missing-map", "--map is required");
+		return Result::Failed;
+	}
+	if (options.player0CoId.empty() || options.player1CoId.empty()) {
+		SetError(error, "missing-co", "--player0-co and --player1-co are required");
+		return Result::Failed;
+	}
+	if (options.games < 1) {
+		SetError(error, "invalid-games", "--games must be at least 1");
+		return Result::Failed;
+	}
+	if (options.maxActions < 1) {
+		SetError(error, "invalid-max-actions", "--max-actions must be at least 1");
+		return Result::Failed;
+	}
+	if (options.mctsOptions.maxSimulations < 1) {
+		SetError(error, "invalid-mcts-simulations", "--mcts-simulations must be at least 1");
+		return Result::Failed;
+	}
+	if (options.mctsOptions.maxNodes < 1 || options.mctsOptions.maxRolloutActions < 0 || options.mctsOptions.temperature < 0.0) {
+		SetError(error, "invalid-mcts-options", "MCTS limits must be nonnegative, and max nodes must be positive");
+		return Result::Failed;
+	}
+	return Result::Succeeded;
+}
+
+bool ParseInt(const std::string& text, int& value) {
+	try {
+		std::size_t processed = 0;
+		value = std::stoi(text, &processed);
+		return processed == text.size();
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool ParseUInt32(const std::string& text, std::uint32_t& value) {
+	try {
+		std::size_t processed = 0;
+		const unsigned long parsed = std::stoul(text, &processed);
+		if (processed != text.size() || parsed > 0xffffffffUL) {
+			return false;
+		}
+		value = static_cast<std::uint32_t>(parsed);
+		return true;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool ParseDouble(const std::string& text, double& value) {
+	try {
+		std::size_t processed = 0;
+		value = std::stod(text, &processed);
+		return processed == text.size();
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+int PrintError(const SelfPlayError& error) {
+	std::cerr << error.code << ": " << error.message;
+	if (error.line > 0) {
+		std::cerr << " (line " << error.line << ")";
+	}
+	if (error.gameIndex >= 0) {
+		std::cerr << " (game " << error.gameIndex << ")";
+	}
+	if (error.ply >= 0) {
+		std::cerr << " (ply " << error.ply << ")";
+	}
+	std::cerr << std::endl;
+	return 1;
+}
+}
+
+Result RunSelfPlay(const SelfPlayRunnerOptions& options, SelfPlayRunSummary& summary, SelfPlayError& error) {
+	summary = SelfPlayRunSummary{};
+	IfFailedReturn(ValidateOptions(options, error));
+
+	const json header = BuildHeader(options);
+	int existingGames = 0;
+	IfFailedReturn(PrepareOutputFile(options, header, existingGames, error));
+
+	const bool writeHeader = !std::filesystem::exists(options.outputPath) || IsFileEmpty(options.outputPath);
+	std::ofstream output(options.outputPath, std::ios::app);
+	if (!output.is_open()) {
+		SetError(error, "open-failed", "could not open output file: " + options.outputPath.string());
+		return Result::Failed;
+	}
+
+	if (writeHeader) {
+		output << header.dump() << "\n";
+	}
+
+	for (int gameIndex = 0; gameIndex < options.games; ++gameIndex) {
+		json gameRecord;
+		IfFailedReturn(BuildGameRecord(options, existingGames + gameIndex, existingGames + gameIndex, gameRecord, summary, error));
+		output << gameRecord.dump() << "\n";
+		if (!options.quiet) {
+			std::cout << "self-play game " << (existingGames + gameIndex) <<
+				" terminalReason=" << gameRecord.at("terminalReason").dump() <<
+				" winner=" << gameRecord.at("winner").dump() <<
+				" actions=" << gameRecord.at("metrics").at("actionCount") <<
+				" samples=" << gameRecord.at("metrics").at("sampleCount") <<
+				" elapsedMs=" << gameRecord.at("metrics").at("totalElapsedMs") <<
+				" out=" << options.outputPath.string() << std::endl;
+		}
+	}
+	output.close();
+
+	SelfPlayReplayValidationSummary validationSummary;
+	IfFailedReturn(ValidateSelfPlayReplay(options.outputPath, validationSummary, error));
+	return Result::Succeeded;
+}
+
+int RunSelfPlayCommand(int argc, char* argv[]) noexcept {
+	SelfPlayRunnerOptions options;
+	options.mctsOptions.maxSimulations = 128;
+	options.mctsOptions.temperature = 1.0;
+
+	for (int i = 0; i < argc; ++i) {
+		const std::string arg = argv[i];
+		auto requireValue = [&](std::string& value) -> bool {
+			if (i + 1 >= argc) {
+				return false;
+			}
+			value = argv[++i];
+			return true;
+		};
+
+		std::string value;
+		if (arg == "--out" && requireValue(value)) {
+			options.outputPath = value;
+		}
+		else if (arg == "--map" && requireValue(value)) {
+			options.mapId = value;
+		}
+		else if (arg == "--player0-co" && requireValue(value)) {
+			options.player0CoId = value;
+		}
+		else if (arg == "--player1-co" && requireValue(value)) {
+			options.player1CoId = value;
+		}
+		else if (arg == "--games" && requireValue(value) && ParseInt(value, options.games)) {}
+		else if (arg == "--max-actions" && requireValue(value) && ParseInt(value, options.maxActions)) {}
+		else if (arg == "--seed" && requireValue(value) && ParseUInt32(value, options.baseSeed)) {}
+		else if (arg == "--unit-cap" && requireValue(value) && ParseInt(value, options.unitCap)) {}
+		else if (arg == "--capture-limit" && requireValue(value) && ParseInt(value, options.captureLimit)) {}
+		else if (arg == "--day-limit" && requireValue(value) && ParseInt(value, options.dayLimit)) {
+			options.hasDayLimit = true;
+		}
+		else if (arg == "--mcts-simulations" && requireValue(value) && ParseInt(value, options.mctsOptions.maxSimulations)) {}
+		else if (arg == "--mcts-max-nodes" && requireValue(value) && ParseInt(value, options.mctsOptions.maxNodes)) {}
+		else if (arg == "--mcts-max-rollout-actions" && requireValue(value) && ParseInt(value, options.mctsOptions.maxRolloutActions)) {}
+		else if (arg == "--mcts-exploration" && requireValue(value) && ParseDouble(value, options.mctsOptions.explorationConstant)) {}
+		else if (arg == "--temperature" && requireValue(value) && ParseDouble(value, options.mctsOptions.temperature)) {}
+		else if (arg == "--heuristic-auto-resign") {
+			options.heuristicAutoResign = true;
+		}
+		else if (arg == "--append") {
+			options.append = true;
+		}
+		else if (arg == "--quiet") {
+			options.quiet = true;
+		}
+		else {
+			std::cerr << "invalid self-play argument: " << arg << std::endl;
+			return 1;
+		}
+	}
+
+	SelfPlayRunSummary summary;
+	SelfPlayError error;
+	if (RunSelfPlay(options, summary, error) == Result::Failed) {
+		return PrintError(error);
+	}
+
+	if (!options.quiet) {
+		std::cout << "self-play replay validated: games=" << summary.gamesWritten <<
+			" samples=" << summary.samplesWritten <<
+			" actions=" << summary.actionsWritten << std::endl;
+	}
+	return 0;
+}
+
+int RunValidateReplayCommand(int argc, char* argv[]) noexcept {
+	if (argc != 1) {
+		std::cerr << "usage: -validate-replay <path>" << std::endl;
+		return 1;
+	}
+
+	SelfPlayReplayValidationSummary summary;
+	SelfPlayError error;
+	if (ValidateSelfPlayReplay(argv[0], summary, error) == Result::Failed) {
+		return PrintError(error);
+	}
+
+	std::cout << "Replay valid: games=" << summary.games <<
+		" samples=" << summary.samples <<
+		" actions=" << summary.actions <<
+		" invalidActions=" << summary.invalidActions << std::endl;
+	return 0;
+}

--- a/AdvanceWarsServer/src/StandardGameSetup.cpp
+++ b/AdvanceWarsServer/src/StandardGameSetup.cpp
@@ -1,0 +1,450 @@
+#include "StandardGameSetup.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+#include "Platform.h"
+
+namespace {
+struct MapTemplate {
+	const char* id;
+	const char* path;
+};
+
+constexpr std::array<MapTemplate, 2> MapTemplates{ {
+	{ "lefty", "res/AWBW/MapSources/Lefty.json" },
+	{ "mcts", "res/AWBW/MapSources/MCTS.json" },
+} };
+
+void SetError(StandardGameSetupError& error, StandardGameSetupErrorType type, const std::string& code, const std::string& message, json details = json::object()) {
+	error.type = type;
+	error.code = code;
+	error.message = message;
+	error.details = std::move(details);
+}
+
+bool ContainsOnlyFields(const json& object, const std::vector<std::string>& allowedFields, std::string& invalidField) {
+	if (!object.is_object()) {
+		invalidField.clear();
+		return false;
+	}
+
+	for (auto it = object.begin(); it != object.end(); ++it) {
+		if (std::find(allowedFields.begin(), allowedFields.end(), it.key()) == allowedFields.end()) {
+			invalidField = it.key();
+			return false;
+		}
+	}
+
+	return true;
+}
+
+std::string ToPascalNoHyphen(std::string value) {
+	std::string converted;
+	bool capitalizeNext = true;
+	for (char ch : value) {
+		if (ch == '-') {
+			capitalizeNext = true;
+			continue;
+		}
+
+		if (capitalizeNext) {
+			converted.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+			capitalizeNext = false;
+		}
+		else {
+			converted.push_back(ch);
+		}
+	}
+	return converted;
+}
+
+bool TryParseCoId(const std::string& coId, CommandingOfficier& co, std::string& coJsonName) {
+	coJsonName = ToPascalNoHyphen(coId);
+	json coJson = coJsonName;
+	try {
+		from_json(coJson, co);
+		return co.m_type != CommandingOfficier::Type::Invalid;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool IsStandardBannedUnits(const json& bannedUnits) {
+	return bannedUnits.is_array() &&
+		bannedUnits.size() == 1 &&
+		bannedUnits.at(0).is_string() &&
+		bannedUnits.at(0).get<std::string>() == "blackbomb";
+}
+
+const MapTemplate* FindMapTemplate(const std::string& mapId) {
+	for (const MapTemplate& mapTemplate : MapTemplates) {
+		if (mapId == mapTemplate.id) {
+			return &mapTemplate;
+		}
+	}
+	return nullptr;
+}
+
+Result LoadMapTemplateJson(const std::string& mapId, json& templateJson, StandardGameSetupError& error) {
+	const MapTemplate* mapTemplate = FindMapTemplate(mapId);
+	if (mapTemplate == nullptr) {
+		SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unknown-map-id", "Map id is not supported.", {
+			{ "field", "mapId" },
+			{ "value", mapId },
+			{ "supportedMapIds", SupportedStandardMapIds() },
+		});
+		return Result::Failed;
+	}
+
+	std::fstream filestream(mapTemplate->path, std::ios::in);
+	if (filestream.fail() || filestream.eof()) {
+		SetError(error, StandardGameSetupErrorType::Internal, "map-template-unavailable", "Map template could not be loaded.", { { "mapId", mapId } });
+		return Result::Failed;
+	}
+
+	try {
+		filestream >> templateJson;
+	}
+	catch (const std::exception& err) {
+		SetError(error, StandardGameSetupErrorType::Internal, "map-template-invalid", err.what(), { { "mapId", mapId } });
+		return Result::Failed;
+	}
+
+	return Result::Succeeded;
+}
+
+Result ValidateSettings(const json& request, json& resolvedSettings, StandardGameSetupError& error) {
+	if (!request.contains("settings")) {
+		resolvedSettings = StandardSettingsJson();
+		return Result::Succeeded;
+	}
+
+	const json& settings = request.at("settings");
+	if (!settings.is_object()) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "settings must be an object.", { { "field", "settings" } });
+		return Result::Failed;
+	}
+
+	std::string invalidField;
+	if (!ContainsOnlyFields(settings, { "mode", "fog", "weather", "coPowers", "tags", "startingFunds", "incomePerProperty", "unitCap", "captureLimit", "dayLimit", "bannedUnits", "heuristicAutoResign" }, invalidField)) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "Unknown settings field.", { { "field", "settings." + invalidField } });
+		return Result::Failed;
+	}
+
+	int unitCap = 50;
+	int captureLimit = 21;
+	std::optional<int> dayLimit;
+	try {
+		if (settings.contains("mode") && (!settings.at("mode").is_string() || settings.at("mode").get<std::string>() != "standard")) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Only standard mode is supported.", { { "field", "settings.mode" }, { "value", settings.at("mode") } });
+			return Result::Failed;
+		}
+		if (settings.contains("fog") && (!settings.at("fog").is_boolean() || settings.at("fog").get<bool>() != false)) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Fog of War is not supported for standard games yet.", { { "field", "settings.fog" }, { "value", settings.at("fog") } });
+			return Result::Failed;
+		}
+		if (settings.contains("weather") && (!settings.at("weather").is_string() || settings.at("weather").get<std::string>() != "clear")) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Only clear weather is supported for standard games.", { { "field", "settings.weather" }, { "value", settings.at("weather") } });
+			return Result::Failed;
+		}
+		if (settings.contains("coPowers") && (!settings.at("coPowers").is_boolean() || settings.at("coPowers").get<bool>() != true)) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "CO powers must remain enabled for standard games.", { { "field", "settings.coPowers" }, { "value", settings.at("coPowers") } });
+			return Result::Failed;
+		}
+		if (settings.contains("tags") && (!settings.at("tags").is_boolean() || settings.at("tags").get<bool>() != false)) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Tag powers are not supported for standard games yet.", { { "field", "settings.tags" }, { "value", settings.at("tags") } });
+			return Result::Failed;
+		}
+		if (settings.contains("startingFunds") && (!settings.at("startingFunds").is_number_integer() || settings.at("startingFunds").get<int>() != 0)) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Only 0 starting funds are supported for standard games.", { { "field", "settings.startingFunds" }, { "value", settings.at("startingFunds") } });
+			return Result::Failed;
+		}
+		if (settings.contains("incomePerProperty") && (!settings.at("incomePerProperty").is_number_integer() || settings.at("incomePerProperty").get<int>() != 1000)) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Only 1000 income per property is supported.", { { "field", "settings.incomePerProperty" }, { "value", settings.at("incomePerProperty") } });
+			return Result::Failed;
+		}
+		if (settings.contains("unitCap")) {
+			if (!settings.at("unitCap").is_number_integer()) {
+				SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "unitCap must be an integer.", { { "field", "settings.unitCap" } });
+				return Result::Failed;
+			}
+			unitCap = settings.at("unitCap").get<int>();
+			if (unitCap <= 0) {
+				SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "unitCap must be positive for standard games.", { { "field", "settings.unitCap" }, { "value", settings.at("unitCap") } });
+				return Result::Failed;
+			}
+		}
+		if (settings.contains("captureLimit")) {
+			if (!settings.at("captureLimit").is_number_integer()) {
+				SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "captureLimit must be an integer.", { { "field", "settings.captureLimit" } });
+				return Result::Failed;
+			}
+			captureLimit = settings.at("captureLimit").get<int>();
+			if (captureLimit <= 0) {
+				SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "captureLimit must be positive for standard games.", { { "field", "settings.captureLimit" }, { "value", settings.at("captureLimit") } });
+				return Result::Failed;
+			}
+		}
+		if (settings.contains("dayLimit")) {
+			if (settings.at("dayLimit").is_null()) {
+				dayLimit.reset();
+			}
+			else if (!settings.at("dayLimit").is_number_integer()) {
+				SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "dayLimit must be an integer or null.", { { "field", "settings.dayLimit" } });
+				return Result::Failed;
+			}
+			else {
+				const int parsedDayLimit = settings.at("dayLimit").get<int>();
+				if (parsedDayLimit <= 0) {
+					SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "dayLimit must be positive for standard games.", { { "field", "settings.dayLimit" }, { "value", settings.at("dayLimit") } });
+					return Result::Failed;
+				}
+				dayLimit = parsedDayLimit;
+			}
+		}
+		if (settings.contains("bannedUnits") && !IsStandardBannedUnits(settings.at("bannedUnits"))) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-setting", "Only the standard blackbomb ban is supported.", { { "field", "settings.bannedUnits" }, { "value", settings.at("bannedUnits") } });
+			return Result::Failed;
+		}
+		if (settings.contains("heuristicAutoResign") && !settings.at("heuristicAutoResign").is_boolean()) {
+			SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "heuristicAutoResign must be a boolean.", { { "field", "settings.heuristicAutoResign" } });
+			return Result::Failed;
+		}
+	}
+	catch (const std::exception&) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "settings contains a value with the wrong type.", { { "field", "settings" } });
+		return Result::Failed;
+	}
+
+	const bool heuristicAutoResign = settings.contains("heuristicAutoResign") && settings.at("heuristicAutoResign").get<bool>();
+	resolvedSettings = StandardSettingsJson(unitCap, captureLimit, dayLimit, heuristicAutoResign);
+	return Result::Succeeded;
+}
+
+bool IsValidSeedJson(const json& value) {
+	return value.is_number_unsigned() ||
+		(value.is_number_integer() && value.get<std::int64_t>() >= 0);
+}
+}
+
+json StandardSettingsJson(int unitCap, int captureLimit, std::optional<int> dayLimit, bool heuristicAutoResign) {
+	json dayLimitJson = nullptr;
+	if (dayLimit.has_value()) {
+		dayLimitJson = dayLimit.value();
+	}
+
+	return {
+		{ "mode", "standard" },
+		{ "fog", false },
+		{ "weather", "clear" },
+		{ "coPowers", true },
+		{ "tags", false },
+		{ "startingFunds", 0 },
+		{ "incomePerProperty", 1000 },
+		{ "unitCap", unitCap },
+		{ "captureLimit", captureLimit },
+		{ "dayLimit", dayLimitJson },
+		{ "bannedUnits", json::array({ "blackbomb" }) },
+		{ "heuristicAutoResign", heuristicAutoResign },
+	};
+}
+
+json SupportedStandardMapIds() {
+	json supported = json::array();
+	for (const MapTemplate& mapTemplate : MapTemplates) {
+		supported.push_back(mapTemplate.id);
+	}
+	return supported;
+}
+
+Result BuildStandardGameRequestFromSlots(
+	const std::string& mapId,
+	const std::string& player0CoId,
+	const std::string& player1CoId,
+	const json& settings,
+	std::optional<std::uint32_t> seed,
+	json& request,
+	StandardGameSetupError& error) {
+	json templateJson;
+	IfFailedReturn(LoadMapTemplateJson(mapId, templateJson, error));
+	if (!templateJson.contains("players") || !templateJson.at("players").is_array() || templateJson.at("players").size() != 2) {
+		SetError(error, StandardGameSetupErrorType::Internal, "map-template-invalid", "Map template must contain exactly two players.", { { "mapId", mapId } });
+		return Result::Failed;
+	}
+
+	request = {
+		{ "mapId", mapId },
+		{ "players", json::array({
+			{
+				{ "co", player0CoId },
+				{ "armyType", templateJson.at("players").at(0).at("armyType") },
+			},
+			{
+				{ "co", player1CoId },
+				{ "armyType", templateJson.at("players").at(1).at("armyType") },
+			},
+		}) },
+		{ "settings", settings },
+	};
+	if (seed.has_value()) {
+		request["seed"] = seed.value();
+	}
+
+	return Result::Succeeded;
+}
+
+Result CreateStandardGameFromRequest(const json& request, StandardGameSetupResult& result, StandardGameSetupError& error) {
+	if (!request.is_object()) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "Create game payload must be an object.");
+		return Result::Failed;
+	}
+
+	std::string invalidField;
+	if (!ContainsOnlyFields(request, { "mapId", "players", "settings", "seed" }, invalidField)) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "Unknown create-game field.", { { "field", invalidField } });
+		return Result::Failed;
+	}
+
+	if (!request.contains("mapId") || !request.at("mapId").is_string()) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "missing-required-field", "mapId is required.", { { "field", "mapId" } });
+		return Result::Failed;
+	}
+
+	const std::string mapId = request.at("mapId").get<std::string>();
+	json templateJson;
+	IfFailedReturn(LoadMapTemplateJson(mapId, templateJson, error));
+
+	if (!request.contains("players") || !request.at("players").is_array() || request.at("players").size() != 2) {
+		SetError(error, StandardGameSetupErrorType::BadRequest, "missing-required-field", "players must contain exactly two players.", { { "field", "players" } });
+		return Result::Failed;
+	}
+
+	json resolvedSettings;
+	IfFailedReturn(ValidateSettings(request, resolvedSettings, error));
+	const bool heuristicAutoResign = resolvedSettings.at("heuristicAutoResign").get<bool>();
+
+	templateJson["gameId"] = Platform::createUuid();
+	templateJson["settings"] = resolvedSettings;
+	templateJson["unit-cap"] = resolvedSettings.at("unitCap").get<int>();
+	templateJson["cap-limit"] = resolvedSettings.at("captureLimit").get<int>();
+	templateJson["activePlayer"] = 0;
+	templateJson["turn-count"] = 0;
+	templateJson.erase("combat-rng-seed");
+
+	std::array<std::string, 2> coIds;
+	std::array<std::string, 2> armyTypes;
+	for (int i = 0; i < 2; ++i) {
+		const json& requestedPlayer = request.at("players").at(i);
+		if (!requestedPlayer.is_object()) {
+			SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "Player setup must be an object.", { { "field", "players[" + std::to_string(i) + "]" } });
+			return Result::Failed;
+		}
+
+		if (!ContainsOnlyFields(requestedPlayer, { "co", "armyType" }, invalidField)) {
+			SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "Unknown player field.", { { "field", "players[" + std::to_string(i) + "]." + invalidField } });
+			return Result::Failed;
+		}
+
+		if (!requestedPlayer.contains("co") || !requestedPlayer.at("co").is_string()) {
+			SetError(error, StandardGameSetupErrorType::BadRequest, "missing-required-field", "Player co is required.", { { "field", "players[" + std::to_string(i) + "].co" } });
+			return Result::Failed;
+		}
+
+		if (!requestedPlayer.contains("armyType") || !requestedPlayer.at("armyType").is_string()) {
+			SetError(error, StandardGameSetupErrorType::BadRequest, "missing-required-field", "Player armyType is required.", { { "field", "players[" + std::to_string(i) + "].armyType" } });
+			return Result::Failed;
+		}
+
+		const std::string armyType = requestedPlayer.at("armyType").get<std::string>();
+		const std::string templateArmyType = templateJson.at("players").at(i).at("armyType").get<std::string>();
+		if (armyType != templateArmyType || Player::armyTypefromString(armyType) == Player::ArmyType::Invalid) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-army", "Requested armyType must match the map template player slot.", {
+				{ "field", "players[" + std::to_string(i) + "].armyType" },
+				{ "value", armyType },
+				{ "templateArmyType", templateArmyType },
+			});
+			return Result::Failed;
+		}
+
+		CommandingOfficier co;
+		std::string coJsonName;
+		coIds[i] = requestedPlayer.at("co").get<std::string>();
+		if (!TryParseCoId(coIds[i], co, coJsonName)) {
+			SetError(error, StandardGameSetupErrorType::UnprocessableEntity, "unsupported-co", "Commanding officer is not supported.", { { "field", "players[" + std::to_string(i) + "].co" }, { "value", requestedPlayer.at("co") } });
+			return Result::Failed;
+		}
+
+		Player player(co.m_type, Player::armyTypefromString(armyType));
+		player.m_funds = resolvedSettings.at("startingFunds").get<int>();
+		json playerJson;
+		to_json(playerJson, player);
+		templateJson["players"][i] = std::move(playerJson);
+		armyTypes[i] = armyType;
+	}
+
+	GameState gameState;
+	try {
+		GameState::from_json(templateJson, gameState);
+	}
+	catch (const std::exception& err) {
+		SetError(error, StandardGameSetupErrorType::Internal, "map-template-invalid", err.what(), { { "mapId", mapId } });
+		return Result::Failed;
+	}
+
+	std::optional<std::uint32_t> seed;
+	if (request.contains("seed")) {
+		if (!IsValidSeedJson(request.at("seed"))) {
+			SetError(error, StandardGameSetupErrorType::BadRequest, "invalid-field", "seed must be an integer.", { { "field", "seed" } });
+			return Result::Failed;
+		}
+		seed = request.at("seed").get<std::uint32_t>();
+		gameState.SetCombatRngSeed(seed.value());
+	}
+	gameState.SetHeuristicAutoResign(heuristicAutoResign);
+
+	if (gameState.StartFirstTurn() == Result::Failed) {
+		SetError(error, StandardGameSetupErrorType::Internal, "game-initialization-failed", "Game could not run the opening turn start.", { { "mapId", mapId } });
+		return Result::Failed;
+	}
+
+	result.gameState = std::move(gameState);
+	result.resolvedSettings = std::move(resolvedSettings);
+	result.mapId = mapId;
+	result.playerCoIds = coIds;
+	result.playerArmyTypes = armyTypes;
+	result.seed = seed;
+	return Result::Succeeded;
+}
+
+json SerializeStandardGameForApi(const GameState& gameState) {
+	json game;
+	GameState::to_json(game, gameState);
+	game.erase("combat-rng-seed");
+	game.erase("heuristic-auto-resign");
+	if (gameState.GetTerminalReason().has_value()) {
+		game["terminalReason"] = gameState.GetTerminalReason().value();
+	}
+	else {
+		game["terminalReason"] = nullptr;
+	}
+	return game;
+}
+
+json SerializeGameStateForReplay(const GameState& gameState) {
+	json game;
+	GameState::to_json(game, gameState);
+	if (gameState.GetTerminalReason().has_value()) {
+		game["terminalReason"] = gameState.GetTerminalReason().value();
+	}
+	else {
+		game["terminalReason"] = nullptr;
+	}
+	return game;
+}

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -32,6 +32,7 @@ Set-Location .\AdvanceWarsServer
 ..\x64\Debug\AdvanceWarsServer.exe -test test/json
 ..\x64\Debug\AdvanceWarsServer.exe -test-api-contract
 ..\x64\Debug\AdvanceWarsServer.exe -test-mcts
+..\x64\Debug\AdvanceWarsServer.exe -test-replay
 ```
 
 Release:
@@ -56,6 +57,9 @@ The executable currently recognizes these development commands:
 | `-test [path]` | Run the recursive JSON fixture suite. | Defaults to `test/json`. Run from `AdvanceWarsServer/` so relative paths resolve. |
 | `-test-api-contract` | Run focused REST lifecycle/action contract tests. | Run from `AdvanceWarsServer/` so map templates and fixtures resolve. |
 | `-test-mcts` | Run focused MCTS contract tests. | Uses scripted fake states for deterministic search semantics. |
+| `-test-replay` | Run focused self-play replay writer/validator tests. | Writes temporary replay shards and cleans them up on success. |
+| `-self-play --out <path> --map <id> --player0-co <id> --player1-co <id> [options]` | Generate validated sparse self-play replay JSONL. | Fails if `--out` exists unless `--append` is passed. See `docs/SELF_PLAY_REPLAYS.md`. |
+| `-validate-replay <path>` | Validate a self-play replay JSONL shard. | Prints a concise summary on success and exact failure location on error. |
 | `-sim-random-move-game [seed]` | Run an experimental random-action simulation. | Uses local output paths that still need cleanup before general use. |
 | `-sim-mcts-game` | Run an experimental MCTS simulation. | Uses local output paths that still need cleanup before general use. |
 | `-server` | Run the current HTTP server on port 80. | Serves the canonical REST routes documented in `docs/API.md`. |
@@ -95,3 +99,4 @@ Set-Location .\AdvanceWarsServer
 - `STANDARD_ENGINE_COMPLETENESS.md`: current Standard rules/API matrix.
 - `docs/API.md`: current and target API shape.
 - `docs/JSON_FIXTURES.md`: fixture authoring guide.
+- `docs/SELF_PLAY_REPLAYS.md`: self-play replay command and schema reference.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [STANDARD_ENGINE_COMPLETENESS.md](STANDARD_ENGINE_COMPLETENESS.md) for the c
 | `TRAINING_LOOP_WORK_ITEMS.md` | Self-play, MCTS, tensor, model, and training-loop roadmap. |
 | `docs/API.md` | Current and target REST/API contract notes. |
 | `docs/TRAINING_DESIGN.md` | Recommended self-play training architecture and data flow. |
+| `docs/SELF_PLAY_REPLAYS.md` | Self-play replay JSONL command and schema reference. |
 | `docs/JSON_FIXTURES.md` | JSON regression fixture format and authoring guide. |
 
 ## Quick Start
@@ -61,6 +62,16 @@ Run a focused subset:
 ```
 
 More command details are in [BUILD_AND_TEST.md](BUILD_AND_TEST.md).
+
+Generate and validate a small self-play replay shard:
+
+```powershell
+Set-Location .\AdvanceWarsServer
+..\x64\Debug\AdvanceWarsServer.exe -self-play --out ..\artifacts\replays\smoke.jsonl --map mcts --player0-co andy --player1-co adder --games 1 --max-actions 1000 --mcts-simulations 128
+..\x64\Debug\AdvanceWarsServer.exe -validate-replay ..\artifacts\replays\smoke.jsonl
+```
+
+Replay schema details are in [docs/SELF_PLAY_REPLAYS.md](docs/SELF_PLAY_REPLAYS.md).
 
 ## Development Workflow
 

--- a/STANDARD_ENGINE_COMPLETENESS.md
+++ b/STANDARD_ENGINE_COMPLETENESS.md
@@ -68,7 +68,7 @@ Explicitly deferred modes and options:
 | State tensor | `StateTensor` exposes the deterministic `standard-gl-v1-state` current-player-relative tensor with JSON fixture coverage. | Deterministic current-player-relative tensor. | Complete for v1 | none |
 | Action encoding and masks | `Action` variants and legal action generation exist. | Stable encoded action space plus mask. | Partial | #4 |
 | MCTS sequence handling | Existing MCTS needs action-level self-play cleanup. | Same-player action sequences backed up correctly until `EndTurn`. | Partial | #5 |
-| Replay writer | Not complete. | Versioned self-play samples and reconstructable action history. | Partial | #6 |
+| Replay writer | `-self-play` writes validated sparse `standard-gl-self-play-replay-v1` JSONL shards with full initial/final states, action history, sparse legal action indices, sparse MCTS visit counts, per-sample tensor checksums, outcomes, and metrics. `-validate-replay` reconstructs and checks shards. | Versioned self-play samples and reconstructable action history. | Complete for v1 sparse replay | #172, #173, #174 for cache/orchestration/compression |
 | Policy/value scaffold | Not complete. | Model input/output aligned with tensor/action encodings. | Partial | #7 |
 | Training entry point | Not complete. | Train from replay data and write checkpoints. | Partial | #8 |
 | Evaluation harness | Not complete. | Deterministic checkpoint evaluation against baselines. | Partial | #9 |
@@ -172,6 +172,9 @@ Training loop:
 - #4: Implement action encoding and legal action masks.
 - #5: Refactor MCTS for action-level self-play and same-player turn sequences.
 - #6: Add self-play replay writer.
+- #172: Add optional materialized replay cache for faster training loads.
+- #173: Add self-play orchestration for map pools, matchups, and side balancing.
+- #174: Add compressed self-play replay shard support.
 - #7: Add policy/value network scaffold.
 - #8: Add training command-line entry point.
 - #9: Add checkpoint evaluation harness.

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -26,7 +26,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] Fix capture-limit property counting. Capture-limit wins count Cities, Bases, Airports, Ports, and HQs, excluding Labs and Com Towers (#73).
 - [ ] Audit unit count caching around load/unload, clone, add, and destroy paths before relying on unit-cap logic in training.
 - [ ] Replace hardcoded local paths such as `D:/awai`, `D:/MNIST`, and local libtorch directories with config or command-line options.
-- [ ] Add a maximum turn/action limit outcome for self-play games so training cannot hang indefinitely. Coordinate with day-limit and terminal metadata work in #74 and #82.
+- [x] Add a maximum action limit outcome for self-play games so training cannot hang indefinitely. `-self-play` records `terminalReason: "action-limit"` and null winner for runner safety stops (#6).
 - [x] Make combat RNG deterministic, seedable, or policy-controlled from the self-play runner (#2).
 
 ## Phase 1: Trainable Environment API
@@ -52,12 +52,12 @@ The rules/API completeness target for the initial playable environment is normal
 
 ## Phase 3: Self-Play Data Generation
 
-- [ ] Add a self-play command-line entry point.
-- [ ] Generate games using MCTS-selected actions.
-- [ ] Record each training sample as state tensor, legal action mask, MCTS visit policy, current player, and final outcome.
-- [ ] Store replay data in a versioned format.
-- [ ] Add replay validation that can reconstruct a game from recorded actions.
-- [ ] Add basic metrics: game length, winner, resignations, average branching factor, and search time per move.
+- [x] Add a self-play command-line entry point (`-self-play`).
+- [x] Generate games using MCTS-selected atomic actions.
+- [x] Record each training sample as a reconstructable sparse row: tensor checksum, sparse legal action indices, positive MCTS visit counts, current player, selected action index, and final outcome.
+- [x] Store replay data in the versioned `standard-gl-self-play-replay-v1` JSONL format.
+- [x] Add replay validation that reconstructs a game from recorded actions (`-validate-replay`).
+- [x] Add basic metrics: action count, turn count, winner, resignations, average branching factor, invalid action count, and search time per action.
 - [ ] Add parallel self-play workers after the single-worker path is reliable.
 
 ## Phase 4: Neural Network
@@ -82,7 +82,7 @@ The rules/API completeness target for the initial playable environment is normal
 
 - [ ] Add head-to-head evaluation between checkpoints.
 - [ ] Add random-player and heuristic-player baselines.
-- [ ] Add deterministic smoke tests for short self-play games.
+- [x] Add deterministic smoke tests for short self-play games (`-test-replay`).
 - [ ] Track win rate, average value loss, policy loss, game length, invalid action count, and search throughput.
 - [ ] Add regression maps that cover captures, purchases, transport logic, indirect combat, powers, and end-game conditions.
 
@@ -92,13 +92,16 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] #3 Implement state tensor encoding.
 - [ ] #4 Implement action encoding and legal action masks.
 - [ ] #5 Refactor MCTS for action-level self-play and same-player turn sequences.
-- [ ] #6 Add self-play replay writer.
+- [x] #6 Add self-play replay writer.
 - [ ] #7 Add policy/value network scaffold.
 - [ ] #8 Add training command-line entry point.
 - [ ] #9 Add checkpoint evaluation harness.
 - [ ] #166 Add neural-guided MCTS with PUCT.
 - [ ] #167 Add reusable MCTS search tree re-rooting.
 - [ ] #168 Add wall-clock MCTS search limits.
+- [ ] #172 Add optional materialized replay cache for faster training loads.
+- [ ] #173 Add self-play orchestration for map pools, matchups, and side balancing.
+- [ ] #174 Add compressed self-play replay shard support.
 - [ ] #65 Define and enforce normal Global League Standard game settings.
 - [ ] #66 Add REST game lifecycle and step API contract for self-play.
 - [ ] #67 Validate and atomically reject illegal submitted actions.

--- a/docs/SELF_PLAY_REPLAYS.md
+++ b/docs/SELF_PLAY_REPLAYS.md
@@ -1,0 +1,219 @@
+# Self-Play Replay Shards
+
+Self-play replay shards are compact JSONL files produced by `-self-play` and checked by `-validate-replay`.
+
+The v1 format is `standard-gl-self-play-replay-v1`. It targets normal Global League Standard games that fit the `standard-gl-v1` action space and `standard-gl-v1-state` tensor shape.
+
+## Commands
+
+Generate one deterministic smoke replay:
+
+```powershell
+Set-Location .\AdvanceWarsServer
+..\x64\Debug\AdvanceWarsServer.exe -self-play `
+  --out ..\artifacts\replays\smoke.jsonl `
+  --map mcts `
+  --player0-co andy `
+  --player1-co adder `
+  --seed 123 `
+  --games 1 `
+  --max-actions 1000 `
+  --mcts-simulations 128
+```
+
+Validate an existing shard:
+
+```powershell
+..\x64\Debug\AdvanceWarsServer.exe -validate-replay ..\artifacts\replays\smoke.jsonl
+```
+
+`-self-play` writes the replay and then validates the whole file. If validation fails, the file is left in place for debugging and the process returns nonzero.
+
+By default, `-self-play` fails when `--out` already exists. Pass `--append` to append to an existing compatible shard. Appends validate the whole existing file first. An empty existing file is treated as a new shard and receives a fresh header.
+
+## Options
+
+Required:
+
+| Option | Meaning |
+| --- | --- |
+| `--out <path>` | Output JSONL shard. Missing parent directories are created. |
+| `--map <id>` | Supported Standard map id, currently `lefty` or `mcts`. |
+| `--player0-co <id>` | Player 0 CO id in API style, such as `andy` or `von-bolt`. |
+| `--player1-co <id>` | Player 1 CO id in API style. |
+
+Common optional settings:
+
+| Option | Default | Meaning |
+| --- | ---: | --- |
+| `--games <n>` | `1` | Number of games to write. |
+| `--seed <n>` | `0` | Base deterministic seed. Per-game combat and MCTS seeds are derived from it. |
+| `--max-actions <n>` | `1000` | Runner safety cap over all atomic actions. |
+| `--unit-cap <n>` | `50` | Standard unit cap. |
+| `--capture-limit <n>` | `21` | Standard capture limit. |
+| `--day-limit <n>` | unset | Engine day-limit rule. |
+| `--heuristic-auto-resign` | off | Opt into the existing engine army-value early resign heuristic. |
+| `--append` | off | Append to a compatible shard. |
+| `--quiet` | off | Suppress progress output, but not errors. |
+
+MCTS options:
+
+| Option | Default | Meaning |
+| --- | ---: | --- |
+| `--mcts-simulations <n>` | `128` | Root simulations per action. Must be at least `1`. |
+| `--mcts-max-nodes <n>` | `10000` | Search node cap. |
+| `--mcts-max-rollout-actions <n>` | `512` | Rollout action cap. |
+| `--mcts-exploration <x>` | `sqrt(2)` | UCT exploration constant. |
+| `--temperature <x>` | `1.0` | Visit-count action selection temperature. Use `0` for greedy highest-visit selection. |
+
+## JSONL Records
+
+Each line is one compact JSON object with an explicit `recordType`.
+
+The first line is a header:
+
+```json
+{
+  "recordType": "header",
+  "replayFormatVersion": "standard-gl-self-play-replay-v1",
+  "createdAt": "2026-06-01T00:00:00Z",
+  "versions": {
+    "stateTensor": "standard-gl-v1-state",
+    "actionSpace": "standard-gl-v1"
+  },
+  "config": {
+    "mapId": "mcts",
+    "player0Co": "andy",
+    "player1Co": "adder",
+    "baseSeed": 123,
+    "maxActions": 1000,
+    "settings": {},
+    "mctsOptions": {}
+  }
+}
+```
+
+Every following line is a game record. Game records are self-contained enough to inspect or validate independently:
+
+```json
+{
+  "recordType": "game",
+  "replayFormatVersion": "standard-gl-self-play-replay-v1",
+  "versions": {
+    "stateTensor": "standard-gl-v1-state",
+    "actionSpace": "standard-gl-v1"
+  },
+  "gameIndex": 0,
+  "config": {
+    "mapId": "mcts",
+    "baseSeed": 123,
+    "combatSeed": 123,
+    "mctsSeed": 1000126,
+    "maxActions": 1000,
+    "mctsOptions": {}
+  },
+  "players": [
+    { "slot": 0, "co": "andy", "armyType": "orange-star" },
+    { "slot": 1, "co": "adder", "armyType": "blue-moon" }
+  ],
+  "settings": {},
+  "initialState": {},
+  "actions": [],
+  "samples": [],
+  "finalState": {},
+  "terminalReason": "action-limit",
+  "winner": null,
+  "metrics": {}
+}
+```
+
+`initialState` and `finalState` are full authoritative engine states. They intentionally include exact hidden information because replay shards are training/debug artifacts, not player-facing API responses.
+
+## Actions And Samples
+
+There is exactly one sample for every applied atomic action:
+
+```text
+actions.length == samples.length
+```
+
+`ply` is zero-based. Sample `ply: 0` is the pre-action state for `actions[0]`.
+
+Action history entries contain raw action JSON plus the stable encoded action index:
+
+```json
+{
+  "ply": 0,
+  "player": 0,
+  "actionIndex": 1554363,
+  "action": { "type": "end-turn" }
+}
+```
+
+Samples contain compact training targets:
+
+```json
+{
+  "ply": 0,
+  "currentPlayer": 0,
+  "stateTensorChecksum": "0123456789abcdef",
+  "legalActionCount": 3,
+  "legalActionIndices": [1203, 98112, 1554363],
+  "visitCounts": [
+    { "actionIndex": 1203, "visits": 18 },
+    { "actionIndex": 1554363, "visits": 110 }
+  ],
+  "selectedActionIndex": 1554363,
+  "outcome": -1,
+  "mcts": {
+    "mctsSeed": 3992670690,
+    "simulationsRun": 128,
+    "nodesCreated": 128,
+    "searchTimeMs": 14.7
+  }
+}
+```
+
+Replay v1 does not store dense state tensors or dense legal action masks. Validation rebuilds the state from `initialState` plus `actions[0..ply)`, regenerates the tensor checksum and sparse legal action indices, and compares them exactly.
+
+`visitCounts` stores positive visits only, sorted by `actionIndex`. Legal actions with zero visits are implied by `legalActionIndices`.
+
+`outcome` is from the sample's `currentPlayer` perspective:
+
+- `1`: current player eventually won
+- `-1`: current player eventually lost
+- `0`: draw or runner safety stop
+
+## Terminal Handling
+
+Engine terminal states store the engine winner and terminal reason. If `--heuristic-auto-resign` is enabled and the engine emits `heuristic-resign`, samples receive normal win/loss outcomes.
+
+If the runner reaches `--max-actions` before the engine is terminal, the game record uses:
+
+```json
+{
+  "terminalReason": "action-limit",
+  "winner": null
+}
+```
+
+All sample outcomes for an action-limit game are `0`.
+
+## Validation Rules
+
+`-validate-replay` is strict for v1:
+
+- unknown fields are rejected
+- replay, state tensor, and action-space versions must match this binary
+- action history must replay from `initialState` to `finalState`
+- every sample's tensor checksum and sparse legal action indices must match the replayed pre-action state
+- selected actions must be legal and have positive MCTS visits
+- `sum(visitCounts.visits)` must equal `mcts.simulationsRun`
+- `actions.length` must equal `samples.length`
+- timing metrics must be present and nonnegative
+
+Validation does not rerun MCTS. It treats visit counts as recorded search output and checks structural consistency.
+
+## Deferred Optimizations
+
+The v1 shard is plain JSONL. Follow-up work tracks derived materialized caches (#172), map/matchup orchestration and side balancing (#173), and compressed shard support (#174).

--- a/docs/TRAINING_DESIGN.md
+++ b/docs/TRAINING_DESIGN.md
@@ -52,6 +52,8 @@ Replay data should be versioned and compact. Each sample should include:
 
 Do not store dense legal masks in replay. A dense mask for `standard-gl-v1` is about 1.55 MB per state, which grows too quickly. Materialize dense masks only for the active training batch if the loss implementation needs them.
 
+The v1 C++ replay writer emits sparse JSONL shards using `standard-gl-self-play-replay-v1`; see `docs/SELF_PLAY_REPLAYS.md` for the command and schema. The canonical replay stores full initial/final engine states, raw action history, sparse legal action indices, sparse positive MCTS visit counts, per-sample tensor checksums, and current-player-relative outcomes. Dense tensors and masks remain derived data.
+
 ## Training Loop
 
 Training should sample replay positions, rebuild tensors, expand sparse legal indices for masking, and optimize two losses:
@@ -77,4 +79,4 @@ CO matchup and pregame selection metrics should feed the later CO picker, not th
 
 ## Recommended First Milestone
 
-The first useful milestone is a single-worker self-play runner that writes sparse replay shards from deterministic games on a small Standard GL map set. Once replay validation is reliable, add the neural trainer and only then scale to parallel self-play workers.
+The first useful milestone is a single-worker self-play runner that writes validated sparse replay shards from deterministic games on a small Standard GL map set. Once replay validation is reliable, add the neural trainer and only then scale to parallel self-play workers.


### PR DESCRIPTION
## Summary
- Add a single-worker `-self-play` command that writes validated sparse JSONL replay shards for Standard GL games.
- Add strict `-validate-replay` reconstruction checks for header/game schema, state tensor checksums, sparse legal actions, positive MCTS visit counts, selected action legality, outcomes, final state, and metrics.
- Share Standard game setup between REST game creation and self-play, and document the command/schema in `docs/SELF_PLAY_REPLAYS.md` plus the build/test docs.

## Verification
- `MSBuild AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test-replay`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test-mcts`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- CLI smoke: `-self-play --out <temp> --map mcts --player0-co andy --player1-co adder --games 1 --max-actions 2 --mcts-simulations 1 --mcts-max-nodes 16 --mcts-max-rollout-actions 4 --temperature 0 --seed 31 --quiet`, followed by `-validate-replay <temp>`

## Follow-ups
- #172 materialized replay cache for faster training loads
- #173 map/matchup orchestration and side balancing
- #174 compressed replay shards

Closes #6