### PR TITLE
Add policy/value network scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 
+# Local training/model artifacts
+checkpoints/
+*.pt
+*.pth
+
 *_i.c
 *_p.c
 *_i.h

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -69,22 +69,26 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Label="UserMacros">
+    <UseLibtorchCuda Condition="'$(UseLibtorchCuda)'==''">false</UseLibtorchCuda>
+    <LibtorchBaseDependencies>$(LIBTORCH_ROOT)\lib\c10.lib;$(LIBTORCH_ROOT)\lib\torch.lib;$(LIBTORCH_ROOT)\lib\torch_cpu.lib;$(LIBTORCH_ROOT)\lib\kineto.lib</LibtorchBaseDependencies>
+    <LibtorchCudaDependencies>$(LIBTORCH_ROOT)\lib\caffe2_nvrtc.lib;$(LIBTORCH_ROOT)\lib\c10_cuda.lib;$(LIBTORCH_ROOT)\lib\torch_cuda.lib;$(CUDA_PATH)\lib\x64\cublas.lib;$(CUDA_PATH)\lib\x64\cudart.lib;$(CUDA_PATH)\lib\x64\cufft.lib;$(CUDA_PATH)\lib\x64\curand.lib;$(CUDNN_LIB_PATH)\cudnn.lib;$(NVTOOLSEXT_PATH)\lib\x64\nvToolsExt64_1.lib;-INCLUDE:?warp_size@cuda@at@@YAHXZ</LibtorchCudaDependencies>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\include;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\include\torch\csrc\api\include;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
-    <LibraryPath>D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(LIBTORCH_ROOT)\include;$(LIBTORCH_ROOT)\include\torch\csrc\api\include;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LIBTORCH_ROOT)\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\torch\csrc\api\include;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
-    <LibraryPath>D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\bin;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(LIBTORCH_ROOT)\include;$(LIBTORCH_ROOT)\include\torch\csrc\api\include;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\deps\json-develop\single_include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LIBTORCH_ROOT)\bin;$(LIBTORCH_ROOT)\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -107,16 +111,19 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseLibtorchCuda)'!='true'">_ITERATOR_DEBUG_LEVEL=0;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseLibtorchCuda)'=='true'">AW_USE_LIBTORCH_CUDA;_ITERATOR_DEBUG_LEVEL=0;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)inc;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)inc;$(LIBTORCH_ROOT)\include;$(LIBTORCH_ROOT)\include\torch\csrc\api\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>rpcrt4.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\caffe2_nvrtc.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\c10.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\c10_cuda.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\kineto.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\torch.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\torch_cpu.lib;D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch\lib\torch_cuda.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cublas.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cudart.lib;C:\Program Files\NVIDIA\CUDNN\v9.7\lib\11.8\x64\cudnn.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cufft.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\curand.lib;C:\Program Files\NVIDIA Corporation\NvToolsExt\lib\x64\nvToolsExt64_1.lib;-INCLUDE:?warp_size@cuda@at@@YAHXZ;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseLibtorchCuda)'!='true'">rpcrt4.lib;$(LibtorchBaseDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseLibtorchCuda)'=='true'">rpcrt4.lib;$(LibtorchBaseDependencies);$(LibtorchCudaDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -147,17 +154,19 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseLibtorchCuda)'!='true'">_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseLibtorchCuda)'=='true'">AW_USE_LIBTORCH_CUDA;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;ASIO_STANDALONE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(ProjectDir)inc;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include\torch\csrc\api\include;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)inc;$(LIBTORCH_ROOT)\include;$(LIBTORCH_ROOT)\include\torch\csrc\api\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>rpcrt4.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\caffe2_nvrtc.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\c10.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\c10_cuda.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\kineto.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\torch.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\torch_cpu.lib;D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch\lib\torch_cuda.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cublas.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cudart.lib;C:\Program Files\NVIDIA\CUDNN\v9.7\lib\11.8\x64\cudnn.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\cufft.lib;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\lib\x64\curand.lib;C:\Program Files\NVIDIA Corporation\NvToolsExt\lib\x64\nvToolsExt64_1.lib;-INCLUDE:?warp_size@cuda@at@@YAHXZ;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseLibtorchCuda)'!='true'">rpcrt4.lib;$(LibtorchBaseDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(UseLibtorchCuda)'=='true'">rpcrt4.lib;$(LibtorchBaseDependencies);$(LibtorchCudaDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -172,6 +181,9 @@
     <ClCompile Include="src\MapTile.cpp" />
     <ClCompile Include="src\MctsTest.cpp" />
     <ClCompile Include="src\Player.cpp" />
+    <ClCompile Include="src\PolicyValueModel.cpp" />
+    <ClCompile Include="src\PolicyValueModelCommands.cpp" />
+    <ClCompile Include="src\PolicyValueModelTest.cpp" />
     <ClCompile Include="src\RestGameService.cpp" />
     <ClCompile Include="src\SelfPlayReplay.cpp" />
     <ClCompile Include="src\SelfPlayReplayTest.cpp" />
@@ -201,6 +213,9 @@
     <ClInclude Include="inc\MonteCarloTreeSearch.h" />
     <ClInclude Include="inc\MovementTypes.h" />
     <ClInclude Include="inc\Platform.h" />
+    <ClInclude Include="inc\PolicyValueModel.h" />
+    <ClInclude Include="inc\PolicyValueModelCommands.h" />
+    <ClInclude Include="inc\PolicyValueModelTest.h" />
     <ClInclude Include="inc\Player.h" />
     <ClInclude Include="inc\Result.h" />
     <ClInclude Include="inc\RestGameService.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -78,6 +78,15 @@
     <ClCompile Include="src\MctsTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\PolicyValueModelTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\PolicyValueModel.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\PolicyValueModelCommands.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\SelfPlayReplayTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -174,6 +183,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\MctsTest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\PolicyValueModelTest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\PolicyValueModel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\PolicyValueModelCommands.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\SelfPlayReplayTest.h">

--- a/AdvanceWarsServer/inc/PolicyValueModel.h
+++ b/AdvanceWarsServer/inc/PolicyValueModel.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <torch/torch.h>
+
+#include "Result.h"
+
+struct PolicyValueModelConfig {
+	int hiddenChannels{ 64 };
+	int residualBlocks{ 4 };
+	int normGroups{ 8 };
+};
+
+struct PolicyValueModelError {
+	std::string code;
+	std::string message;
+};
+
+struct PolicyValueNetworkOutput {
+	torch::Tensor policyLogits;
+	torch::Tensor value;
+};
+
+class PolicyValueNetworkImpl : public torch::nn::Module {
+public:
+	explicit PolicyValueNetworkImpl(const PolicyValueModelConfig& config);
+	PolicyValueNetworkOutput forward(torch::Tensor input);
+	const PolicyValueModelConfig& Config() const noexcept;
+	void ResetParameters();
+
+private:
+	PolicyValueModelConfig m_config;
+	torch::nn::Conv2d m_inputConv{ nullptr };
+	torch::nn::GroupNorm m_inputNorm{ nullptr };
+	torch::nn::ModuleList m_residualBlocks{ nullptr };
+	torch::nn::Conv2d m_policyConv{ nullptr };
+	torch::nn::Linear m_globalPolicy{ nullptr };
+	torch::nn::Conv2d m_valueConv{ nullptr };
+	torch::nn::Linear m_valueHidden{ nullptr };
+	torch::nn::Linear m_valueOutput{ nullptr };
+};
+
+TORCH_MODULE(PolicyValueNetwork);
+
+const char* PolicyValueModelVersion() noexcept;
+int PolicyValuePolicyPlaneCount() noexcept;
+int PolicyValueGlobalActionCount() noexcept;
+bool PolicyValueCudaAvailable() noexcept;
+int PolicyValueCudaDeviceCount() noexcept;
+Result ValidatePolicyValueModelConfig(const PolicyValueModelConfig& config, PolicyValueModelError& error) noexcept;
+torch::Device ResolvePolicyValueDevice(const std::string& deviceName, PolicyValueModelError& error) noexcept;
+std::string PolicyValueDeviceName(const torch::Device& device);
+PolicyValueNetwork CreatePolicyValueNetwork(const PolicyValueModelConfig& config, std::int64_t seed);
+std::int64_t CountPolicyValueParameters(const PolicyValueNetwork& model);
+Result RunPolicyValueInference(PolicyValueNetwork& model, torch::Tensor input, PolicyValueNetworkOutput& output, PolicyValueModelError& error) noexcept;
+Result RunPolicyValueInference(PolicyValueNetwork& model, const std::vector<float>& flatBatch, int batchSize, PolicyValueNetworkOutput& output, PolicyValueModelError& error) noexcept;
+Result SavePolicyValueCheckpoint(
+	const std::filesystem::path& checkpointDir,
+	PolicyValueNetwork& model,
+	const PolicyValueModelConfig& config,
+	std::int64_t seed,
+	const std::string& validatedDevice,
+	bool force,
+	PolicyValueModelError& error) noexcept;
+Result LoadPolicyValueCheckpoint(
+	const std::filesystem::path& checkpointDir,
+	PolicyValueNetwork& model,
+	PolicyValueModelConfig& config,
+	std::int64_t& seed,
+	PolicyValueModelError& error) noexcept;

--- a/AdvanceWarsServer/inc/PolicyValueModelCommands.h
+++ b/AdvanceWarsServer/inc/PolicyValueModelCommands.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int RunModelInitCommand(int argc, char* argv[]) noexcept;
+int RunTorchLibCommand(int argc, char* argv[]) noexcept;

--- a/AdvanceWarsServer/inc/PolicyValueModelTest.h
+++ b/AdvanceWarsServer/inc/PolicyValueModelTest.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int RunPolicyValueModelTests(int argc, char* argv[]) noexcept;

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -8,11 +8,12 @@
 #include "AdvanceWarsServer.h"
 #include "MonteCarloTreeSearch.h"
 #include "MctsTest.h"
+#include "PolicyValueModelCommands.h"
+#include "PolicyValueModelTest.h"
 #include "SelfPlayReplayTest.h"
 #include "SelfPlayRunner.h"
 #include "SubsystemTest.h"
 #include "Platform.h"
-#include <torch/torch.h>
 
 int RunRestApiContractTests();
 
@@ -26,78 +27,17 @@ int main(int argc, char* argv[]) noexcept {
 			std::cerr << "  -self-play [options]  : Generate validated self-play replay JSONL.\n";
 			std::cerr << "  -validate-replay <path> : Validate a self-play replay JSONL file.\n";
 			std::cerr << "  -test-mcts            : Run focused MCTS tests.\n";
+			std::cerr << "  -test-model           : Run focused policy/value model tests.\n";
 			std::cerr << "  -test-replay          : Run focused self-play replay tests.\n";
+			std::cerr << "  -model-init --out <dir> : Initialize and validate a policy/value checkpoint bundle.\n";
+			std::cerr << "  -torchlib [--mnist-path <path>] : Run a LibTorch smoke check and optional MNIST experiment.\n";
 			std::cerr << "  -server               : Act as game server.\n";
 			return 1; // Return an error code
 		}
 
 		std::string argument = argv[1];
 		if (argument == "-torchlib") {
-
-			std::cout << "CUDA support: " << (torch::cuda::is_available() ? "true" : "false") << std::endl;
-			std::cout << "CUDA devices: " << (torch::cuda::device_count()) << std::endl;
-
-			torch::Tensor tensor = torch::rand({ 2, 3 });
-			std::cout << tensor << std::endl;
-
-			struct Net : torch::nn::Module {
-				Net()
-					: conv1(torch::nn::Conv2dOptions(1, 32, 5)),
-					conv2(torch::nn::Conv2dOptions(32, 64, 5)),
-					fc1(1024, 128),
-					fc2(128, 10) {
-					register_module("conv1", conv1);
-					register_module("conv2", conv2);
-					register_module("fc1", fc1);
-					register_module("fc2", fc2);
-				}
-
-				torch::Tensor forward(torch::Tensor x) {
-					x = torch::relu(conv1->forward(x));
-					x = torch::max_pool2d(x, 2);
-					x = torch::relu(conv2->forward(x));
-					x = torch::max_pool2d(x, 2);
-					x = x.view({ x.size(0), -1 });
-					x = torch::relu(fc1->forward(x));
-					x = fc2->forward(x);
-					return torch::log_softmax(x, 1);
-				}
-
-				torch::nn::Conv2d conv1, conv2;
-				torch::nn::Linear fc1, fc2;
-			};
-			torch::Device device(torch::cuda::is_available() ? torch::kCUDA : torch::kCPU);
-			std::cout << "Using device: " << (device.is_cuda() ? "CUDA" : "CPU") << "\n";
-
-			// Load MNIST dataset
-			auto train_dataset = torch::data::datasets::MNIST("D:/MNIST/MNIST/raw").map(
-				torch::data::transforms::Stack<>());
-			auto train_loader = torch::data::make_data_loader(std::move(train_dataset),
-				torch::data::DataLoaderOptions().batch_size(64));
-
-			// Initialize model, optimizer, and loss function
-			Net model;
-			model.to(device);
-			torch::optim::SGD optimizer(model.parameters(), torch::optim::SGDOptions(0.01).momentum(0.9));
-
-			// Training loop
-			for (size_t epoch = 1; epoch <= 5; ++epoch) {
-				size_t batch_idx = 0;
-				for (auto& batch : *train_loader) {
-					model.train();
-					auto data = batch.data.to(device), targets = batch.target.to(device);
-					optimizer.zero_grad();
-					auto output = model.forward(data);
-					auto loss = torch::nll_loss(output, targets);
-					loss.backward();
-					optimizer.step();
-
-					if (batch_idx++ % 100 == 0) {
-						std::cout << "Train Epoch: " << epoch << " [" << batch_idx * 64
-							<< "/60000] Loss: " << loss.item<float>() << "\n";
-					}
-				}
-			}
+			return RunTorchLibCommand(argc - 2, argv + 2);
 		}
 		else if (argument == "-sim-random-move-game") {
 			std::uint32_t randomMoveSeed = std::random_device{}();
@@ -270,6 +210,12 @@ int main(int argc, char* argv[]) noexcept {
 		}
 		else if (argument == "-test-mcts") {
 			return RunMctsTests();
+		}
+		else if (argument == "-test-model") {
+			return RunPolicyValueModelTests(argc - 2, argv + 2);
+		}
+		else if (argument == "-model-init") {
+			return RunModelInitCommand(argc - 2, argv + 2);
 		}
 		else if (argument == "-test-replay") {
 			return RunSelfPlayReplayTests();

--- a/AdvanceWarsServer/src/PolicyValueModel.cpp
+++ b/AdvanceWarsServer/src/PolicyValueModel.cpp
@@ -1,0 +1,627 @@
+#include "PolicyValueModel.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <ctime>
+#include <fstream>
+#include <limits>
+#include <set>
+#include <sstream>
+
+#include <ATen/CPUGeneratorImpl.h>
+
+#include "ActionSpace.h"
+#include "StateTensor.h"
+#include "nlohmann/json.hpp"
+
+namespace {
+using ordered_json = nlohmann::ordered_json;
+using json = nlohmann::json;
+
+constexpr int kMetadataVersion = 1;
+constexpr const char* kModelVersion = "standard-gl-policy-value-v1";
+constexpr int kPolicyPlaneCount = 2503;
+constexpr int kGlobalActionCount = 3;
+constexpr int kValueSize = 1;
+constexpr double kHeadInitStdDev = 0.01;
+
+void SetError(PolicyValueModelError& error, const std::string& code, const std::string& message) noexcept {
+	error.code = code;
+	error.message = message;
+}
+
+void ClearError(PolicyValueModelError& error) noexcept {
+	error.code.clear();
+	error.message.clear();
+}
+
+std::int64_t ValuesPerState() noexcept {
+	return static_cast<std::int64_t>(StateTensor::ChannelCount()) *
+		StateTensor::BoardHeight() *
+		StateTensor::BoardWidth();
+}
+
+bool PolicyLayoutMatchesActionSpace() noexcept {
+	return kPolicyPlaneCount * StateTensor::BoardHeight() * StateTensor::BoardWidth() + kGlobalActionCount == ActionSpace::ActionCount();
+}
+
+class PolicyValueResidualBlockImpl final : public torch::nn::Module {
+public:
+	PolicyValueResidualBlockImpl(int channels, int normGroups) :
+		m_conv1(torch::nn::Conv2dOptions(channels, channels, 3).padding(1)),
+		m_norm1(torch::nn::GroupNormOptions(normGroups, channels)),
+		m_conv2(torch::nn::Conv2dOptions(channels, channels, 3).padding(1)),
+		m_norm2(torch::nn::GroupNormOptions(normGroups, channels)) {
+		register_module("conv1", m_conv1);
+		register_module("norm1", m_norm1);
+		register_module("conv2", m_conv2);
+		register_module("norm2", m_norm2);
+	}
+
+	torch::Tensor forward(torch::Tensor input) {
+		torch::Tensor residual = input;
+		torch::Tensor x = torch::relu(m_norm1->forward(m_conv1->forward(input)));
+		x = m_norm2->forward(m_conv2->forward(x));
+		return torch::relu(x + residual);
+	}
+
+	torch::nn::Conv2d m_conv1{ nullptr };
+	torch::nn::GroupNorm m_norm1{ nullptr };
+	torch::nn::Conv2d m_conv2{ nullptr };
+	torch::nn::GroupNorm m_norm2{ nullptr };
+};
+
+TORCH_MODULE(PolicyValueResidualBlock);
+
+void InitializeConv(torch::nn::Conv2d& conv, bool smallHead) {
+	if (smallHead) {
+		torch::nn::init::normal_(conv->weight, 0.0, kHeadInitStdDev);
+	}
+	else {
+		torch::nn::init::kaiming_normal_(conv->weight, 0.0, torch::kFanOut, torch::kReLU);
+	}
+
+	if (conv->bias.defined()) {
+		torch::nn::init::zeros_(conv->bias);
+	}
+}
+
+void InitializeLinear(torch::nn::Linear& linear, bool smallHead) {
+	if (smallHead) {
+		torch::nn::init::normal_(linear->weight, 0.0, kHeadInitStdDev);
+	}
+	else {
+		torch::nn::init::kaiming_normal_(linear->weight, 0.0, torch::kFanOut, torch::kReLU);
+	}
+
+	if (linear->bias.defined()) {
+		torch::nn::init::zeros_(linear->bias);
+	}
+}
+
+void InitializeGroupNorm(torch::nn::GroupNorm& norm) {
+	if (norm->weight.defined()) {
+		torch::nn::init::ones_(norm->weight);
+	}
+	if (norm->bias.defined()) {
+		torch::nn::init::zeros_(norm->bias);
+	}
+}
+
+std::string CurrentUtcTimestamp() {
+	std::time_t now = std::time(nullptr);
+	std::tm utc{};
+	gmtime_s(&utc, &now);
+	char buffer[32]{};
+	std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &utc);
+	return buffer;
+}
+
+ordered_json BuildMetadata(const PolicyValueModelConfig& config, std::int64_t seed, const std::string& validatedDevice, std::int64_t parameterCount) {
+	ordered_json metadata;
+	metadata["metadataVersion"] = kMetadataVersion;
+	metadata["modelVersion"] = kModelVersion;
+	metadata["createdAt"] = CurrentUtcTimestamp();
+	metadata["validatedDevice"] = validatedDevice;
+	metadata["seed"] = seed;
+	metadata["architecture"] = ordered_json{
+		{ "hiddenChannels", config.hiddenChannels },
+		{ "residualBlocks", config.residualBlocks },
+		{ "normGroups", config.normGroups },
+		{ "policyPlaneCount", kPolicyPlaneCount },
+		{ "globalActionCount", kGlobalActionCount },
+	};
+	metadata["stateTensor"] = ordered_json{
+		{ "version", StateTensor::Version() },
+		{ "channels", StateTensor::ChannelCount() },
+		{ "height", StateTensor::BoardHeight() },
+		{ "width", StateTensor::BoardWidth() },
+	};
+	metadata["actionSpace"] = ordered_json{
+		{ "version", ActionSpace::Version() },
+		{ "actionCount", ActionSpace::ActionCount() },
+	};
+	metadata["outputs"] = ordered_json{
+		{ "policyLogits", ActionSpace::ActionCount() },
+		{ "value", kValueSize },
+	};
+	metadata["parameterCount"] = parameterCount;
+	return metadata;
+}
+
+bool HasOnlyFields(const json& object, const std::vector<std::string>& allowedFields, std::string& invalidField) {
+	if (!object.is_object()) {
+		invalidField.clear();
+		return false;
+	}
+
+	for (auto it = object.begin(); it != object.end(); ++it) {
+		if (std::find(allowedFields.begin(), allowedFields.end(), it.key()) == allowedFields.end()) {
+			invalidField = it.key();
+			return false;
+		}
+	}
+	return true;
+}
+
+Result RequireObjectFields(const json& object, const std::vector<std::string>& fields, const std::string& label, PolicyValueModelError& error) {
+	std::string invalidField;
+	if (!HasOnlyFields(object, fields, invalidField)) {
+		const std::string message = invalidField.empty() ? label + " must be an object" : label + " contains unknown field: " + invalidField;
+		SetError(error, "metadata-schema-error", message);
+		return Result::Failed;
+	}
+
+	for (const std::string& field : fields) {
+		if (!object.contains(field)) {
+			SetError(error, "metadata-schema-error", label + " is missing required field: " + field);
+			return Result::Failed;
+		}
+	}
+	return Result::Succeeded;
+}
+
+template<typename T>
+Result RequireValue(const json& object, const std::string& field, const T& expected, const std::string& label, PolicyValueModelError& error) {
+	if (!object.contains(field) || object.at(field) != expected) {
+		std::ostringstream message;
+		message << label << "." << field << " is incompatible";
+		SetError(error, "metadata-incompatible", message.str());
+		return Result::Failed;
+	}
+	return Result::Succeeded;
+}
+
+Result ParseMetadata(const json& metadata, PolicyValueModelConfig& config, std::int64_t& seed, std::int64_t& parameterCount, PolicyValueModelError& error) {
+	IfFailedReturn(RequireObjectFields(metadata, {
+		"metadataVersion",
+		"modelVersion",
+		"createdAt",
+		"validatedDevice",
+		"seed",
+		"architecture",
+		"stateTensor",
+		"actionSpace",
+		"outputs",
+		"parameterCount",
+	}, "metadata", error));
+
+	IfFailedReturn(RequireValue(metadata, "metadataVersion", kMetadataVersion, "metadata", error));
+	IfFailedReturn(RequireValue(metadata, "modelVersion", std::string(kModelVersion), "metadata", error));
+
+	if (!metadata.at("seed").is_number_integer()) {
+		SetError(error, "metadata-schema-error", "metadata.seed must be an integer");
+		return Result::Failed;
+	}
+	seed = metadata.at("seed").get<std::int64_t>();
+	if (seed < 0) {
+		SetError(error, "metadata-schema-error", "metadata.seed must be non-negative");
+		return Result::Failed;
+	}
+	if (!metadata.at("parameterCount").is_number_integer()) {
+		SetError(error, "metadata-schema-error", "metadata.parameterCount must be an integer");
+		return Result::Failed;
+	}
+	parameterCount = metadata.at("parameterCount").get<std::int64_t>();
+	if (parameterCount <= 0) {
+		SetError(error, "metadata-schema-error", "metadata.parameterCount must be positive");
+		return Result::Failed;
+	}
+
+	const json& architecture = metadata.at("architecture");
+	IfFailedReturn(RequireObjectFields(architecture, {
+		"hiddenChannels",
+		"residualBlocks",
+		"normGroups",
+		"policyPlaneCount",
+		"globalActionCount",
+	}, "architecture", error));
+
+	if (!architecture.at("hiddenChannels").is_number_integer() ||
+		!architecture.at("residualBlocks").is_number_integer() ||
+		!architecture.at("normGroups").is_number_integer()) {
+		SetError(error, "metadata-schema-error", "architecture numeric fields must be integers");
+		return Result::Failed;
+	}
+
+	config.hiddenChannels = architecture.at("hiddenChannels").get<int>();
+	config.residualBlocks = architecture.at("residualBlocks").get<int>();
+	config.normGroups = architecture.at("normGroups").get<int>();
+	IfFailedReturn(RequireValue(architecture, "policyPlaneCount", kPolicyPlaneCount, "architecture", error));
+	IfFailedReturn(RequireValue(architecture, "globalActionCount", kGlobalActionCount, "architecture", error));
+
+	const json& stateTensor = metadata.at("stateTensor");
+	IfFailedReturn(RequireObjectFields(stateTensor, { "version", "channels", "height", "width" }, "stateTensor", error));
+	IfFailedReturn(RequireValue(stateTensor, "version", std::string(StateTensor::Version()), "stateTensor", error));
+	IfFailedReturn(RequireValue(stateTensor, "channels", StateTensor::ChannelCount(), "stateTensor", error));
+	IfFailedReturn(RequireValue(stateTensor, "height", StateTensor::BoardHeight(), "stateTensor", error));
+	IfFailedReturn(RequireValue(stateTensor, "width", StateTensor::BoardWidth(), "stateTensor", error));
+
+	const json& actionSpace = metadata.at("actionSpace");
+	IfFailedReturn(RequireObjectFields(actionSpace, { "version", "actionCount" }, "actionSpace", error));
+	IfFailedReturn(RequireValue(actionSpace, "version", std::string(ActionSpace::Version()), "actionSpace", error));
+	IfFailedReturn(RequireValue(actionSpace, "actionCount", ActionSpace::ActionCount(), "actionSpace", error));
+
+	const json& outputs = metadata.at("outputs");
+	IfFailedReturn(RequireObjectFields(outputs, { "policyLogits", "value" }, "outputs", error));
+	IfFailedReturn(RequireValue(outputs, "policyLogits", ActionSpace::ActionCount(), "outputs", error));
+	IfFailedReturn(RequireValue(outputs, "value", kValueSize, "outputs", error));
+
+	return ValidatePolicyValueModelConfig(config, error);
+}
+
+Result PrepareCheckpointDirectory(const std::filesystem::path& checkpointDir, bool force, PolicyValueModelError& error) {
+	const std::filesystem::path metadataPath = checkpointDir / "metadata.json";
+	const std::filesystem::path modelPath = checkpointDir / "model.pt";
+
+	if (std::filesystem::exists(checkpointDir)) {
+		if (!std::filesystem::is_directory(checkpointDir)) {
+			SetError(error, "checkpoint-path-not-directory", "checkpoint path exists but is not a directory");
+			return Result::Failed;
+		}
+		if (!force) {
+			SetError(error, "checkpoint-exists", "checkpoint directory already exists; pass --force to overwrite known bundle files");
+			return Result::Failed;
+		}
+
+		for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(checkpointDir)) {
+			const std::filesystem::path filename = entry.path().filename();
+			if (filename != "metadata.json" && filename != "model.pt") {
+				SetError(error, "checkpoint-has-unexpected-file", "checkpoint directory contains unexpected file: " + filename.string());
+				return Result::Failed;
+			}
+		}
+		std::filesystem::remove(metadataPath);
+		std::filesystem::remove(modelPath);
+		return Result::Succeeded;
+	}
+
+	const std::filesystem::path parent = checkpointDir.parent_path();
+	if (!parent.empty()) {
+		std::filesystem::create_directories(parent);
+	}
+	std::filesystem::create_directory(checkpointDir);
+	return Result::Succeeded;
+}
+
+Result ValidateInputTensor(const torch::Tensor& input, PolicyValueModelError& error) noexcept {
+	if (input.dim() != 4) {
+		SetError(error, "invalid-input-shape", "input tensor must have shape [N, C, H, W]");
+		return Result::Failed;
+	}
+	if (input.size(0) <= 0) {
+		SetError(error, "invalid-input-shape", "input batch size must be positive");
+		return Result::Failed;
+	}
+	if (input.size(1) != StateTensor::ChannelCount() ||
+		input.size(2) != StateTensor::BoardHeight() ||
+		input.size(3) != StateTensor::BoardWidth()) {
+		SetError(error, "invalid-input-shape", "input tensor shape does not match StateTensor NCHW layout");
+		return Result::Failed;
+	}
+	if (input.scalar_type() != torch::kFloat32) {
+		SetError(error, "invalid-input-type", "input tensor must be float32");
+		return Result::Failed;
+	}
+	if (!input.is_contiguous()) {
+		SetError(error, "invalid-input-layout", "input tensor must be contiguous");
+		return Result::Failed;
+	}
+	return Result::Succeeded;
+}
+}
+
+PolicyValueNetworkImpl::PolicyValueNetworkImpl(const PolicyValueModelConfig& config) :
+	m_config(config),
+	m_inputConv(torch::nn::Conv2dOptions(StateTensor::ChannelCount(), config.hiddenChannels, 3).padding(1)),
+	m_inputNorm(torch::nn::GroupNormOptions(config.normGroups, config.hiddenChannels)),
+	m_residualBlocks(torch::nn::ModuleList()),
+	m_policyConv(torch::nn::Conv2dOptions(config.hiddenChannels, kPolicyPlaneCount, 1)),
+	m_globalPolicy(config.hiddenChannels, kGlobalActionCount),
+	m_valueConv(torch::nn::Conv2dOptions(config.hiddenChannels, 1, 1)),
+	m_valueHidden(StateTensor::BoardHeight() * StateTensor::BoardWidth(), config.hiddenChannels),
+	m_valueOutput(config.hiddenChannels, kValueSize) {
+	register_module("inputConv", m_inputConv);
+	register_module("inputNorm", m_inputNorm);
+	register_module("residualBlocks", m_residualBlocks);
+	for (int i = 0; i < config.residualBlocks; ++i) {
+		m_residualBlocks->push_back(PolicyValueResidualBlock(config.hiddenChannels, config.normGroups));
+	}
+	register_module("policyConv", m_policyConv);
+	register_module("globalPolicy", m_globalPolicy);
+	register_module("valueConv", m_valueConv);
+	register_module("valueHidden", m_valueHidden);
+	register_module("valueOutput", m_valueOutput);
+}
+
+PolicyValueNetworkOutput PolicyValueNetworkImpl::forward(torch::Tensor input) {
+	torch::Tensor x = torch::relu(m_inputNorm->forward(m_inputConv->forward(input)));
+	for (std::size_t i = 0; i < m_residualBlocks->size(); ++i) {
+		x = m_residualBlocks->at<PolicyValueResidualBlockImpl>(i).forward(x);
+	}
+
+	const std::int64_t batchSize = input.size(0);
+	torch::Tensor policyPlanes = m_policyConv->forward(x).view({ batchSize, -1 });
+	torch::Tensor pooled = torch::adaptive_avg_pool2d(x, { 1, 1 }).view({ batchSize, m_config.hiddenChannels });
+	torch::Tensor globalPolicy = m_globalPolicy->forward(pooled);
+
+	torch::Tensor value = torch::relu(m_valueConv->forward(x)).view({ batchSize, -1 });
+	value = torch::relu(m_valueHidden->forward(value));
+	value = torch::tanh(m_valueOutput->forward(value));
+
+	return {
+		torch::cat({ policyPlanes, globalPolicy }, 1).contiguous(),
+		value.contiguous(),
+	};
+}
+
+const PolicyValueModelConfig& PolicyValueNetworkImpl::Config() const noexcept {
+	return m_config;
+}
+
+void PolicyValueNetworkImpl::ResetParameters() {
+	InitializeConv(m_inputConv, false);
+	InitializeGroupNorm(m_inputNorm);
+	for (std::size_t i = 0; i < m_residualBlocks->size(); ++i) {
+		PolicyValueResidualBlockImpl& block = m_residualBlocks->at<PolicyValueResidualBlockImpl>(i);
+		InitializeConv(block.m_conv1, false);
+		InitializeGroupNorm(block.m_norm1);
+		InitializeConv(block.m_conv2, false);
+		InitializeGroupNorm(block.m_norm2);
+	}
+
+	InitializeConv(m_policyConv, true);
+	InitializeLinear(m_globalPolicy, true);
+	InitializeConv(m_valueConv, true);
+	InitializeLinear(m_valueHidden, false);
+	InitializeLinear(m_valueOutput, true);
+}
+
+const char* PolicyValueModelVersion() noexcept {
+	return kModelVersion;
+}
+
+int PolicyValuePolicyPlaneCount() noexcept {
+	return kPolicyPlaneCount;
+}
+
+int PolicyValueGlobalActionCount() noexcept {
+	return kGlobalActionCount;
+}
+
+bool PolicyValueCudaAvailable() noexcept {
+#ifdef AW_USE_LIBTORCH_CUDA
+	return torch::cuda::is_available();
+#else
+	return false;
+#endif
+}
+
+int PolicyValueCudaDeviceCount() noexcept {
+#ifdef AW_USE_LIBTORCH_CUDA
+	return static_cast<int>(torch::cuda::device_count());
+#else
+	return 0;
+#endif
+}
+
+Result ValidatePolicyValueModelConfig(const PolicyValueModelConfig& config, PolicyValueModelError& error) noexcept {
+	ClearError(error);
+	if (config.hiddenChannels <= 0) {
+		SetError(error, "invalid-model-config", "hiddenChannels must be positive");
+		return Result::Failed;
+	}
+	if (config.residualBlocks < 0) {
+		SetError(error, "invalid-model-config", "residualBlocks must be non-negative");
+		return Result::Failed;
+	}
+	if (config.normGroups <= 0) {
+		SetError(error, "invalid-model-config", "normGroups must be positive");
+		return Result::Failed;
+	}
+	if (config.hiddenChannels % config.normGroups != 0) {
+		SetError(error, "invalid-model-config", "hiddenChannels must be divisible by normGroups");
+		return Result::Failed;
+	}
+	if (!PolicyLayoutMatchesActionSpace()) {
+		SetError(error, "policy-layout-mismatch", "policy planes and global logits do not reconstruct ActionSpace::ActionCount");
+		return Result::Failed;
+	}
+	return Result::Succeeded;
+}
+
+torch::Device ResolvePolicyValueDevice(const std::string& deviceName, PolicyValueModelError& error) noexcept {
+	ClearError(error);
+	if (deviceName == "cpu") {
+		return torch::Device(torch::kCPU);
+	}
+	if (deviceName == "auto") {
+		return PolicyValueCudaAvailable() ? torch::Device(torch::kCUDA, 0) : torch::Device(torch::kCPU);
+	}
+	if (deviceName == "cuda") {
+		if (!PolicyValueCudaAvailable()) {
+			SetError(error, "cuda-unavailable", "CUDA was requested but is not available");
+			return torch::Device(torch::kCPU);
+		}
+		return torch::Device(torch::kCUDA, 0);
+	}
+
+	SetError(error, "invalid-device", "device must be cpu, auto, or cuda");
+	return torch::Device(torch::kCPU);
+}
+
+std::string PolicyValueDeviceName(const torch::Device& device) {
+	if (device.is_cuda()) {
+		return "cuda:" + std::to_string(device.index());
+	}
+	return "cpu";
+}
+
+PolicyValueNetwork CreatePolicyValueNetwork(const PolicyValueModelConfig& config, std::int64_t seed) {
+	auto cpuGenerator = at::detail::getDefaultCPUGenerator();
+	cpuGenerator.set_current_seed(static_cast<std::uint64_t>(seed));
+	PolicyValueNetwork model(config);
+	model->ResetParameters();
+	model->eval();
+	return model;
+}
+
+std::int64_t CountPolicyValueParameters(const PolicyValueNetwork& model) {
+	std::int64_t count = 0;
+	for (const torch::Tensor& parameter : model->parameters()) {
+		count += parameter.numel();
+	}
+	return count;
+}
+
+Result RunPolicyValueInference(PolicyValueNetwork& model, torch::Tensor input, PolicyValueNetworkOutput& output, PolicyValueModelError& error) noexcept {
+	try {
+		ClearError(error);
+		IfFailedReturn(ValidateInputTensor(input, error));
+		torch::NoGradGuard noGrad;
+		model->eval();
+		output = model->forward(input);
+		if (output.policyLogits.size(0) != input.size(0) ||
+			output.policyLogits.size(1) != ActionSpace::ActionCount() ||
+			output.value.size(0) != input.size(0) ||
+			output.value.size(1) != kValueSize) {
+			SetError(error, "invalid-output-shape", "model output shape does not match policy/value contract");
+			return Result::Failed;
+		}
+		return Result::Succeeded;
+	}
+	catch (const std::exception& err) {
+		SetError(error, "inference-failed", err.what());
+		return Result::Failed;
+	}
+}
+
+Result RunPolicyValueInference(PolicyValueNetwork& model, const std::vector<float>& flatBatch, int batchSize, PolicyValueNetworkOutput& output, PolicyValueModelError& error) noexcept {
+	try {
+		ClearError(error);
+		if (batchSize <= 0) {
+			SetError(error, "invalid-input-shape", "batchSize must be positive");
+			return Result::Failed;
+		}
+		const std::int64_t expectedValues = ValuesPerState() * batchSize;
+		if (flatBatch.size() != static_cast<std::size_t>(expectedValues)) {
+			SetError(error, "invalid-input-shape", "flat batch size does not match StateTensor shape and batchSize");
+			return Result::Failed;
+		}
+
+		torch::Tensor input = torch::from_blob(
+			const_cast<float*>(flatBatch.data()),
+			{ batchSize, StateTensor::ChannelCount(), StateTensor::BoardHeight(), StateTensor::BoardWidth() },
+			torch::TensorOptions().dtype(torch::kFloat32)).clone().contiguous();
+		return RunPolicyValueInference(model, input, output, error);
+	}
+	catch (const std::exception& err) {
+		SetError(error, "inference-failed", err.what());
+		return Result::Failed;
+	}
+}
+
+Result SavePolicyValueCheckpoint(
+	const std::filesystem::path& checkpointDir,
+	PolicyValueNetwork& model,
+	const PolicyValueModelConfig& config,
+	std::int64_t seed,
+	const std::string& validatedDevice,
+	bool force,
+	PolicyValueModelError& error) noexcept {
+	try {
+		ClearError(error);
+		if (seed < 0) {
+			SetError(error, "invalid-seed", "seed must be non-negative");
+			return Result::Failed;
+		}
+		IfFailedReturn(ValidatePolicyValueModelConfig(config, error));
+		IfFailedReturn(PrepareCheckpointDirectory(checkpointDir, force, error));
+
+		model->to(torch::kCPU);
+		model->eval();
+		const ordered_json metadata = BuildMetadata(config, seed, validatedDevice, CountPolicyValueParameters(model));
+
+		std::ofstream metadataOutput(checkpointDir / "metadata.json", std::ios::trunc);
+		if (!metadataOutput.is_open()) {
+			SetError(error, "metadata-write-failed", "metadata.json could not be opened for writing");
+			return Result::Failed;
+		}
+		metadataOutput << metadata.dump(2) << "\n";
+		metadataOutput.close();
+
+		torch::save(model, (checkpointDir / "model.pt").string());
+		return Result::Succeeded;
+	}
+	catch (const std::exception& err) {
+		SetError(error, "checkpoint-save-failed", err.what());
+		return Result::Failed;
+	}
+}
+
+Result LoadPolicyValueCheckpoint(
+	const std::filesystem::path& checkpointDir,
+	PolicyValueNetwork& model,
+	PolicyValueModelConfig& config,
+	std::int64_t& seed,
+	PolicyValueModelError& error) noexcept {
+	try {
+		ClearError(error);
+		const std::filesystem::path metadataPath = checkpointDir / "metadata.json";
+		const std::filesystem::path modelPath = checkpointDir / "model.pt";
+		if (!std::filesystem::exists(metadataPath)) {
+			SetError(error, "metadata-missing", "metadata.json is missing from checkpoint bundle");
+			return Result::Failed;
+		}
+		if (!std::filesystem::exists(modelPath)) {
+			SetError(error, "model-missing", "model.pt is missing from checkpoint bundle");
+			return Result::Failed;
+		}
+
+		std::ifstream metadataInput(metadataPath);
+		if (!metadataInput.is_open()) {
+			SetError(error, "metadata-read-failed", "metadata.json could not be opened");
+			return Result::Failed;
+		}
+
+		json metadata;
+		metadataInput >> metadata;
+		std::int64_t metadataParameterCount = 0;
+		IfFailedReturn(ParseMetadata(metadata, config, seed, metadataParameterCount, error));
+
+		model = CreatePolicyValueNetwork(config, seed);
+		if (CountPolicyValueParameters(model) != metadataParameterCount) {
+			SetError(error, "metadata-incompatible", "metadata.parameterCount is incompatible");
+			return Result::Failed;
+		}
+		torch::load(model, modelPath.string());
+		model->to(torch::kCPU);
+		model->eval();
+		return Result::Succeeded;
+	}
+	catch (const std::exception& err) {
+		SetError(error, "checkpoint-load-failed", err.what());
+		return Result::Failed;
+	}
+}

--- a/AdvanceWarsServer/src/PolicyValueModelCommands.cpp
+++ b/AdvanceWarsServer/src/PolicyValueModelCommands.cpp
@@ -1,0 +1,253 @@
+#include "PolicyValueModelCommands.h"
+
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "ActionSpace.h"
+#include "PolicyValueModel.h"
+#include "StateTensor.h"
+
+namespace {
+bool ParseIntOption(const std::string& value, int& parsed) {
+	try {
+		std::size_t index = 0;
+		const long long raw = std::stoll(value, &index, 10);
+		if (index != value.size() || raw < std::numeric_limits<int>::min() || raw > std::numeric_limits<int>::max()) {
+			return false;
+		}
+		parsed = static_cast<int>(raw);
+		return true;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool ParseSeedOption(const std::string& value, std::int64_t& parsed) {
+	try {
+		std::size_t index = 0;
+		const long long raw = std::stoll(value, &index, 10);
+		if (index != value.size() || raw < 0) {
+			return false;
+		}
+		parsed = static_cast<std::int64_t>(raw);
+		return true;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+torch::Tensor MakeModelCommandSmokeInput() {
+	return torch::zeros(
+		{ 1, StateTensor::ChannelCount(), StateTensor::BoardHeight(), StateTensor::BoardWidth() },
+		torch::TensorOptions().dtype(torch::kFloat32)).contiguous();
+}
+
+int PrintModelError(const PolicyValueModelError& error) {
+	std::cerr << error.code << ": " << error.message << std::endl;
+	return 1;
+}
+
+int RunCheckpointValidation(const std::filesystem::path& checkpointDir, const torch::Device& requestedDevice, PolicyValueModelError& error) {
+	PolicyValueNetwork loaded(nullptr);
+	PolicyValueModelConfig loadedConfig;
+	std::int64_t loadedSeed = -1;
+	if (LoadPolicyValueCheckpoint(checkpointDir, loaded, loadedConfig, loadedSeed, error) == Result::Failed) {
+		return PrintModelError(error);
+	}
+
+	PolicyValueNetworkOutput output;
+	if (RunPolicyValueInference(loaded, MakeModelCommandSmokeInput(), output, error) == Result::Failed) {
+		return PrintModelError(error);
+	}
+
+	if (requestedDevice.is_cuda()) {
+		loaded->to(requestedDevice);
+		if (RunPolicyValueInference(loaded, MakeModelCommandSmokeInput().to(requestedDevice), output, error) == Result::Failed) {
+			return PrintModelError(error);
+		}
+	}
+
+	std::cout << "Checkpoint ready: " << checkpointDir.string() <<
+		" version=" << PolicyValueModelVersion() <<
+		" hiddenChannels=" << loadedConfig.hiddenChannels <<
+		" residualBlocks=" << loadedConfig.residualBlocks <<
+		" normGroups=" << loadedConfig.normGroups <<
+		" actions=" << ActionSpace::ActionCount() <<
+		" seed=" << loadedSeed <<
+		" validatedDevice=" << PolicyValueDeviceName(requestedDevice) << std::endl;
+	return 0;
+}
+
+int RunMnistExperiment(const std::filesystem::path& mnistPath) {
+	struct Net : torch::nn::Module {
+		Net()
+			: conv1(torch::nn::Conv2dOptions(1, 32, 5)),
+			conv2(torch::nn::Conv2dOptions(32, 64, 5)),
+			fc1(1024, 128),
+			fc2(128, 10) {
+			register_module("conv1", conv1);
+			register_module("conv2", conv2);
+			register_module("fc1", fc1);
+			register_module("fc2", fc2);
+		}
+
+		torch::Tensor forward(torch::Tensor x) {
+			x = torch::relu(conv1->forward(x));
+			x = torch::max_pool2d(x, 2);
+			x = torch::relu(conv2->forward(x));
+			x = torch::max_pool2d(x, 2);
+			x = x.view({ x.size(0), -1 });
+			x = torch::relu(fc1->forward(x));
+			x = fc2->forward(x);
+			return torch::log_softmax(x, 1);
+		}
+
+		torch::nn::Conv2d conv1, conv2;
+		torch::nn::Linear fc1, fc2;
+	};
+
+	torch::Device device(PolicyValueCudaAvailable() ? torch::kCUDA : torch::kCPU);
+	std::cout << "Using device: " << (device.is_cuda() ? "CUDA" : "CPU") << "\n";
+
+	auto trainDataset = torch::data::datasets::MNIST(mnistPath.string()).map(
+		torch::data::transforms::Stack<>());
+	auto trainLoader = torch::data::make_data_loader(std::move(trainDataset),
+		torch::data::DataLoaderOptions().batch_size(64));
+
+	Net model;
+	model.to(device);
+	torch::optim::SGD optimizer(model.parameters(), torch::optim::SGDOptions(0.01).momentum(0.9));
+
+	for (size_t epoch = 1; epoch <= 5; ++epoch) {
+		size_t batchIndex = 0;
+		for (auto& batch : *trainLoader) {
+			model.train();
+			auto data = batch.data.to(device);
+			auto targets = batch.target.to(device);
+			optimizer.zero_grad();
+			auto output = model.forward(data);
+			auto loss = torch::nll_loss(output, targets);
+			loss.backward();
+			optimizer.step();
+
+			if (batchIndex++ % 100 == 0) {
+				std::cout << "Train Epoch: " << epoch << " [" << batchIndex * 64
+					<< "/60000] Loss: " << loss.item<float>() << "\n";
+			}
+		}
+	}
+	return 0;
+}
+}
+
+int RunModelInitCommand(int argc, char* argv[]) noexcept {
+	try {
+		std::filesystem::path outputPath;
+		std::string deviceName = "cpu";
+		PolicyValueModelConfig config;
+		std::int64_t seed = 0;
+		bool force = false;
+
+		for (int i = 0; i < argc; ++i) {
+			const std::string argument = argv[i];
+			if (argument == "--out" && i + 1 < argc) {
+				outputPath = argv[++i];
+			}
+			else if (argument == "--device" && i + 1 < argc) {
+				deviceName = argv[++i];
+			}
+			else if (argument == "--hidden-channels" && i + 1 < argc) {
+				if (!ParseIntOption(argv[++i], config.hiddenChannels)) {
+					std::cerr << "Invalid --hidden-channels value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--res-blocks" && i + 1 < argc) {
+				if (!ParseIntOption(argv[++i], config.residualBlocks)) {
+					std::cerr << "Invalid --res-blocks value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--norm-groups" && i + 1 < argc) {
+				if (!ParseIntOption(argv[++i], config.normGroups)) {
+					std::cerr << "Invalid --norm-groups value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--seed" && i + 1 < argc) {
+				if (!ParseSeedOption(argv[++i], seed)) {
+					std::cerr << "Invalid --seed value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--force") {
+				force = true;
+			}
+			else {
+				std::cerr << "Unknown -model-init option: " << argument << std::endl;
+				return 1;
+			}
+		}
+
+		if (outputPath.empty()) {
+			std::cerr << "-model-init requires --out <checkpoint-dir>" << std::endl;
+			return 1;
+		}
+
+		PolicyValueModelError error;
+		const torch::Device requestedDevice = ResolvePolicyValueDevice(deviceName, error);
+		if (!error.code.empty()) {
+			return PrintModelError(error);
+		}
+		if (ValidatePolicyValueModelConfig(config, error) == Result::Failed) {
+			return PrintModelError(error);
+		}
+
+		PolicyValueNetwork model = CreatePolicyValueNetwork(config, seed);
+		if (SavePolicyValueCheckpoint(outputPath, model, config, seed, PolicyValueDeviceName(requestedDevice), force, error) == Result::Failed) {
+			return PrintModelError(error);
+		}
+
+		return RunCheckpointValidation(outputPath, requestedDevice, error);
+	}
+	catch (const std::exception& err) {
+		std::cerr << "model init exception: " << err.what() << std::endl;
+		return 1;
+	}
+}
+
+int RunTorchLibCommand(int argc, char* argv[]) noexcept {
+	try {
+		std::filesystem::path mnistPath;
+		for (int i = 0; i < argc; ++i) {
+			const std::string argument = argv[i];
+			if (argument == "--mnist-path" && i + 1 < argc) {
+				mnistPath = argv[++i];
+			}
+			else {
+				std::cerr << "Unknown -torchlib option: " << argument << std::endl;
+				return 1;
+			}
+		}
+
+		std::cout << "CUDA support: " << (PolicyValueCudaAvailable() ? "true" : "false") << std::endl;
+		std::cout << "CUDA devices: " << PolicyValueCudaDeviceCount() << std::endl;
+		torch::Tensor tensor = torch::rand({ 2, 3 });
+		std::cout << tensor << std::endl;
+
+		if (mnistPath.empty()) {
+			std::cout << "MNIST experiment skipped; pass --mnist-path <path> to run it." << std::endl;
+			return 0;
+		}
+
+		return RunMnistExperiment(mnistPath);
+	}
+	catch (const std::exception& err) {
+		std::cerr << "torchlib exception: " << err.what() << std::endl;
+		return 1;
+	}
+}

--- a/AdvanceWarsServer/src/PolicyValueModelTest.cpp
+++ b/AdvanceWarsServer/src/PolicyValueModelTest.cpp
@@ -1,0 +1,294 @@
+#include "PolicyValueModelTest.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "ActionSpace.h"
+#include "PolicyValueModel.h"
+#include "StandardGameSetup.h"
+#include "StateTensor.h"
+
+namespace {
+bool Expect(bool condition, const std::string& message) {
+	if (!condition) {
+		std::cerr << "Policy/value model test failed: " << message << std::endl;
+		return false;
+	}
+
+	return true;
+}
+
+bool TensorClose(const torch::Tensor& left, const torch::Tensor& right, double tolerance = 1e-6) {
+	if (!left.sizes().equals(right.sizes())) {
+		return false;
+	}
+
+	return torch::allclose(left.cpu(), right.cpu(), tolerance, tolerance);
+}
+
+std::filesystem::path MakeTempCheckpointPath(const std::string& name) {
+	return std::filesystem::temp_directory_path() / ("advance-wars-" + name);
+}
+
+torch::Tensor MakeSyntheticInput(int batchSize) {
+	const std::int64_t valuesPerState = static_cast<std::int64_t>(StateTensor::ChannelCount() * StateTensor::BoardHeight() * StateTensor::BoardWidth());
+	return torch::linspace(0.0f, 1.0f, batchSize * valuesPerState, torch::kFloat32)
+		.view({ batchSize, StateTensor::ChannelCount(), StateTensor::BoardHeight(), StateTensor::BoardWidth() })
+		.contiguous();
+}
+
+bool RewriteMetadata(const std::filesystem::path& checkpointPath, const std::function<void(json&)>& mutate) {
+	std::ifstream input(checkpointPath / "metadata.json");
+	if (!Expect(input.is_open(), "metadata.json should open for mutation")) {
+		return false;
+	}
+
+	json metadata;
+	input >> metadata;
+	input.close();
+	mutate(metadata);
+
+	std::ofstream output(checkpointPath / "metadata.json", std::ios::trunc);
+	if (!Expect(output.is_open(), "metadata.json should reopen for mutation")) {
+		return false;
+	}
+	output << metadata.dump(2) << "\n";
+	return true;
+}
+
+bool LoadCheckpointShouldFail(const std::filesystem::path& checkpointPath, const std::string& expectedCode) {
+	PolicyValueNetwork loaded(nullptr);
+	PolicyValueModelConfig loadedConfig;
+	std::int64_t loadedSeed = -1;
+	PolicyValueModelError error;
+	const bool failed = Expect(LoadPolicyValueCheckpoint(checkpointPath, loaded, loadedConfig, loadedSeed, error) == Result::Failed, "checkpoint load should fail");
+	return failed && Expect(error.code == expectedCode, "checkpoint load should fail with " + expectedCode + ", got " + error.code);
+}
+
+bool ForwardOutputHasExpectedContract(const PolicyValueModelConfig& config, const std::string& deviceName) {
+	PolicyValueModelError error;
+	const torch::Device device = ResolvePolicyValueDevice(deviceName, error);
+	if (!Expect(error.code.empty(), "device should resolve for model test: " + error.message)) {
+		return false;
+	}
+
+	PolicyValueNetwork model = CreatePolicyValueNetwork(config, 0);
+	model->to(device);
+
+	PolicyValueNetworkOutput output;
+	if (!Expect(RunPolicyValueInference(model, MakeSyntheticInput(2).to(device), output, error) == Result::Succeeded, "synthetic inference should succeed: " + error.message)) {
+		return false;
+	}
+
+	return Expect(output.policyLogits.sizes() == torch::IntArrayRef({ 2, ActionSpace::ActionCount() }), "policy logits should align with action space") &&
+		Expect(output.value.sizes() == torch::IntArrayRef({ 2, 1 }), "value output should be one scalar per batch item") &&
+		Expect(output.policyLogits.is_contiguous(), "policy logits should be contiguous") &&
+		Expect(output.value.is_contiguous(), "value output should be contiguous") &&
+		Expect(torch::isfinite(output.policyLogits).all().item<bool>(), "policy logits should be finite") &&
+		Expect(torch::isfinite(output.value).all().item<bool>(), "value output should be finite") &&
+		Expect(output.value.min().item<float>() >= -1.0f && output.value.max().item<float>() <= 1.0f, "value output should be in [-1, 1]");
+}
+
+bool RealStandardStateRunsThroughVectorWrapper() {
+	json request;
+	StandardGameSetupError setupError;
+	if (!Expect(BuildStandardGameRequestFromSlots("mcts", "andy", "adder", StandardSettingsJson(), 101, request, setupError) == Result::Succeeded, "standard setup request should build")) {
+		return false;
+	}
+
+	StandardGameSetupResult setup;
+	if (!Expect(CreateStandardGameFromRequest(request, setup, setupError) == Result::Succeeded, "standard setup should create a game")) {
+		return false;
+	}
+
+	std::vector<float> values;
+	if (!Expect(StateTensor::Encode(setup.gameState, values) == Result::Succeeded, "state tensor should encode a standard game")) {
+		return false;
+	}
+
+	PolicyValueModelConfig config;
+	PolicyValueNetwork model = CreatePolicyValueNetwork(config, 0);
+	PolicyValueNetworkOutput output;
+	PolicyValueModelError error;
+	if (!Expect(RunPolicyValueInference(model, values, 1, output, error) == Result::Succeeded, "vector wrapper inference should succeed: " + error.message)) {
+		return false;
+	}
+
+	return Expect(output.policyLogits.sizes() == torch::IntArrayRef({ 1, ActionSpace::ActionCount() }), "real-state policy logits should align with action space") &&
+		Expect(output.value.sizes() == torch::IntArrayRef({ 1, 1 }), "real-state value should be one scalar");
+}
+
+bool PolicyLayoutInvariantIsEnforced() {
+	PolicyValueModelConfig config;
+	PolicyValueModelError error;
+	if (!Expect(ValidatePolicyValueModelConfig(config, error) == Result::Succeeded, "default config should be valid: " + error.message)) {
+		return false;
+	}
+
+	config.normGroups = 7;
+	if (!Expect(ValidatePolicyValueModelConfig(config, error) == Result::Failed, "norm groups that do not divide channels should be rejected")) {
+		return false;
+	}
+
+	return Expect(PolicyValuePolicyPlaneCount() * StateTensor::BoardHeight() * StateTensor::BoardWidth() + PolicyValueGlobalActionCount() == ActionSpace::ActionCount(),
+		"policy plane/global split should reconstruct the action count");
+}
+
+bool SeededInitializationIsDeterministic() {
+	PolicyValueModelConfig config;
+	const torch::Tensor input = MakeSyntheticInput(1);
+	PolicyValueModelError error;
+
+	PolicyValueNetwork first = CreatePolicyValueNetwork(config, 123);
+	PolicyValueNetwork second = CreatePolicyValueNetwork(config, 123);
+	PolicyValueNetwork different = CreatePolicyValueNetwork(config, 124);
+
+	PolicyValueNetworkOutput firstOutput;
+	PolicyValueNetworkOutput secondOutput;
+	PolicyValueNetworkOutput differentOutput;
+	if (!Expect(RunPolicyValueInference(first, input, firstOutput, error) == Result::Succeeded, "first seeded inference should succeed")) {
+		return false;
+	}
+	if (!Expect(RunPolicyValueInference(second, input, secondOutput, error) == Result::Succeeded, "second seeded inference should succeed")) {
+		return false;
+	}
+	if (!Expect(RunPolicyValueInference(different, input, differentOutput, error) == Result::Succeeded, "different seeded inference should succeed")) {
+		return false;
+	}
+
+	return Expect(TensorClose(firstOutput.policyLogits, secondOutput.policyLogits), "same seed should produce identical policy logits") &&
+		Expect(TensorClose(firstOutput.value, secondOutput.value), "same seed should produce identical values") &&
+		Expect(!TensorClose(firstOutput.policyLogits, differentOutput.policyLogits) || !TensorClose(firstOutput.value, differentOutput.value), "different seed should change at least one output");
+}
+
+bool CheckpointRoundTripPreservesOutputs() {
+	const std::filesystem::path checkpointPath = MakeTempCheckpointPath("policy-value-roundtrip");
+	std::filesystem::remove_all(checkpointPath);
+
+	PolicyValueModelConfig config;
+	const std::int64_t seed = 77;
+	PolicyValueModelError error;
+	PolicyValueNetwork model = CreatePolicyValueNetwork(config, seed);
+	PolicyValueNetworkOutput before;
+	const torch::Tensor input = MakeSyntheticInput(1);
+	if (!Expect(RunPolicyValueInference(model, input, before, error) == Result::Succeeded, "pre-save inference should succeed: " + error.message)) {
+		return false;
+	}
+
+	if (!Expect(SavePolicyValueCheckpoint(checkpointPath, model, config, seed, "cpu", false, error) == Result::Succeeded, "checkpoint save should succeed: " + error.message)) {
+		return false;
+	}
+
+	PolicyValueNetwork loaded(nullptr);
+	PolicyValueModelConfig loadedConfig;
+	std::int64_t loadedSeed = -1;
+	if (!Expect(LoadPolicyValueCheckpoint(checkpointPath, loaded, loadedConfig, loadedSeed, error) == Result::Succeeded, "checkpoint load should succeed: " + error.message)) {
+		std::filesystem::remove_all(checkpointPath);
+		return false;
+	}
+
+	PolicyValueNetworkOutput after;
+	const bool inferenceSucceeded = Expect(RunPolicyValueInference(loaded, input, after, error) == Result::Succeeded, "post-load inference should succeed: " + error.message);
+	const bool outputsMatch = inferenceSucceeded &&
+		Expect(TensorClose(before.policyLogits, after.policyLogits), "checkpoint policy logits should round trip") &&
+		Expect(TensorClose(before.value, after.value), "checkpoint value should round trip");
+	std::filesystem::remove_all(checkpointPath);
+	return outputsMatch;
+}
+
+bool InvalidCheckpointMetadataIsRejected() {
+	const std::filesystem::path checkpointPath = MakeTempCheckpointPath("policy-value-invalid");
+	std::filesystem::remove_all(checkpointPath);
+
+	PolicyValueModelConfig config;
+	PolicyValueNetwork model = CreatePolicyValueNetwork(config, 0);
+	PolicyValueModelError error;
+	if (!Expect(SavePolicyValueCheckpoint(checkpointPath, model, config, 0, "cpu", false, error) == Result::Succeeded, "baseline checkpoint save should succeed")) {
+		return false;
+	}
+
+	std::filesystem::remove(checkpointPath / "model.pt");
+	bool passed = LoadCheckpointShouldFail(checkpointPath, "model-missing");
+
+	if (!Expect(SavePolicyValueCheckpoint(checkpointPath, model, config, 0, "cpu", true, error) == Result::Succeeded, "baseline checkpoint should resave with force")) {
+		std::filesystem::remove_all(checkpointPath);
+		return false;
+	}
+	passed = RewriteMetadata(checkpointPath, [](json& metadata) {
+		metadata["unknownField"] = true;
+	}) && LoadCheckpointShouldFail(checkpointPath, "metadata-schema-error") && passed;
+
+	if (!Expect(SavePolicyValueCheckpoint(checkpointPath, model, config, 0, "cpu", true, error) == Result::Succeeded, "baseline checkpoint should resave after unknown field")) {
+		std::filesystem::remove_all(checkpointPath);
+		return false;
+	}
+	passed = RewriteMetadata(checkpointPath, [](json& metadata) {
+		metadata["actionSpace"]["actionCount"] = ActionSpace::ActionCount() + 1;
+	}) && LoadCheckpointShouldFail(checkpointPath, "metadata-incompatible") && passed;
+
+	if (!Expect(SavePolicyValueCheckpoint(checkpointPath, model, config, 0, "cpu", true, error) == Result::Succeeded, "baseline checkpoint should resave after action mismatch")) {
+		std::filesystem::remove_all(checkpointPath);
+		return false;
+	}
+	passed = RewriteMetadata(checkpointPath, [](json& metadata) {
+		metadata["parameterCount"] = metadata["parameterCount"].get<std::int64_t>() + 1;
+	}) && LoadCheckpointShouldFail(checkpointPath, "metadata-incompatible") && passed;
+
+	std::filesystem::remove_all(checkpointPath);
+	return passed;
+}
+}
+
+int RunPolicyValueModelTests(int argc, char* argv[]) noexcept {
+	try {
+		std::string deviceName = "cpu";
+		for (int i = 0; i < argc; ++i) {
+			const std::string argument = argv[i];
+			if (argument == "--device" && i + 1 < argc) {
+				deviceName = argv[++i];
+			}
+			else {
+				std::cerr << "Unknown -test-model option: " << argument << std::endl;
+				return 1;
+			}
+		}
+
+		PolicyValueModelConfig tinyConfig;
+		tinyConfig.hiddenChannels = 8;
+		tinyConfig.residualBlocks = 1;
+		tinyConfig.normGroups = 1;
+
+		bool passed = true;
+		passed = ForwardOutputHasExpectedContract(PolicyValueModelConfig(), deviceName) && passed;
+		passed = ForwardOutputHasExpectedContract(tinyConfig, deviceName) && passed;
+		passed = RealStandardStateRunsThroughVectorWrapper() && passed;
+		passed = PolicyLayoutInvariantIsEnforced() && passed;
+		passed = SeededInitializationIsDeterministic() && passed;
+		passed = CheckpointRoundTripPreservesOutputs() && passed;
+		passed = InvalidCheckpointMetadataIsRejected() && passed;
+
+		if (!passed) {
+			return 1;
+		}
+
+		PolicyValueModelConfig config;
+		PolicyValueNetwork model = CreatePolicyValueNetwork(config, 0);
+		std::cout << "Policy/value model tests passed: version=" << PolicyValueModelVersion() <<
+			" hiddenChannels=" << config.hiddenChannels <<
+			" residualBlocks=" << config.residualBlocks <<
+			" normGroups=" << config.normGroups <<
+			" input=" << StateTensor::ChannelCount() << "x" << StateTensor::BoardHeight() << "x" << StateTensor::BoardWidth() <<
+			" actions=" << ActionSpace::ActionCount() <<
+			" parameters=" << CountPolicyValueParameters(model) << std::endl;
+		return 0;
+	}
+	catch (const std::exception& err) {
+		std::cerr << "Policy/value model test exception: " << err.what() << std::endl;
+		return 1;
+	}
+}

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -26,13 +26,23 @@ $libtorchRoot = 'C:\path\to\libtorch'
 & 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Release /p:Platform=x64 /p:LIBTORCH_ROOT="$libtorchRoot" /v:minimal
 ```
 
-The default build links the CPU LibTorch libraries and keeps CUDA probing disabled so development does not require a configured CUDA toolchain. To build the CUDA-enabled path, pass `/p:UseLibtorchCuda=true` and make sure `CUDA_PATH`, `CUDNN_LIB_PATH`, and `NVTOOLSEXT_PATH` resolve on the machine.
+The default build links the CPU LibTorch libraries and keeps CUDA probing disabled so development does not require a configured CUDA toolchain. For GPU training, build with CUDA enabled:
+
+```powershell
+$libtorchRoot = 'C:\path\to\libtorch'
+$cudaRoot = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8'
+$cudnnRoot = 'C:\Program Files\NVIDIA\CUDNN\v9.7'
+$nvToolsExtRoot = 'C:\Program Files\NVIDIA Corporation\NvToolsExt'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Release /p:Platform=x64 /p:LIBTORCH_ROOT="$libtorchRoot" /p:UseLibtorchCuda=true /p:CUDA_PATH="$cudaRoot" /p:CUDNN_LIB_PATH="$cudnnRoot\lib\11.8\x64" /p:NVTOOLSEXT_PATH="$nvToolsExtRoot" /v:minimal
+```
 
 When running model commands, add the LibTorch `bin` directory to `PATH` first:
 
 ```powershell
 $libtorchRoot = 'C:\path\to\libtorch'
-$env:PATH = "$libtorchRoot\bin;" + $env:PATH
+$cudaRoot = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8'
+$cudnnRoot = 'C:\Program Files\NVIDIA\CUDNN\v9.7'
+$env:PATH = "$libtorchRoot\bin;$cudaRoot\bin;$cudnnRoot\bin\11.8;" + $env:PATH
 ```
 
 ## Run Tests

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -6,7 +6,8 @@ This project can be built from the Visual Studio solution with MSBuild.
 
 - Visual Studio 2022 with the v143 C++ toolset.
 - Windows SDK 10.0.
-- The local dependency paths referenced by `AdvanceWarsServer/AdvanceWarsServer.vcxproj`, including libtorch, nlohmann-json, asio, and via-httplib.
+- The local dependency paths referenced by `AdvanceWarsServer/AdvanceWarsServer.vcxproj`, including nlohmann-json, asio, and via-httplib.
+- LibTorch for Windows. Pass `LIBTORCH_ROOT` to MSBuild, pointing at the directory that contains `include/`, `lib/`, and `bin/`.
 - Node.js 24 LTS and Yarn 1.x for the React board viewer.
 
 ## Build
@@ -14,13 +15,24 @@ This project can be built from the Visual Studio solution with MSBuild.
 From the repository root:
 
 ```powershell
-& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal
+$libtorchRoot = 'C:\path\to\libtorch'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /p:LIBTORCH_ROOT="$libtorchRoot" /v:minimal
 ```
 
 Release x64:
 
 ```powershell
-& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Release /p:Platform=x64 /v:minimal
+$libtorchRoot = 'C:\path\to\libtorch'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Release /p:Platform=x64 /p:LIBTORCH_ROOT="$libtorchRoot" /v:minimal
+```
+
+The default build links the CPU LibTorch libraries and keeps CUDA probing disabled so development does not require a configured CUDA toolchain. To build the CUDA-enabled path, pass `/p:UseLibtorchCuda=true` and make sure `CUDA_PATH`, `CUDNN_LIB_PATH`, and `NVTOOLSEXT_PATH` resolve on the machine.
+
+When running model commands, add the LibTorch `bin` directory to `PATH` first:
+
+```powershell
+$libtorchRoot = 'C:\path\to\libtorch'
+$env:PATH = "$libtorchRoot\bin;" + $env:PATH
 ```
 
 ## Run Tests
@@ -32,6 +44,7 @@ Set-Location .\AdvanceWarsServer
 ..\x64\Debug\AdvanceWarsServer.exe -test test/json
 ..\x64\Debug\AdvanceWarsServer.exe -test-api-contract
 ..\x64\Debug\AdvanceWarsServer.exe -test-mcts
+..\x64\Debug\AdvanceWarsServer.exe -test-model
 ..\x64\Debug\AdvanceWarsServer.exe -test-replay
 ```
 
@@ -57,14 +70,16 @@ The executable currently recognizes these development commands:
 | `-test [path]` | Run the recursive JSON fixture suite. | Defaults to `test/json`. Run from `AdvanceWarsServer/` so relative paths resolve. |
 | `-test-api-contract` | Run focused REST lifecycle/action contract tests. | Run from `AdvanceWarsServer/` so map templates and fixtures resolve. |
 | `-test-mcts` | Run focused MCTS contract tests. | Uses scripted fake states for deterministic search semantics. |
+| `-test-model [--device cpu|auto|cuda]` | Run focused policy/value model tests. | Verifies forward shapes, real Standard tensor inference, deterministic init, checkpoint round trip, and strict metadata rejection. |
 | `-test-replay` | Run focused self-play replay writer/validator tests. | Writes temporary replay shards and cleans them up on success. |
+| `-model-init --out <checkpoint-dir> [--device cpu|auto|cuda] [--hidden-channels <n>] [--res-blocks <n>] [--norm-groups <n>] [--seed <n>] [--force]` | Initialize and validate a policy/value checkpoint bundle. | Writes `metadata.json` plus `model.pt`. `model.pt` is required; it cannot be reconstructed from metadata alone. |
 | `-self-play --out <path> --map <id> --player0-co <id> --player1-co <id> [options]` | Generate validated sparse self-play replay JSONL. | Fails if `--out` exists unless `--append` is passed. See `docs/SELF_PLAY_REPLAYS.md`. |
 | `-validate-replay <path>` | Validate a self-play replay JSONL shard. | Prints a concise summary on success and exact failure location on error. |
 | `-sim-random-move-game [seed]` | Run an experimental random-action simulation. | Uses local output paths that still need cleanup before general use. |
 | `-sim-mcts-game` | Run an experimental MCTS simulation. | Uses local output paths that still need cleanup before general use. |
 | `-server` | Run the current HTTP server on port 80. | Serves the canonical REST routes documented in `docs/API.md`. |
 | `-converter` | Regenerate the hardcoded Lefty map JSON. | Developer utility. |
-| `-torchlib` | Run a local libtorch/MNIST experiment. | Depends on local `D:/MNIST` and libtorch paths. |
+| `-torchlib [--mnist-path <path>]` | Run a local libtorch smoke check, optionally followed by the old MNIST experiment. | MNIST stays disabled unless `--mnist-path` is passed. |
 
 ## Frontend Board Viewer
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ See [STANDARD_ENGINE_COMPLETENESS.md](STANDARD_ENGINE_COMPLETENESS.md) for the c
 Build the Debug x64 configuration from the repository root:
 
 ```powershell
-& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /v:minimal
+$libtorchRoot = 'C:\path\to\libtorch'
+& 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe' 'AdvanceWarsServer.sln' /m /p:Configuration=Debug /p:Platform=x64 /p:LIBTORCH_ROOT="$libtorchRoot" /v:minimal
 ```
 
 Run the full JSON suite from the project directory:
 
 ```powershell
 Set-Location .\AdvanceWarsServer
+$libtorchRoot = 'C:\path\to\libtorch'
+$env:PATH = "$libtorchRoot\bin;" + $env:PATH
 ..\x64\Debug\AdvanceWarsServer.exe -test test/json
 ```
 

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -25,7 +25,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] Fix action deserialization for `unloadIndex`; action JSON now assigns `Action::m_optUnloadIndex`, equality includes it, and REST/action-space tests cover unload-index handling (#4, #67).
 - [x] Fix capture-limit property counting. Capture-limit wins count Cities, Bases, Airports, Ports, and HQs, excluding Labs and Com Towers (#73).
 - [ ] Audit unit count caching around load/unload, clone, add, and destroy paths before relying on unit-cap logic in training.
-- [ ] Replace hardcoded local paths such as `D:/awai`, `D:/MNIST`, and local libtorch directories with config or command-line options.
+- [ ] Replace remaining hardcoded local paths such as `D:/awai` with config or command-line options. LibTorch now uses `LIBTORCH_ROOT`, and the old MNIST experiment only runs when `-torchlib --mnist-path <path>` is provided.
 - [x] Add a maximum action limit outcome for self-play games so training cannot hang indefinitely. `-self-play` records `terminalReason: "action-limit"` and null winner for runner safety stops (#6).
 - [x] Make combat RNG deterministic, seedable, or policy-controlled from the self-play runner (#2).
 
@@ -67,9 +67,11 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] Define model input planes via `standard-gl-v1-state` in `docs/STATE_TENSOR.md`.
 - [x] Define policy head output shape matching the action encoding: source-cell planes over `27x23` plus global logits in `docs/TRAINING_DESIGN.md`.
 - [x] Define value head output as expected win/loss result from the current player's perspective in `docs/TRAINING_DESIGN.md`.
-- [ ] Add model save/load checkpoints.
+- [x] Add a LibTorch policy/value model scaffold for `standard-gl-policy-value-v1` (#7).
+- [x] Add model save/load checkpoints with strict `metadata.json` compatibility checks and required `model.pt` weights (#7).
 - [ ] Add inference batching for MCTS.
-- [ ] Add CPU-only fallback so development does not depend on CUDA being configured.
+- [x] Add CPU-only fallback so development does not depend on CUDA being configured (#7).
+- [x] Add focused model smoke tests for forward shape, real Standard tensor inference, deterministic init, and checkpoint rejection (`-test-model`) (#7).
 
 ## Phase 5: Training Loop
 
@@ -98,7 +100,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] #4 Implement action encoding and legal action masks.
 - [x] #5 Refactor MCTS for action-level self-play and same-player turn sequences.
 - [x] #6 Add self-play replay writer.
-- [ ] #7 Add policy/value network scaffold.
+- [x] #7 Add policy/value network scaffold.
 - [ ] #8 Add training command-line entry point.
 - [ ] #9 Add checkpoint evaluation harness.
 - [ ] #164 Track CO matchup statistics for pregame selection.

--- a/docs/TRAINING_DESIGN.md
+++ b/docs/TRAINING_DESIGN.md
@@ -28,6 +28,12 @@ Use a shared convolutional or residual trunk over the fixed board. The policy he
 
 The value head should output the expected game result from the current player's perspective.
 
+The v1 scaffold is `standard-gl-policy-value-v1`. It consumes `standard-gl-v1-state` tensors shaped `[N, 219, 23, 27]`, runs a small residual trunk, emits policy logits shaped `[N, ActionSpace::ActionCount()]`, and emits value predictions shaped `[N, 1]` in `[-1, 1]`. The default architecture is intentionally modest: 64 hidden channels, 4 residual blocks, and 8 group-norm groups. The command-line initializer can make smaller smoke-test models with `--hidden-channels`, `--res-blocks`, and `--norm-groups`; larger production-scale experiments are tracked separately by #177.
+
+Policy logits keep the action-space layout intact: `2503` source-cell planes over `23x27`, followed by the three global actions. MCTS and training should mask or normalize only the sparse legal action indices produced by the engine/action-space layer; the model does not infer legality from the tensor.
+
+Checkpoints are directory bundles containing both `metadata.json` and `model.pt`. `metadata.json` is the compatibility manifest: model version, state tensor version/shape, action-space version/count, policy/value output sizes, architecture knobs, seed, validated device, and parameter count. `model.pt` contains the learned weights and is required; it cannot be reconstructed from `metadata.json`.
+
 Start small enough to fit comfortably on an 8 GB GPU:
 
 - mixed precision when CUDA is available


### PR DESCRIPTION
Closes #7.

## Summary
- Adds a LibTorch `standard-gl-policy-value-v1` scaffold with a residual trunk, source-cell policy planes plus global logits, and a bounded value head.
- Adds strict checkpoint bundles containing `metadata.json` and required `model.pt` weights, with metadata compatibility checks for model/action/state/output shape and parameter count.
- Adds `-test-model`, `-model-init`, and a safer `-torchlib [--mnist-path <path>]` command path; MNIST remains opt-in.
- Moves LibTorch project wiring to `LIBTORCH_ROOT`, defaults CUDA probing/linking off unless `UseLibtorchCuda=true`, and documents the build/runtime contract.

## Verification
- Debug x64 CPU-default build: `MSBuild AdvanceWarsServer.sln /p:Configuration=Debug /p:Platform=x64 /p:LIBTORCH_ROOT=...`
- `AdvanceWarsServer.exe -test-model`
- `AdvanceWarsServer.exe -model-init --out %TEMP%\\aws-model-init-smoke --hidden-channels 8 --res-blocks 1 --norm-groups 1`
- `AdvanceWarsServer.exe -torchlib`
- `AdvanceWarsServer.exe -test-mcts`
- `AdvanceWarsServer.exe -test-replay`
- `AdvanceWarsServer.exe -test-api-contract`
- `AdvanceWarsServer.exe -test test/json`
- Release x64 CPU-default build: `MSBuild AdvanceWarsServer.sln /p:Configuration=Release /p:Platform=x64 /p:LIBTORCH_ROOT=...`
- Release `AdvanceWarsServer.exe -test-model`
- `nvidia-smi`: NVIDIA GeForce GTX 1070, driver 581.80, CUDA runtime 13.0 reported by driver
- Debug x64 CUDA build: `MSBuild AdvanceWarsServer.sln /p:Configuration=Debug /p:Platform=x64 /p:LIBTORCH_ROOT=... /p:UseLibtorchCuda=true /p:CUDA_PATH=... /p:CUDNN_LIB_PATH=... /p:NVTOOLSEXT_PATH=...`
- CUDA probe: `AdvanceWarsServer.exe -torchlib` reported `CUDA support: true` and `CUDA devices: 1`
- Debug `AdvanceWarsServer.exe -test-model --device cuda`
- Debug `AdvanceWarsServer.exe -model-init --out %TEMP%\\aws-model-init-cuda-smoke --device cuda --hidden-channels 8 --res-blocks 1 --norm-groups 1`
- Release x64 CUDA build: `MSBuild AdvanceWarsServer.sln /p:Configuration=Release /p:Platform=x64 /p:LIBTORCH_ROOT=... /p:UseLibtorchCuda=true /p:CUDA_PATH=... /p:CUDNN_LIB_PATH=... /p:NVTOOLSEXT_PATH=...`
- Release `AdvanceWarsServer.exe -test-model --device cuda`