### PR TITLE
Refresh self-play training loop work items

### DIFF
--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -17,7 +17,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] Decide how combat luck should work during self-play. V1 uses seeded deterministic combat RNG derived from the self-play setup seed; averaged or disabled luck can remain a later experiment if training quality needs it.
 - [x] Decide whether v1 includes fog, hidden units, CO powers, transports, naval units, and all unit types. V1 targets normal Global League Standard: fog disabled, CO powers enabled, transports/naval units in scope, and Standard unit bans/settings enforced through setup.
 - [x] Decide the first map set for self-play. The bootstrap runner/API map catalog currently supports `lefty` and `mcts`; broader map pools and side balancing are tracked by #173.
-- [ ] Decide whether training should run inside the C++ executable only, or whether C++ should expose an environment API for a Python training process.
+- [x] Decide whether training should run inside the C++ executable only, or whether C++ should expose an environment API for a Python training process. V1 training stays inside the C++ executable with LibTorch; a Python environment API is deferred unless replay-driven C++ training becomes the bottleneck.
 
 ## Phase 0: Stabilize The Simulator
 

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -14,15 +14,15 @@ The rules/API completeness target for the initial playable environment is normal
 ## Open Product Decisions
 
 - [x] Decide whether v1 targets full AWBW fidelity or a simplified deterministic subset. V1 targets normal Global League Standard play, with other modes explicitly deferred in `STANDARD_ENGINE_COMPLETENESS.md`.
-- [ ] Decide how combat luck should work during self-play: disabled, averaged, or seeded.
-- [ ] Decide whether v1 includes fog, hidden units, CO powers, transports, naval units, and all unit types.
-- [ ] Decide the first map set for self-play. Small maps will make early iteration much faster.
+- [x] Decide how combat luck should work during self-play. V1 uses seeded deterministic combat RNG derived from the self-play setup seed; averaged or disabled luck can remain a later experiment if training quality needs it.
+- [x] Decide whether v1 includes fog, hidden units, CO powers, transports, naval units, and all unit types. V1 targets normal Global League Standard: fog disabled, CO powers enabled, transports/naval units in scope, and Standard unit bans/settings enforced through setup.
+- [x] Decide the first map set for self-play. The bootstrap runner/API map catalog currently supports `lefty` and `mcts`; broader map pools and side balancing are tracked by #173.
 - [ ] Decide whether training should run inside the C++ executable only, or whether C++ should expose an environment API for a Python training process.
 
 ## Phase 0: Stabilize The Simulator
 
-- [ ] Run the JSON subsystem tests from a current build and make failures visible in CI or local output.
-- [ ] Fix action deserialization for `unloadIndex`; it is read but not assigned to `Action::m_optUnloadIndex`. Track under submitted-action validation work in #67 if still present.
+- [x] Run the JSON subsystem tests from a current build and make failures visible in CI or local output. Confirmed locally on 2026-06-06 with `-test test/json`.
+- [x] Fix action deserialization for `unloadIndex`; action JSON now assigns `Action::m_optUnloadIndex`, equality includes it, and REST/action-space tests cover unload-index handling (#4, #67).
 - [x] Fix capture-limit property counting. Capture-limit wins count Cities, Bases, Airports, Ports, and HQs, excluding Labs and Com Towers (#73).
 - [ ] Audit unit count caching around load/unload, clone, add, and destroy paths before relying on unit-cap logic in training.
 - [ ] Replace hardcoded local paths such as `D:/awai`, `D:/MNIST`, and local libtorch directories with config or command-line options.
@@ -31,13 +31,13 @@ The rules/API completeness target for the initial playable environment is normal
 
 ## Phase 1: Trainable Environment API
 
-- [ ] Add a small environment wrapper around `GameState`; the REST/self-play API contract is tracked by #66.
-- [ ] Expose `reset`, `legalActions`, `step`, `isTerminal`, `currentPlayer`, and `winner` operations.
-- [ ] Add stable state serialization for replay data.
+- [x] Add a small environment wrapper around `GameState`; `RestGameService`, `StandardGameSetup`, and the self-play runner now create Standard games and step through engine-owned actions (#66).
+- [x] Expose create/reset-by-recreate, legal actions, step, terminal status, current player, and winner through the REST/self-play contract. V1 intentionally recreates from setup instead of exposing a mutable reset endpoint (#66).
+- [x] Add stable state serialization for replay data via full initial/final engine states and `SerializeGameStateForReplay`.
 - [x] Add state tensor encoding in `Tensor.cpp` (#3).
-- [ ] Add a stable action encoding scheme for every `Action` variant (#4).
-- [ ] Add legal action masks aligned with the action encoding (#4).
-- [ ] Add tests proving encode/decode preserves actions, including move-attack, unload, buy, powers, and end-turn.
+- [x] Add a stable action encoding scheme for every in-game `Action` variant (#4).
+- [x] Add legal action masks aligned with the action encoding (#4).
+- [x] Add tests proving encode/decode preserves actions, including move-attack, unload, buy, powers, and end-turn.
 
 ## Phase 2: MCTS Improvements
 
@@ -58,13 +58,15 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] Store replay data in the versioned `standard-gl-self-play-replay-v1` JSONL format.
 - [x] Add replay validation that reconstructs a game from recorded actions (`-validate-replay`).
 - [x] Add basic metrics: action count, turn count, winner, resignations, average branching factor, invalid action count, and search time per action.
+- [ ] Add map-pool, matchup, and side-balancing orchestration on top of the single-map runner (#173).
+- [ ] Add optional compressed replay shard support after plain JSONL replay loading is stable (#174).
 - [ ] Add parallel self-play workers after the single-worker path is reliable.
 
 ## Phase 4: Neural Network
 
 - [x] Define model input planes via `standard-gl-v1-state` in `docs/STATE_TENSOR.md`.
-- [ ] Define policy head output shape matching the action encoding.
-- [ ] Define value head output as win/loss value from the current player's perspective.
+- [x] Define policy head output shape matching the action encoding: source-cell planes over `27x23` plus global logits in `docs/TRAINING_DESIGN.md`.
+- [x] Define value head output as expected win/loss result from the current player's perspective in `docs/TRAINING_DESIGN.md`.
 - [ ] Add model save/load checkpoints.
 - [ ] Add inference batching for MCTS.
 - [ ] Add CPU-only fallback so development does not depend on CUDA being configured.
@@ -74,7 +76,9 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] Add supervised-style training over replay samples.
 - [ ] Train policy with cross entropy against MCTS visit distributions.
 - [ ] Train value with mean squared error or cross entropy against final outcomes.
+- [ ] Add a replay shard reader/dataset that reconstructs tensors, sparse legal indices, dense batch-local masks, visit distributions, and outcomes from `standard-gl-self-play-replay-v1`.
 - [ ] Add replay buffer sampling and retention policy.
+- [ ] Add optional materialized replay cache for faster repeated training loads (#172).
 - [ ] Add checkpoint promotion/evaluation against previous models.
 - [ ] Add command-line options for epochs, batch size, learning rate, device, checkpoint path, and replay path.
 
@@ -84,26 +88,28 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] Add random-player and heuristic-player baselines.
 - [x] Add deterministic smoke tests for short self-play games (`-test-replay`).
 - [ ] Track win rate, average value loss, policy loss, game length, invalid action count, and search throughput.
+- [ ] Track CO matchup statistics for pregame CO selection separately from the in-game action model (#164).
 - [ ] Add regression maps that cover captures, purchases, transport logic, indirect combat, powers, and end-game conditions.
 
 ## Candidate GitHub Issues
 
 - [x] #2 Create deterministic combat RNG for self-play.
 - [x] #3 Implement state tensor encoding.
-- [ ] #4 Implement action encoding and legal action masks.
-- [ ] #5 Refactor MCTS for action-level self-play and same-player turn sequences.
+- [x] #4 Implement action encoding and legal action masks.
+- [x] #5 Refactor MCTS for action-level self-play and same-player turn sequences.
 - [x] #6 Add self-play replay writer.
 - [ ] #7 Add policy/value network scaffold.
 - [ ] #8 Add training command-line entry point.
 - [ ] #9 Add checkpoint evaluation harness.
+- [ ] #164 Track CO matchup statistics for pregame selection.
 - [ ] #166 Add neural-guided MCTS with PUCT.
 - [ ] #167 Add reusable MCTS search tree re-rooting.
 - [ ] #168 Add wall-clock MCTS search limits.
 - [ ] #172 Add optional materialized replay cache for faster training loads.
 - [ ] #173 Add self-play orchestration for map pools, matchups, and side balancing.
 - [ ] #174 Add compressed self-play replay shard support.
-- [ ] #65 Define and enforce normal Global League Standard game settings.
-- [ ] #66 Add REST game lifecycle and step API contract for self-play.
-- [ ] #67 Validate and atomically reject illegal submitted actions.
+- [x] #65 Define and enforce normal Global League Standard game settings.
+- [x] #66 Add REST game lifecycle and step API contract for self-play.
+- [x] #67 Validate and atomically reject illegal submitted actions.
 - [x] #68 Make REST action stepping explicit and remove implicit auto-end-turn.
 - [x] #69 Gate heuristic auto-resign behind an explicit setting that defaults off.

--- a/docs/TRAINING_DESIGN.md
+++ b/docs/TRAINING_DESIGN.md
@@ -56,6 +56,8 @@ The v1 C++ replay writer emits sparse JSONL shards using `standard-gl-self-play-
 
 ## Training Loop
 
+V1 training should run inside the C++ executable with LibTorch. Do not expose a Python environment API yet; the replay shard format is the language-neutral boundary for future tools if Python becomes useful for experimentation, reporting, or distributed training.
+
 Training should sample replay positions, rebuild tensors, expand sparse legal indices for masking, and optimize two losses:
 
 - policy loss against the MCTS visit distribution


### PR DESCRIPTION
## Summary

- mark completed self-play infrastructure work in `TRAINING_LOOP_WORK_ITEMS.md`, including action encoding/masks, action-level MCTS, REST contract work, Standard setup enforcement, unload-index handling, replay state serialization, and current product decisions
- add missing follow-up work for replay shard loading, materialized replay caches, map/matchup orchestration, compression, and CO matchup statistics
- align the candidate issue checklist with currently closed/open GitHub issues

## Verification

- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test-mcts`
- `..\x64\Debug\AdvanceWarsServer.exe -test-replay`