### PR TITLE
Add replay training command

### DIFF
--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj
@@ -118,6 +118,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir)inc;$(LIBTORCH_ROOT)\include;$(LIBTORCH_ROOT)\include\torch\csrc\api\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -159,6 +160,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir)inc;$(LIBTORCH_ROOT)\include;$(LIBTORCH_ROOT)\include\torch\csrc\api\include;D:\Projects\json-develop\json-develop\include;D:\Projects\via-httplib-main\via-httplib-main\include;D:\Projects\asio-1.30.2\asio-1.30.2\include\;C:\Users\Roshan\source\repos\AdvanceWarsServer\AdvanceWarsServer\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -191,6 +193,9 @@
     <ClCompile Include="src\StandardGameSetup.cpp" />
     <ClCompile Include="src\Tensor.cpp" />
     <ClCompile Include="src\TerrainInfo.cpp" />
+    <ClCompile Include="src\Training.cpp" />
+    <ClCompile Include="src\TrainingCommand.cpp" />
+    <ClCompile Include="src\TrainingTest.cpp" />
     <ClCompile Include="src\Unit.cpp" />
     <ClCompile Include="src\UnitInfo.cpp" />
     <ClCompile Include="src\RestApiContractTest.cpp" />
@@ -229,6 +234,9 @@
     <ClInclude Include="inc\Terrain.h" />
     <ClInclude Include="inc\TerrainFileId.h" />
     <ClInclude Include="inc\TerrainInfo.h" />
+    <ClInclude Include="inc\Training.h" />
+    <ClInclude Include="inc\TrainingCommand.h" />
+    <ClInclude Include="inc\TrainingTest.h" />
     <ClInclude Include="inc\Unit.h" />
     <ClInclude Include="inc\UnitInfo.h" />
     <ClInclude Include="resource.h" />

--- a/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
+++ b/AdvanceWarsServer/AdvanceWarsServer.vcxproj.filters
@@ -99,6 +99,15 @@
     <ClCompile Include="src\StandardGameSetup.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Training.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TrainingCommand.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TrainingTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\Map.h">
@@ -204,6 +213,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inc\StandardGameSetup.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\Training.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\TrainingCommand.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\TrainingTest.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AdvanceWarsServer/inc/Training.h
+++ b/AdvanceWarsServer/inc/Training.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include "Result.h"
+
+struct TrainingOptions {
+	std::filesystem::path replayPath;
+	std::filesystem::path checkpointIn;
+	std::filesystem::path checkpointOut;
+	std::filesystem::path checkpointDir;
+	bool force{ false };
+	int epochs{ 1 };
+	int batchSize{ 32 };
+	std::optional<int> maxSamples;
+	double learningRate{ 0.001 };
+	double weightDecay{ 0.0001 };
+	double policyLossWeight{ 1.0 };
+	double valueLossWeight{ 1.0 };
+	double maxGradNorm{ 0.0 };
+	std::int64_t seed{ 0 };
+	int logEveryBatches{ 0 };
+	int checkpointEveryEpoch{ 0 };
+	std::string deviceName{ "auto" };
+	bool quiet{ false };
+};
+
+struct TrainingEpochSummary {
+	int epoch{ 0 };
+	int samples{ 0 };
+	int batches{ 0 };
+	double averagePolicyLoss{ 0.0 };
+	double averageValueLoss{ 0.0 };
+	double averageTotalLoss{ 0.0 };
+	double elapsedSeconds{ 0.0 };
+	std::filesystem::path checkpointPath;
+};
+
+struct TrainingSummary {
+	int replayFiles{ 0 };
+	int samplesLoaded{ 0 };
+	int samplesTrained{ 0 };
+	int epochsCompleted{ 0 };
+	int batchesCompleted{ 0 };
+	double averagePolicyLoss{ 0.0 };
+	double averageValueLoss{ 0.0 };
+	double averageTotalLoss{ 0.0 };
+	double elapsedSeconds{ 0.0 };
+	std::string resolvedDevice;
+	std::filesystem::path lastPeriodicCheckpoint;
+};
+
+struct TrainingError {
+	std::string code;
+	std::string message;
+	std::filesystem::path replayPath;
+	int line{ 0 };
+	int gameIndex{ -1 };
+	int ply{ -1 };
+	int epoch{ 0 };
+	int batch{ 0 };
+};
+
+Result RunTraining(const TrainingOptions& options, TrainingSummary& summary, TrainingError& error) noexcept;

--- a/AdvanceWarsServer/inc/TrainingCommand.h
+++ b/AdvanceWarsServer/inc/TrainingCommand.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int RunTrainingCommand(int argc, char* argv[]) noexcept;

--- a/AdvanceWarsServer/inc/TrainingTest.h
+++ b/AdvanceWarsServer/inc/TrainingTest.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int RunTrainingTests() noexcept;

--- a/AdvanceWarsServer/main.cpp
+++ b/AdvanceWarsServer/main.cpp
@@ -14,6 +14,8 @@
 #include "SelfPlayRunner.h"
 #include "SubsystemTest.h"
 #include "Platform.h"
+#include "TrainingCommand.h"
+#include "TrainingTest.h"
 
 int RunRestApiContractTests();
 
@@ -29,7 +31,9 @@ int main(int argc, char* argv[]) noexcept {
 			std::cerr << "  -test-mcts            : Run focused MCTS tests.\n";
 			std::cerr << "  -test-model           : Run focused policy/value model tests.\n";
 			std::cerr << "  -test-replay          : Run focused self-play replay tests.\n";
+			std::cerr << "  -test-train           : Run focused replay training tests.\n";
 			std::cerr << "  -model-init --out <dir> : Initialize and validate a policy/value checkpoint bundle.\n";
+			std::cerr << "  -train [options]      : Train a policy/value checkpoint from replay data.\n";
 			std::cerr << "  -torchlib [--mnist-path <path>] : Run a LibTorch smoke check and optional MNIST experiment.\n";
 			std::cerr << "  -server               : Act as game server.\n";
 			return 1; // Return an error code
@@ -220,11 +224,17 @@ int main(int argc, char* argv[]) noexcept {
 		else if (argument == "-test-replay") {
 			return RunSelfPlayReplayTests();
 		}
+		else if (argument == "-test-train") {
+			return RunTrainingTests();
+		}
 		else if (argument == "-self-play") {
 			return RunSelfPlayCommand(argc - 2, argv + 2);
 		}
 		else if (argument == "-validate-replay") {
 			return RunValidateReplayCommand(argc - 2, argv + 2);
+		}
+		else if (argument == "-train") {
+			return RunTrainingCommand(argc - 2, argv + 2);
 		}
 		else if (argument == "-server") {
 			return AdvanceWarsServer::getInstance().run();

--- a/AdvanceWarsServer/src/PolicyValueModel.cpp
+++ b/AdvanceWarsServer/src/PolicyValueModel.cpp
@@ -274,6 +274,7 @@ Result ParseMetadata(const json& metadata, PolicyValueModelConfig& config, std::
 Result PrepareCheckpointDirectory(const std::filesystem::path& checkpointDir, bool force, PolicyValueModelError& error) {
 	const std::filesystem::path metadataPath = checkpointDir / "metadata.json";
 	const std::filesystem::path modelPath = checkpointDir / "model.pt";
+	const std::filesystem::path trainingPath = checkpointDir / "training.json";
 
 	if (std::filesystem::exists(checkpointDir)) {
 		if (!std::filesystem::is_directory(checkpointDir)) {
@@ -287,13 +288,14 @@ Result PrepareCheckpointDirectory(const std::filesystem::path& checkpointDir, bo
 
 		for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(checkpointDir)) {
 			const std::filesystem::path filename = entry.path().filename();
-			if (filename != "metadata.json" && filename != "model.pt") {
+			if (filename != "metadata.json" && filename != "model.pt" && filename != "training.json") {
 				SetError(error, "checkpoint-has-unexpected-file", "checkpoint directory contains unexpected file: " + filename.string());
 				return Result::Failed;
 			}
 		}
 		std::filesystem::remove(metadataPath);
 		std::filesystem::remove(modelPath);
+		std::filesystem::remove(trainingPath);
 		return Result::Succeeded;
 	}
 

--- a/AdvanceWarsServer/src/Training.cpp
+++ b/AdvanceWarsServer/src/Training.cpp
@@ -1,0 +1,728 @@
+#include "Training.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <set>
+#include <sstream>
+#include <vector>
+
+#include <torch/torch.h>
+
+#include "ActionSpace.h"
+#include "PolicyValueModel.h"
+#include "SelfPlayReplay.h"
+#include "StateTensor.h"
+#include "nlohmann/json.hpp"
+
+namespace {
+using json = nlohmann::json;
+using ordered_json = nlohmann::ordered_json;
+
+struct ReplayGameRecord {
+	std::filesystem::path path;
+	int line{ 0 };
+	int gameIndex{ -1 };
+	json initialState;
+	json actions;
+};
+
+struct ReplaySampleRecord {
+	int gameRecordIndex{ -1 };
+	int ply{ -1 };
+	int currentPlayer{ -1 };
+	std::string stateTensorChecksum;
+	std::vector<int> legalActionIndices;
+	std::vector<std::pair<int, int>> visitCounts;
+	int selectedActionIndex{ -1 };
+	int outcome{ 0 };
+};
+
+struct ReplayDataset {
+	std::vector<std::filesystem::path> files;
+	std::vector<ReplayGameRecord> games;
+	std::vector<ReplaySampleRecord> samples;
+};
+
+struct BatchData {
+	std::vector<float> flatStates;
+	std::vector<std::vector<int>> legalActionIndices;
+	std::vector<std::vector<std::pair<int, int>>> visitCounts;
+	std::vector<float> outcomes;
+};
+
+void SetError(TrainingError& error, const std::string& code, const std::string& message, const std::filesystem::path& path = {}, int line = 0, int gameIndex = -1, int ply = -1, int epoch = 0, int batch = 0) {
+	error.code = code;
+	error.message = message;
+	error.replayPath = path;
+	error.line = line;
+	error.gameIndex = gameIndex;
+	error.ply = ply;
+	error.epoch = epoch;
+	error.batch = batch;
+}
+
+std::string ChecksumToHex(std::uint64_t checksum) {
+	std::ostringstream stream;
+	stream << std::hex << std::setw(16) << std::setfill('0') << checksum;
+	return stream.str();
+}
+
+std::string CurrentUtcTimestamp() {
+	const std::time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+	std::tm utc{};
+	gmtime_s(&utc, &now);
+	std::ostringstream stream;
+	stream << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+	return stream.str();
+}
+
+double ElapsedSeconds(const std::chrono::steady_clock::time_point& start, const std::chrono::steady_clock::time_point& end) {
+	return std::chrono::duration<double>(end - start).count();
+}
+
+std::filesystem::path NormalizePath(const std::filesystem::path& path) {
+	return std::filesystem::absolute(path).lexically_normal();
+}
+
+bool IsKnownTrainingBundleFile(const std::filesystem::path& path) {
+	const std::filesystem::path filename = path.filename();
+	return filename == "metadata.json" || filename == "model.pt" || filename == "training.json";
+}
+
+std::string EpochCheckpointName(int epoch) {
+	std::ostringstream stream;
+	stream << "epoch-" << std::setw(6) << std::setfill('0') << epoch;
+	return stream.str();
+}
+
+Result CheckCheckpointOutputAvailable(const std::filesystem::path& path, bool force, TrainingError& error, const std::string& label) {
+	if (!std::filesystem::exists(path)) {
+		return Result::Succeeded;
+	}
+	if (!std::filesystem::is_directory(path)) {
+		SetError(error, "checkpoint-path-not-directory", label + " exists but is not a directory");
+		return Result::Failed;
+	}
+	if (!force) {
+		SetError(error, "checkpoint-exists", label + " already exists; pass --force to overwrite known bundle files");
+		return Result::Failed;
+	}
+
+	for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(path)) {
+		if (!IsKnownTrainingBundleFile(entry.path())) {
+			SetError(error, "checkpoint-has-unexpected-file", label + " contains unexpected file: " + entry.path().filename().string());
+			return Result::Failed;
+		}
+	}
+	return Result::Succeeded;
+}
+
+Result ValidateTrainingOptions(const TrainingOptions& options, TrainingError& error) {
+	if (options.replayPath.empty()) {
+		SetError(error, "missing-replay", "--replay is required");
+		return Result::Failed;
+	}
+	if (options.checkpointIn.empty()) {
+		SetError(error, "missing-checkpoint-in", "--checkpoint-in is required");
+		return Result::Failed;
+	}
+	if (options.checkpointOut.empty()) {
+		SetError(error, "missing-checkpoint-out", "--checkpoint-out is required");
+		return Result::Failed;
+	}
+	if (options.epochs <= 0) {
+		SetError(error, "invalid-epochs", "--epochs must be greater than 0");
+		return Result::Failed;
+	}
+	if (options.batchSize <= 0) {
+		SetError(error, "invalid-batch-size", "--batch-size must be greater than 0");
+		return Result::Failed;
+	}
+	if (options.maxSamples.has_value() && options.maxSamples.value() <= 0) {
+		SetError(error, "invalid-max-samples", "--max-samples must be greater than 0");
+		return Result::Failed;
+	}
+	if (!std::isfinite(options.learningRate) || options.learningRate <= 0.0) {
+		SetError(error, "invalid-learning-rate", "--learning-rate must be finite and greater than 0");
+		return Result::Failed;
+	}
+	if (!std::isfinite(options.weightDecay) || options.weightDecay < 0.0) {
+		SetError(error, "invalid-weight-decay", "--weight-decay must be finite and greater than or equal to 0");
+		return Result::Failed;
+	}
+	if (!std::isfinite(options.policyLossWeight) || !std::isfinite(options.valueLossWeight) ||
+		options.policyLossWeight < 0.0 || options.valueLossWeight < 0.0 || (options.policyLossWeight == 0.0 && options.valueLossWeight == 0.0)) {
+		SetError(error, "invalid-loss-weights", "loss weights must be finite, nonnegative, and at least one must be positive");
+		return Result::Failed;
+	}
+	if (!std::isfinite(options.maxGradNorm) || options.maxGradNorm < 0.0) {
+		SetError(error, "invalid-max-grad-norm", "--max-grad-norm must be finite and greater than or equal to 0");
+		return Result::Failed;
+	}
+	if (options.seed < 0) {
+		SetError(error, "invalid-seed", "--seed must be nonnegative");
+		return Result::Failed;
+	}
+	if (options.logEveryBatches < 0) {
+		SetError(error, "invalid-log-every-batches", "--log-every-batches must be greater than or equal to 0");
+		return Result::Failed;
+	}
+	if (options.checkpointEveryEpoch < 0) {
+		SetError(error, "invalid-checkpoint-every-epochs", "--checkpoint-every-epochs must be greater than or equal to 0");
+		return Result::Failed;
+	}
+	if (options.checkpointEveryEpoch > 0 && options.checkpointDir.empty()) {
+		SetError(error, "missing-checkpoint-dir", "--checkpoint-dir is required with --checkpoint-every-epochs");
+		return Result::Failed;
+	}
+	if (NormalizePath(options.checkpointIn) == NormalizePath(options.checkpointOut)) {
+		SetError(error, "checkpoint-path-conflict", "--checkpoint-in and --checkpoint-out must be different paths");
+		return Result::Failed;
+	}
+	if (!std::filesystem::exists(options.checkpointIn)) {
+		SetError(error, "checkpoint-in-missing", "--checkpoint-in does not exist");
+		return Result::Failed;
+	}
+	IfFailedReturn(CheckCheckpointOutputAvailable(options.checkpointOut, options.force, error, "--checkpoint-out"));
+	if (options.checkpointEveryEpoch > 0) {
+		for (int epoch = options.checkpointEveryEpoch; epoch <= options.epochs; epoch += options.checkpointEveryEpoch) {
+			const std::filesystem::path checkpointPath = options.checkpointDir / EpochCheckpointName(epoch);
+			IfFailedReturn(CheckCheckpointOutputAvailable(checkpointPath, options.force, error, "periodic checkpoint"));
+		}
+	}
+	return Result::Succeeded;
+}
+
+Result ResolveReplayFiles(const std::filesystem::path& replayPath, std::vector<std::filesystem::path>& files, TrainingError& error) {
+	files.clear();
+	if (!std::filesystem::exists(replayPath)) {
+		SetError(error, "replay-missing", "replay path does not exist: " + replayPath.string(), replayPath);
+		return Result::Failed;
+	}
+	if (std::filesystem::is_regular_file(replayPath)) {
+		files.push_back(replayPath);
+		return Result::Succeeded;
+	}
+	if (!std::filesystem::is_directory(replayPath)) {
+		SetError(error, "replay-path-invalid", "replay path is neither a file nor directory: " + replayPath.string(), replayPath);
+		return Result::Failed;
+	}
+
+	for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(replayPath)) {
+		if (entry.is_regular_file() && entry.path().extension() == ".jsonl") {
+			files.push_back(entry.path());
+		}
+	}
+	std::sort(files.begin(), files.end());
+	if (files.empty()) {
+		SetError(error, "replay-empty", "replay directory contains no .jsonl shards: " + replayPath.string(), replayPath);
+		return Result::Failed;
+	}
+	return Result::Succeeded;
+}
+
+bool ReadIntArray(const json& value, std::vector<int>& output) {
+	if (!value.is_array()) {
+		return false;
+	}
+	output.clear();
+	for (const json& item : value) {
+		if (!item.is_number_integer()) {
+			return false;
+		}
+		output.push_back(item.get<int>());
+	}
+	return true;
+}
+
+bool ReadVisitCounts(const json& value, std::vector<std::pair<int, int>>& output) {
+	if (!value.is_array()) {
+		return false;
+	}
+	output.clear();
+	for (const json& item : value) {
+		if (!item.is_object() || !item.contains("actionIndex") || !item.contains("visits") ||
+			!item.at("actionIndex").is_number_integer() || !item.at("visits").is_number_integer()) {
+			return false;
+		}
+		output.push_back({ item.at("actionIndex").get<int>(), item.at("visits").get<int>() });
+	}
+	return true;
+}
+
+Result AppendGameSamples(const std::filesystem::path& path, int line, const json& game, const std::optional<int>& maxSamples, ReplayDataset& dataset, TrainingError& error) {
+	if (!game.is_object() || !game.contains("initialState") || !game.contains("actions") || !game.contains("samples")) {
+		SetError(error, "replay-schema-error", "game record is missing required training fields", path, line);
+		return Result::Failed;
+	}
+
+	ReplayGameRecord gameRecord;
+	gameRecord.path = path;
+	gameRecord.line = line;
+	gameRecord.gameIndex = game.value("gameIndex", -1);
+	gameRecord.initialState = game.at("initialState");
+	gameRecord.actions = game.at("actions");
+	const int gameRecordIndex = static_cast<int>(dataset.games.size());
+	dataset.games.push_back(std::move(gameRecord));
+
+	const json& samples = game.at("samples");
+	for (const json& sample : samples) {
+		if (maxSamples.has_value() && static_cast<int>(dataset.samples.size()) >= maxSamples.value()) {
+			break;
+		}
+		ReplaySampleRecord record;
+		record.gameRecordIndex = gameRecordIndex;
+		record.ply = sample.at("ply").get<int>();
+		record.currentPlayer = sample.at("currentPlayer").get<int>();
+		record.stateTensorChecksum = sample.at("stateTensorChecksum").get<std::string>();
+		record.selectedActionIndex = sample.at("selectedActionIndex").get<int>();
+		record.outcome = sample.at("outcome").get<int>();
+		if (!ReadIntArray(sample.at("legalActionIndices"), record.legalActionIndices) ||
+			!ReadVisitCounts(sample.at("visitCounts"), record.visitCounts)) {
+			SetError(error, "replay-schema-error", "sample has malformed legal action or visit-count arrays", path, line, gameRecord.gameIndex, record.ply);
+			return Result::Failed;
+		}
+		dataset.samples.push_back(std::move(record));
+	}
+	return Result::Succeeded;
+}
+
+Result ParseReplayFile(const std::filesystem::path& path, const std::optional<int>& maxSamples, ReplayDataset& dataset, TrainingError& error) {
+	std::ifstream input(path);
+	if (!input.is_open()) {
+		SetError(error, "replay-open-failed", "could not open replay file: " + path.string(), path);
+		return Result::Failed;
+	}
+
+	std::string line;
+	int lineNumber = 0;
+	while (std::getline(input, line)) {
+		++lineNumber;
+		if (lineNumber == 1) {
+			continue;
+		}
+		if (maxSamples.has_value() && static_cast<int>(dataset.samples.size()) >= maxSamples.value()) {
+			break;
+		}
+		json record;
+		try {
+			record = json::parse(line);
+		}
+		catch (const std::exception& err) {
+			SetError(error, "replay-json-error", err.what(), path, lineNumber);
+			return Result::Failed;
+		}
+		if (record.value("recordType", "") == "game") {
+			IfFailedReturn(AppendGameSamples(path, lineNumber, record, maxSamples, dataset, error));
+		}
+	}
+	return Result::Succeeded;
+}
+
+Result LoadReplayDataset(const TrainingOptions& options, ReplayDataset& dataset, TrainingError& error) {
+	dataset = ReplayDataset{};
+	IfFailedReturn(ResolveReplayFiles(options.replayPath, dataset.files, error));
+
+	for (const std::filesystem::path& path : dataset.files) {
+		SelfPlayReplayValidationSummary validationSummary;
+		SelfPlayError replayError;
+		if (ValidateSelfPlayReplay(path, validationSummary, replayError) == Result::Failed) {
+			SetError(error, replayError.code, replayError.message, path, replayError.line, replayError.gameIndex, replayError.ply);
+			return Result::Failed;
+		}
+		IfFailedReturn(ParseReplayFile(path, options.maxSamples, dataset, error));
+		if (options.maxSamples.has_value() && static_cast<int>(dataset.samples.size()) >= options.maxSamples.value()) {
+			break;
+		}
+	}
+
+	if (dataset.samples.empty()) {
+		SetError(error, "replay-empty", "replay input contains no training samples", options.replayPath);
+		return Result::Failed;
+	}
+	return Result::Succeeded;
+}
+
+Result EncodeLegalActionIndices(const GameState& gameState, std::vector<int>& legalActionIndices, TrainingError& error, const ReplayGameRecord& game, int ply) {
+	std::vector<Action> legalActions;
+	if (gameState.GetValidActions(legalActions) == Result::Failed) {
+		SetError(error, "legal-actions-failed", "legal action generation failed", game.path, game.line, game.gameIndex, ply);
+		return Result::Failed;
+	}
+	legalActionIndices.clear();
+	for (const Action& action : legalActions) {
+		int actionIndex = -1;
+		if (ActionSpace::EncodeAction(action, actionIndex) == Result::Failed) {
+			SetError(error, "action-encoding-failed", "legal action failed to encode", game.path, game.line, game.gameIndex, ply);
+			return Result::Failed;
+		}
+		legalActionIndices.push_back(actionIndex);
+	}
+	std::sort(legalActionIndices.begin(), legalActionIndices.end());
+	legalActionIndices.erase(std::unique(legalActionIndices.begin(), legalActionIndices.end()), legalActionIndices.end());
+	return Result::Succeeded;
+}
+
+Result ReconstructStateForSample(const ReplayGameRecord& game, const ReplaySampleRecord& sample, GameState& gameState, TrainingError& error) {
+	try {
+		json initialState = game.initialState;
+		GameState::from_json(initialState, gameState);
+		for (int i = 0; i < sample.ply; ++i) {
+			json actionJson = game.actions.at(i).at("action");
+			Action action;
+			from_json(actionJson, action);
+			if (gameState.DoAction(action) == Result::Failed) {
+				SetError(error, "action-apply-failed", "recorded action failed during state reconstruction", game.path, game.line, game.gameIndex, i);
+				return Result::Failed;
+			}
+			if (gameState.FHeuristicAutoResign()) {
+				gameState.CheckPlayerResigns();
+			}
+		}
+		return Result::Succeeded;
+	}
+	catch (const std::exception& err) {
+		SetError(error, "state-reconstruction-failed", err.what(), game.path, game.line, game.gameIndex, sample.ply);
+		return Result::Failed;
+	}
+}
+
+Result AddSampleToBatch(const ReplayDataset& dataset, int sampleIndex, BatchData& batch, TrainingError& error) {
+	const ReplaySampleRecord& sample = dataset.samples.at(sampleIndex);
+	const ReplayGameRecord& game = dataset.games.at(sample.gameRecordIndex);
+	GameState gameState;
+	IfFailedReturn(ReconstructStateForSample(game, sample, gameState, error));
+
+	std::vector<int> legalActionIndices;
+	IfFailedReturn(EncodeLegalActionIndices(gameState, legalActionIndices, error, game, sample.ply));
+	if (legalActionIndices != sample.legalActionIndices) {
+		SetError(error, "legal-actions-mismatch", "legalActionIndices do not match reconstructed state", game.path, game.line, game.gameIndex, sample.ply);
+		return Result::Failed;
+	}
+
+	std::vector<float> values;
+	if (StateTensor::Encode(gameState, values) == Result::Failed) {
+		SetError(error, "state-tensor-failed", "state tensor encoding failed", game.path, game.line, game.gameIndex, sample.ply);
+		return Result::Failed;
+	}
+	std::uint64_t rawChecksum = 0;
+	if (StateTensor::Checksum(values, rawChecksum) == Result::Failed) {
+		SetError(error, "state-tensor-checksum-failed", "state tensor checksum failed", game.path, game.line, game.gameIndex, sample.ply);
+		return Result::Failed;
+	}
+	if (ChecksumToHex(rawChecksum) != sample.stateTensorChecksum) {
+		SetError(error, "state-checksum-mismatch", "state tensor checksum does not match replay sample", game.path, game.line, game.gameIndex, sample.ply);
+		return Result::Failed;
+	}
+
+	batch.flatStates.insert(batch.flatStates.end(), values.begin(), values.end());
+	batch.legalActionIndices.push_back(sample.legalActionIndices);
+	batch.visitCounts.push_back(sample.visitCounts);
+	batch.outcomes.push_back(static_cast<float>(sample.outcome));
+	return Result::Succeeded;
+}
+
+Result BuildBatch(const ReplayDataset& dataset, const std::vector<int>& order, int start, int count, BatchData& batch, TrainingError& error) {
+	batch = BatchData{};
+	for (int i = 0; i < count; ++i) {
+		IfFailedReturn(AddSampleToBatch(dataset, order.at(start + i), batch, error));
+	}
+	return Result::Succeeded;
+}
+
+torch::Tensor MakeInputTensor(const BatchData& batch, int batchSize, const torch::Device& device) {
+	return torch::from_blob(
+		const_cast<float*>(batch.flatStates.data()),
+		{ batchSize, StateTensor::ChannelCount(), StateTensor::BoardHeight(), StateTensor::BoardWidth() },
+		torch::TensorOptions().dtype(torch::kFloat32)).clone().contiguous().to(device);
+}
+
+torch::Tensor ComputePolicyLoss(const torch::Tensor& policyLogits, const BatchData& batch, const torch::Device& device) {
+	std::vector<torch::Tensor> losses;
+	for (std::size_t i = 0; i < batch.legalActionIndices.size(); ++i) {
+		const std::vector<int>& legal = batch.legalActionIndices[i];
+		torch::Tensor legalIndices = torch::tensor(legal, torch::TensorOptions().dtype(torch::kInt64)).to(device);
+		torch::Tensor legalLogProbs = torch::log_softmax(policyLogits[static_cast<std::int64_t>(i)].index_select(0, legalIndices), 0);
+
+		std::vector<float> targets(legal.size(), 0.0f);
+		int visitSum = 0;
+		for (const auto& visit : batch.visitCounts[i]) {
+			visitSum += visit.second;
+		}
+		if (visitSum > 0) {
+			for (const auto& visit : batch.visitCounts[i]) {
+				auto it = std::lower_bound(legal.begin(), legal.end(), visit.first);
+				if (it != legal.end() && *it == visit.first) {
+					targets[static_cast<std::size_t>(std::distance(legal.begin(), it))] = static_cast<float>(visit.second) / static_cast<float>(visitSum);
+				}
+			}
+		}
+
+		torch::Tensor targetTensor = torch::from_blob(targets.data(), { static_cast<std::int64_t>(targets.size()) }, torch::TensorOptions().dtype(torch::kFloat32)).clone().to(device);
+		losses.push_back(-(targetTensor * legalLogProbs).sum());
+	}
+	return torch::stack(losses).mean();
+}
+
+ordered_json EpochSummaryJson(const TrainingEpochSummary& epoch) {
+	ordered_json jsonEpoch;
+	jsonEpoch["epoch"] = epoch.epoch;
+	jsonEpoch["samples"] = epoch.samples;
+	jsonEpoch["batches"] = epoch.batches;
+	jsonEpoch["averagePolicyLoss"] = epoch.averagePolicyLoss;
+	jsonEpoch["averageValueLoss"] = epoch.averageValueLoss;
+	jsonEpoch["averageTotalLoss"] = epoch.averageTotalLoss;
+	jsonEpoch["elapsedSeconds"] = epoch.elapsedSeconds;
+	if (!epoch.checkpointPath.empty()) {
+		jsonEpoch["checkpointPath"] = epoch.checkpointPath.string();
+	}
+	return jsonEpoch;
+}
+
+ordered_json BuildTrainingMetadata(
+	const TrainingOptions& options,
+	const TrainingSummary& summary,
+	const std::vector<TrainingEpochSummary>& epochHistory,
+	const std::string& checkpointRole,
+	int completedEpoch,
+	const std::filesystem::path& checkpointPath) {
+	ordered_json metadata;
+	metadata["trainingMetadataVersion"] = 1;
+	metadata["createdAt"] = CurrentUtcTimestamp();
+	metadata["checkpointRole"] = checkpointRole;
+	metadata["completedEpoch"] = completedEpoch;
+	metadata["replayPath"] = options.replayPath.string();
+	metadata["checkpointIn"] = options.checkpointIn.string();
+	metadata["checkpointPath"] = checkpointPath.string();
+	metadata["sampleCount"] = summary.samplesLoaded;
+	metadata["samplesTrained"] = summary.samplesTrained;
+	metadata["epochsCompleted"] = summary.epochsCompleted;
+	metadata["batchesCompleted"] = summary.batchesCompleted;
+	metadata["device"] = summary.resolvedDevice;
+	metadata["elapsedSeconds"] = summary.elapsedSeconds;
+	metadata["options"] = ordered_json{
+		{ "epochs", options.epochs },
+		{ "batchSize", options.batchSize },
+		{ "maxSamples", options.maxSamples.has_value() ? json(options.maxSamples.value()) : json(nullptr) },
+		{ "learningRate", options.learningRate },
+		{ "weightDecay", options.weightDecay },
+		{ "policyLossWeight", options.policyLossWeight },
+		{ "valueLossWeight", options.valueLossWeight },
+		{ "maxGradNorm", options.maxGradNorm },
+		{ "seed", options.seed },
+	};
+	metadata["averagePolicyLoss"] = summary.averagePolicyLoss;
+	metadata["averageValueLoss"] = summary.averageValueLoss;
+	metadata["averageTotalLoss"] = summary.averageTotalLoss;
+	metadata["epochHistory"] = ordered_json::array();
+	for (const TrainingEpochSummary& epoch : epochHistory) {
+		metadata["epochHistory"].push_back(EpochSummaryJson(epoch));
+	}
+	return metadata;
+}
+
+Result WriteTrainingMetadata(
+	const std::filesystem::path& checkpointPath,
+	const TrainingOptions& options,
+	const TrainingSummary& summary,
+	const std::vector<TrainingEpochSummary>& epochHistory,
+	const std::string& checkpointRole,
+	int completedEpoch,
+	TrainingError& error) {
+	std::ofstream output(checkpointPath / "training.json", std::ios::trunc);
+	if (!output.is_open()) {
+		SetError(error, "training-metadata-write-failed", "could not write training.json: " + (checkpointPath / "training.json").string());
+		return Result::Failed;
+	}
+	output << BuildTrainingMetadata(options, summary, epochHistory, checkpointRole, completedEpoch, checkpointPath).dump(2) << "\n";
+	return Result::Succeeded;
+}
+
+Result SaveTrainingCheckpoint(
+	const std::filesystem::path& checkpointPath,
+	PolicyValueNetwork& model,
+	const PolicyValueModelConfig& config,
+	std::int64_t seed,
+	const std::string& resolvedDevice,
+	const TrainingOptions& options,
+	const TrainingSummary& summary,
+	const std::vector<TrainingEpochSummary>& epochHistory,
+	const std::string& role,
+	int completedEpoch,
+	bool force,
+	TrainingError& error) {
+	PolicyValueModelError modelError;
+	if (SavePolicyValueCheckpoint(checkpointPath, model, config, seed, resolvedDevice, force, modelError) == Result::Failed) {
+		SetError(error, modelError.code, modelError.message);
+		return Result::Failed;
+	}
+	return WriteTrainingMetadata(checkpointPath, options, summary, epochHistory, role, completedEpoch, error);
+}
+
+void PrintEpochProgress(const TrainingEpochSummary& epoch) {
+	std::cout << "Epoch " << epoch.epoch <<
+		" samples=" << epoch.samples <<
+		" batches=" << epoch.batches <<
+		" policyLoss=" << epoch.averagePolicyLoss <<
+		" valueLoss=" << epoch.averageValueLoss <<
+		" totalLoss=" << epoch.averageTotalLoss <<
+		" elapsedSeconds=" << epoch.elapsedSeconds << std::endl;
+}
+}
+
+Result RunTraining(const TrainingOptions& options, TrainingSummary& summary, TrainingError& error) noexcept {
+	try {
+		summary = TrainingSummary{};
+		error = TrainingError{};
+		const auto runStart = std::chrono::steady_clock::now();
+
+		IfFailedReturn(ValidateTrainingOptions(options, error));
+
+		PolicyValueNetwork model(nullptr);
+		PolicyValueModelConfig config;
+		std::int64_t checkpointSeed = -1;
+		PolicyValueModelError modelError;
+		if (LoadPolicyValueCheckpoint(options.checkpointIn, model, config, checkpointSeed, modelError) == Result::Failed) {
+			SetError(error, modelError.code, modelError.message);
+			return Result::Failed;
+		}
+
+		const torch::Device device = ResolvePolicyValueDevice(options.deviceName, modelError);
+		if (!modelError.code.empty()) {
+			SetError(error, modelError.code, modelError.message);
+			return Result::Failed;
+		}
+		summary.resolvedDevice = PolicyValueDeviceName(device);
+
+		ReplayDataset dataset;
+		IfFailedReturn(LoadReplayDataset(options, dataset, error));
+		summary.replayFiles = static_cast<int>(dataset.files.size());
+		summary.samplesLoaded = static_cast<int>(dataset.samples.size());
+
+		model->to(device);
+		model->train();
+		torch::optim::AdamW optimizer(model->parameters(), torch::optim::AdamWOptions(options.learningRate).weight_decay(options.weightDecay));
+
+		if (!options.quiet) {
+			std::cout << "Training start: samples=" << summary.samplesLoaded <<
+				" epochs=" << options.epochs <<
+				" batchSize=" << options.batchSize <<
+				" device=" << summary.resolvedDevice <<
+				" checkpointIn=" << options.checkpointIn.string() <<
+				" checkpointOut=" << options.checkpointOut.string() << std::endl;
+		}
+
+		std::vector<int> baseOrder(dataset.samples.size());
+		std::iota(baseOrder.begin(), baseOrder.end(), 0);
+		std::vector<TrainingEpochSummary> epochHistory;
+		epochHistory.reserve(static_cast<std::size_t>(options.epochs));
+
+		double totalPolicyLossWeighted = 0.0;
+		double totalValueLossWeighted = 0.0;
+		double totalLossWeighted = 0.0;
+		int totalSamplesTrained = 0;
+
+		for (int epoch = 1; epoch <= options.epochs; ++epoch) {
+			const auto epochStart = std::chrono::steady_clock::now();
+			std::vector<int> order = baseOrder;
+			std::mt19937_64 rng(static_cast<std::uint64_t>(options.seed) + static_cast<std::uint64_t>(epoch) * 0x9e3779b97f4a7c15ULL);
+			std::shuffle(order.begin(), order.end(), rng);
+
+			TrainingEpochSummary epochSummary;
+			epochSummary.epoch = epoch;
+			double epochPolicyLossWeighted = 0.0;
+			double epochValueLossWeighted = 0.0;
+			double epochTotalLossWeighted = 0.0;
+
+			for (int start = 0; start < static_cast<int>(order.size()); start += options.batchSize) {
+				const int batchNumber = epochSummary.batches + 1;
+				const int batchCount = std::min(options.batchSize, static_cast<int>(order.size()) - start);
+				BatchData batch;
+				if (BuildBatch(dataset, order, start, batchCount, batch, error) == Result::Failed) {
+					error.epoch = epoch;
+					error.batch = batchNumber;
+					return Result::Failed;
+				}
+
+				torch::Tensor input = MakeInputTensor(batch, batchCount, device);
+				torch::Tensor outcomes = torch::from_blob(batch.outcomes.data(), { batchCount }, torch::TensorOptions().dtype(torch::kFloat32)).clone().to(device);
+
+				model->train();
+				PolicyValueNetworkOutput output = model->forward(input);
+				torch::Tensor policyLoss = ComputePolicyLoss(output.policyLogits, batch, device);
+				torch::Tensor valueLoss = torch::mse_loss(output.value.view({ batchCount }), outcomes);
+				torch::Tensor totalLoss = policyLoss * options.policyLossWeight + valueLoss * options.valueLossWeight;
+
+				optimizer.zero_grad();
+				totalLoss.backward();
+				if (options.maxGradNorm > 0.0) {
+					torch::nn::utils::clip_grad_norm_(model->parameters(), options.maxGradNorm);
+				}
+				optimizer.step();
+
+				const double policyLossValue = policyLoss.detach().cpu().item<double>();
+				const double valueLossValue = valueLoss.detach().cpu().item<double>();
+				const double totalLossValue = totalLoss.detach().cpu().item<double>();
+				epochPolicyLossWeighted += policyLossValue * batchCount;
+				epochValueLossWeighted += valueLossValue * batchCount;
+				epochTotalLossWeighted += totalLossValue * batchCount;
+				totalPolicyLossWeighted += policyLossValue * batchCount;
+				totalValueLossWeighted += valueLossValue * batchCount;
+				totalLossWeighted += totalLossValue * batchCount;
+				totalSamplesTrained += batchCount;
+				epochSummary.samples += batchCount;
+				++epochSummary.batches;
+				++summary.batchesCompleted;
+
+				if (!options.quiet && options.logEveryBatches > 0 && batchNumber % options.logEveryBatches == 0) {
+					std::cout << "Batch epoch=" << epoch << " batch=" << batchNumber << " totalLoss=" << totalLossValue << std::endl;
+				}
+			}
+
+			const auto epochEnd = std::chrono::steady_clock::now();
+			epochSummary.elapsedSeconds = ElapsedSeconds(epochStart, epochEnd);
+			epochSummary.averagePolicyLoss = epochPolicyLossWeighted / epochSummary.samples;
+			epochSummary.averageValueLoss = epochValueLossWeighted / epochSummary.samples;
+			epochSummary.averageTotalLoss = epochTotalLossWeighted / epochSummary.samples;
+			summary.samplesTrained += epochSummary.samples;
+			summary.epochsCompleted = epoch;
+			summary.averagePolicyLoss = totalPolicyLossWeighted / totalSamplesTrained;
+			summary.averageValueLoss = totalValueLossWeighted / totalSamplesTrained;
+			summary.averageTotalLoss = totalLossWeighted / totalSamplesTrained;
+			summary.elapsedSeconds = ElapsedSeconds(runStart, epochEnd);
+
+			if (options.checkpointEveryEpoch > 0 && epoch % options.checkpointEveryEpoch == 0) {
+				const std::filesystem::path periodicPath = options.checkpointDir / EpochCheckpointName(epoch);
+				epochSummary.checkpointPath = periodicPath;
+				epochHistory.push_back(epochSummary);
+				summary.lastPeriodicCheckpoint = periodicPath;
+				IfFailedReturn(SaveTrainingCheckpoint(periodicPath, model, config, checkpointSeed, summary.resolvedDevice, options, summary, epochHistory, "periodic", epoch, options.force, error));
+				model->to(device);
+				model->train();
+			}
+			else {
+				epochHistory.push_back(epochSummary);
+			}
+
+			if (!options.quiet) {
+				PrintEpochProgress(epochSummary);
+			}
+		}
+
+		summary.elapsedSeconds = ElapsedSeconds(runStart, std::chrono::steady_clock::now());
+		IfFailedReturn(SaveTrainingCheckpoint(options.checkpointOut, model, config, checkpointSeed, summary.resolvedDevice, options, summary, epochHistory, "final", summary.epochsCompleted, options.force, error));
+		return Result::Succeeded;
+	}
+	catch (const std::exception& err) {
+		SetError(error, "training-exception", err.what());
+		return Result::Failed;
+	}
+}

--- a/AdvanceWarsServer/src/TrainingCommand.cpp
+++ b/AdvanceWarsServer/src/TrainingCommand.cpp
@@ -1,0 +1,202 @@
+#include "TrainingCommand.h"
+
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "Training.h"
+
+namespace {
+bool ParseInt(const std::string& text, int& value) {
+	try {
+		std::size_t processed = 0;
+		const long long parsed = std::stoll(text, &processed);
+		if (processed != text.size() || parsed < std::numeric_limits<int>::min() || parsed > std::numeric_limits<int>::max()) {
+			return false;
+		}
+		value = static_cast<int>(parsed);
+		return true;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool ParseInt64(const std::string& text, std::int64_t& value) {
+	try {
+		std::size_t processed = 0;
+		const long long parsed = std::stoll(text, &processed);
+		if (processed != text.size()) {
+			return false;
+		}
+		value = static_cast<std::int64_t>(parsed);
+		return true;
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+bool ParseDouble(const std::string& text, double& value) {
+	try {
+		std::size_t processed = 0;
+		value = std::stod(text, &processed);
+		return processed == text.size() && std::isfinite(value);
+	}
+	catch (const std::exception&) {
+		return false;
+	}
+}
+
+int PrintTrainingError(const TrainingError& error, const TrainingSummary& summary) {
+	std::cerr << error.code << ": " << error.message;
+	if (!error.replayPath.empty()) {
+		std::cerr << " replay=" << error.replayPath.string();
+	}
+	if (error.line > 0) {
+		std::cerr << " line=" << error.line;
+	}
+	if (error.gameIndex >= 0) {
+		std::cerr << " game=" << error.gameIndex;
+	}
+	if (error.ply >= 0) {
+		std::cerr << " ply=" << error.ply;
+	}
+	if (error.epoch > 0) {
+		std::cerr << " epoch=" << error.epoch;
+	}
+	if (error.batch > 0) {
+		std::cerr << " batch=" << error.batch;
+	}
+	std::cerr << std::endl;
+	std::cerr << "Training failed after samplesLoaded=" << summary.samplesLoaded <<
+		" epochsCompleted=" << summary.epochsCompleted <<
+		" batchesCompleted=" << summary.batchesCompleted;
+	if (!summary.lastPeriodicCheckpoint.empty()) {
+		std::cerr << " lastPeriodicCheckpoint=" << summary.lastPeriodicCheckpoint.string();
+	}
+	std::cerr << std::endl;
+	return 1;
+}
+}
+
+int RunTrainingCommand(int argc, char* argv[]) noexcept {
+	try {
+		TrainingOptions options;
+		for (int i = 0; i < argc; ++i) {
+			const std::string argument = argv[i];
+			if (argument == "--replay" && i + 1 < argc) {
+				options.replayPath = argv[++i];
+			}
+			else if (argument == "--checkpoint-in" && i + 1 < argc) {
+				options.checkpointIn = argv[++i];
+			}
+			else if (argument == "--checkpoint-out" && i + 1 < argc) {
+				options.checkpointOut = argv[++i];
+			}
+			else if (argument == "--checkpoint-dir" && i + 1 < argc) {
+				options.checkpointDir = argv[++i];
+			}
+			else if (argument == "--epochs" && i + 1 < argc) {
+				if (!ParseInt(argv[++i], options.epochs)) {
+					std::cerr << "Invalid --epochs value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--batch-size" && i + 1 < argc) {
+				if (!ParseInt(argv[++i], options.batchSize)) {
+					std::cerr << "Invalid --batch-size value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--max-samples" && i + 1 < argc) {
+				int maxSamples = 0;
+				if (!ParseInt(argv[++i], maxSamples)) {
+					std::cerr << "Invalid --max-samples value" << std::endl;
+					return 1;
+				}
+				options.maxSamples = maxSamples;
+			}
+			else if (argument == "--learning-rate" && i + 1 < argc) {
+				if (!ParseDouble(argv[++i], options.learningRate)) {
+					std::cerr << "Invalid --learning-rate value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--weight-decay" && i + 1 < argc) {
+				if (!ParseDouble(argv[++i], options.weightDecay)) {
+					std::cerr << "Invalid --weight-decay value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--policy-loss-weight" && i + 1 < argc) {
+				if (!ParseDouble(argv[++i], options.policyLossWeight)) {
+					std::cerr << "Invalid --policy-loss-weight value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--value-loss-weight" && i + 1 < argc) {
+				if (!ParseDouble(argv[++i], options.valueLossWeight)) {
+					std::cerr << "Invalid --value-loss-weight value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--max-grad-norm" && i + 1 < argc) {
+				if (!ParseDouble(argv[++i], options.maxGradNorm)) {
+					std::cerr << "Invalid --max-grad-norm value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--seed" && i + 1 < argc) {
+				if (!ParseInt64(argv[++i], options.seed)) {
+					std::cerr << "Invalid --seed value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--device" && i + 1 < argc) {
+				options.deviceName = argv[++i];
+			}
+			else if (argument == "--log-every-batches" && i + 1 < argc) {
+				if (!ParseInt(argv[++i], options.logEveryBatches)) {
+					std::cerr << "Invalid --log-every-batches value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--checkpoint-every-epochs" && i + 1 < argc) {
+				if (!ParseInt(argv[++i], options.checkpointEveryEpoch)) {
+					std::cerr << "Invalid --checkpoint-every-epochs value" << std::endl;
+					return 1;
+				}
+			}
+			else if (argument == "--force") {
+				options.force = true;
+			}
+			else {
+				std::cerr << "Unknown -train option: " << argument << std::endl;
+				return 1;
+			}
+		}
+
+		TrainingSummary summary;
+		TrainingError error;
+		if (RunTraining(options, summary, error) == Result::Failed) {
+			return PrintTrainingError(error, summary);
+		}
+
+		std::cout << "Training complete: samples=" << summary.samplesTrained <<
+			" epochs=" << summary.epochsCompleted <<
+			" batches=" << summary.batchesCompleted <<
+			" policyLoss=" << summary.averagePolicyLoss <<
+			" valueLoss=" << summary.averageValueLoss <<
+			" totalLoss=" << summary.averageTotalLoss <<
+			" elapsedSeconds=" << summary.elapsedSeconds <<
+			" checkpointOut=" << options.checkpointOut.string() << std::endl;
+		return 0;
+	}
+	catch (const std::exception& err) {
+		std::cerr << "training command exception: " << err.what() << std::endl;
+		return 1;
+	}
+}

--- a/AdvanceWarsServer/src/TrainingTest.cpp
+++ b/AdvanceWarsServer/src/TrainingTest.cpp
@@ -1,0 +1,153 @@
+#include "TrainingTest.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "PolicyValueModel.h"
+#include "SelfPlayRunner.h"
+#include "Training.h"
+
+namespace {
+bool Expect(bool condition, const std::string& message) {
+	if (!condition) {
+		std::cerr << "Training test failed: " << message << std::endl;
+		return false;
+	}
+
+	return true;
+}
+
+std::filesystem::path MakeTempPath(const std::string& name) {
+	return std::filesystem::temp_directory_path() / ("advance-wars-" + name);
+}
+
+bool AnyParameterChanged(const std::filesystem::path& beforePath, const std::filesystem::path& afterPath) {
+	PolicyValueNetwork before(nullptr);
+	PolicyValueNetwork after(nullptr);
+	PolicyValueModelConfig beforeConfig;
+	PolicyValueModelConfig afterConfig;
+	std::int64_t beforeSeed = -1;
+	std::int64_t afterSeed = -1;
+	PolicyValueModelError error;
+	if (LoadPolicyValueCheckpoint(beforePath, before, beforeConfig, beforeSeed, error) == Result::Failed) {
+		std::cerr << "Training test failed: input checkpoint reload failed: " << error.message << std::endl;
+		return false;
+	}
+	if (LoadPolicyValueCheckpoint(afterPath, after, afterConfig, afterSeed, error) == Result::Failed) {
+		std::cerr << "Training test failed: output checkpoint reload failed: " << error.message << std::endl;
+		return false;
+	}
+
+	const std::vector<torch::Tensor> beforeParams = before->parameters();
+	const std::vector<torch::Tensor> afterParams = after->parameters();
+	if (beforeParams.size() != afterParams.size()) {
+		return true;
+	}
+
+	for (std::size_t i = 0; i < beforeParams.size(); ++i) {
+		if (!torch::allclose(beforeParams[i].cpu(), afterParams[i].cpu(), 1e-6, 1e-6)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool TinyReplayTrainingWritesCheckpointAndMetrics() {
+	const std::filesystem::path replayPath = MakeTempPath("train-smoke.jsonl");
+	const std::filesystem::path inputCheckpoint = MakeTempPath("train-input-checkpoint");
+	const std::filesystem::path outputCheckpoint = MakeTempPath("train-output-checkpoint");
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove_all(inputCheckpoint);
+	std::filesystem::remove_all(outputCheckpoint);
+
+	SelfPlayRunnerOptions replayOptions;
+	replayOptions.outputPath = replayPath;
+	replayOptions.mapId = "mcts";
+	replayOptions.player0CoId = "andy";
+	replayOptions.player1CoId = "adder";
+	replayOptions.games = 1;
+	replayOptions.maxActions = 2;
+	replayOptions.baseSeed = 41;
+	replayOptions.mctsOptions.maxSimulations = 1;
+	replayOptions.mctsOptions.maxNodes = 16;
+	replayOptions.mctsOptions.maxRolloutActions = 4;
+	replayOptions.mctsOptions.temperature = 0.0;
+	replayOptions.quiet = true;
+
+	SelfPlayRunSummary replaySummary;
+	SelfPlayError replayError;
+	if (!Expect(RunSelfPlay(replayOptions, replaySummary, replayError) == Result::Succeeded, "self-play replay should generate: " + replayError.message)) {
+		return false;
+	}
+
+	PolicyValueModelConfig config;
+	config.hiddenChannels = 8;
+	config.residualBlocks = 0;
+	config.normGroups = 1;
+	PolicyValueModelError modelError;
+	PolicyValueNetwork model = CreatePolicyValueNetwork(config, 7);
+	if (!Expect(SavePolicyValueCheckpoint(inputCheckpoint, model, config, 7, "cpu", false, modelError) == Result::Succeeded, "input checkpoint should save: " + modelError.message)) {
+		std::filesystem::remove(replayPath);
+		return false;
+	}
+
+	TrainingOptions options;
+	options.replayPath = replayPath;
+	options.checkpointIn = inputCheckpoint;
+	options.checkpointOut = outputCheckpoint;
+	options.epochs = 1;
+	options.batchSize = 3;
+	options.learningRate = 0.01;
+	options.weightDecay = 0.0;
+	options.seed = 5;
+	options.deviceName = "cpu";
+	options.quiet = true;
+
+	TrainingSummary summary;
+	TrainingError error;
+	const Result result = RunTraining(options, summary, error);
+
+	bool passed = true;
+	passed = Expect(result == Result::Succeeded, "training should succeed: " + error.code + " " + error.message) && passed;
+	passed = Expect(std::filesystem::exists(outputCheckpoint / "metadata.json"), "output metadata.json should exist") && passed;
+	passed = Expect(std::filesystem::exists(outputCheckpoint / "model.pt"), "output model.pt should exist") && passed;
+	passed = Expect(std::filesystem::exists(outputCheckpoint / "training.json"), "output training.json should exist") && passed;
+	passed = Expect(summary.samplesLoaded == 2, "two replay samples should load") && passed;
+	passed = Expect(summary.samplesTrained == 2, "two replay samples should train") && passed;
+	passed = Expect(summary.batchesCompleted == 1, "partial final batch should be trained") && passed;
+	passed = Expect(AnyParameterChanged(inputCheckpoint, outputCheckpoint), "training should change at least one model parameter") && passed;
+
+	std::ifstream trainingMetadata(outputCheckpoint / "training.json");
+	if (passed && Expect(trainingMetadata.is_open(), "training.json should open")) {
+		json metadata;
+		trainingMetadata >> metadata;
+		passed = Expect(metadata.at("trainingMetadataVersion") == 1, "training metadata version should be 1") && passed;
+		passed = Expect(metadata.at("sampleCount") == 2, "training metadata should record sample count") && passed;
+		passed = Expect(metadata.at("epochsCompleted") == 1, "training metadata should record completed epochs") && passed;
+		passed = Expect(metadata.at("epochHistory").is_array() && metadata.at("epochHistory").size() == 1, "training metadata should record one epoch") && passed;
+	}
+	trainingMetadata.close();
+
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove_all(inputCheckpoint);
+	std::filesystem::remove_all(outputCheckpoint);
+	return passed;
+}
+}
+
+int RunTrainingTests() noexcept {
+	try {
+		if (!TinyReplayTrainingWritesCheckpointAndMetrics()) {
+			return 1;
+		}
+
+		std::cout << "Training tests passed" << std::endl;
+		return 0;
+	}
+	catch (const std::exception& err) {
+		std::cerr << "Training test exception: " << err.what() << std::endl;
+		return 1;
+	}
+}

--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -56,6 +56,7 @@ Set-Location .\AdvanceWarsServer
 ..\x64\Debug\AdvanceWarsServer.exe -test-mcts
 ..\x64\Debug\AdvanceWarsServer.exe -test-model
 ..\x64\Debug\AdvanceWarsServer.exe -test-replay
+..\x64\Debug\AdvanceWarsServer.exe -test-train
 ```
 
 Release:
@@ -82,9 +83,11 @@ The executable currently recognizes these development commands:
 | `-test-mcts` | Run focused MCTS contract tests. | Uses scripted fake states for deterministic search semantics. |
 | `-test-model [--device cpu|auto|cuda]` | Run focused policy/value model tests. | Verifies forward shapes, real Standard tensor inference, deterministic init, checkpoint round trip, and strict metadata rejection. |
 | `-test-replay` | Run focused self-play replay writer/validator tests. | Writes temporary replay shards and cleans them up on success. |
+| `-test-train` | Run focused replay training tests. | Generates a tiny temporary replay, trains a small model for one epoch, verifies `training.json`, and checks that model parameters changed. |
 | `-model-init --out <checkpoint-dir> [--device cpu|auto|cuda] [--hidden-channels <n>] [--res-blocks <n>] [--norm-groups <n>] [--seed <n>] [--force]` | Initialize and validate a policy/value checkpoint bundle. | Writes `metadata.json` plus `model.pt`. `model.pt` is required; it cannot be reconstructed from metadata alone. |
 | `-self-play --out <path> --map <id> --player0-co <id> --player1-co <id> [options]` | Generate validated sparse self-play replay JSONL. | Fails if `--out` exists unless `--append` is passed. See `docs/SELF_PLAY_REPLAYS.md`. |
 | `-validate-replay <path>` | Validate a self-play replay JSONL shard. | Prints a concise summary on success and exact failure location on error. |
+| `-train --replay <file-or-directory> --checkpoint-in <checkpoint-dir> --checkpoint-out <checkpoint-dir> --epochs <n> --batch-size <n> --learning-rate <x> [options]` | Train a policy/value checkpoint from replay data. | Validates replay shards, trains with AdamW in float32, writes `metadata.json`, `model.pt`, and `training.json`. Use `--max-samples` for smoke subsets and `--force` to overwrite known bundle files. |
 | `-sim-random-move-game [seed]` | Run an experimental random-action simulation. | Uses local output paths that still need cleanup before general use. |
 | `-sim-mcts-game` | Run an experimental MCTS simulation. | Uses local output paths that still need cleanup before general use. |
 | `-server` | Run the current HTTP server on port 80. | Serves the canonical REST routes documented in `docs/API.md`. |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [STANDARD_ENGINE_COMPLETENESS.md](STANDARD_ENGINE_COMPLETENESS.md) for the c
 | `TRAINING_LOOP_WORK_ITEMS.md` | Self-play, MCTS, tensor, model, and training-loop roadmap. |
 | `docs/API.md` | Current and target REST/API contract notes. |
 | `docs/TRAINING_DESIGN.md` | Recommended self-play training architecture and data flow. |
+| `docs/TRAINING_COMMAND_DESIGN.md` | Concrete v1 replay training command design and follow-up boundaries. |
 | `docs/SELF_PLAY_REPLAYS.md` | Self-play replay JSONL command and schema reference. |
 | `docs/JSON_FIXTURES.md` | JSON regression fixture format and authoring guide. |
 
@@ -75,6 +76,19 @@ Set-Location .\AdvanceWarsServer
 ```
 
 Replay schema details are in [docs/SELF_PLAY_REPLAYS.md](docs/SELF_PLAY_REPLAYS.md).
+
+Run a tiny replay-to-checkpoint training smoke test:
+
+```powershell
+Set-Location .\AdvanceWarsServer
+$libtorchRoot = 'C:\path\to\libtorch'
+$env:PATH = "$libtorchRoot\bin;" + $env:PATH
+..\x64\Debug\AdvanceWarsServer.exe -model-init --out ..\artifacts\checkpoints\seed --hidden-channels 8 --res-blocks 0 --norm-groups 1 --seed 7 --force
+..\x64\Debug\AdvanceWarsServer.exe -self-play --out ..\artifacts\replays\train-smoke.jsonl --map mcts --player0-co andy --player1-co adder --games 1 --max-actions 2 --mcts-simulations 1 --mcts-max-nodes 16
+..\x64\Debug\AdvanceWarsServer.exe -train --replay ..\artifacts\replays\train-smoke.jsonl --checkpoint-in ..\artifacts\checkpoints\seed --checkpoint-out ..\artifacts\checkpoints\trained --epochs 1 --batch-size 3 --learning-rate 0.01 --device cpu --force
+```
+
+The training command writes a new checkpoint bundle with `metadata.json`, `model.pt`, and `training.json`. Detailed trainer scope and follow-up issues are in [docs/TRAINING_COMMAND_DESIGN.md](docs/TRAINING_COMMAND_DESIGN.md).
 
 ## Development Workflow
 

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -75,14 +75,14 @@ The rules/API completeness target for the initial playable environment is normal
 
 ## Phase 5: Training Loop
 
-- [ ] Add supervised-style training over replay samples.
-- [ ] Train policy with cross entropy against MCTS visit distributions.
-- [ ] Train value with mean squared error or cross entropy against final outcomes.
-- [ ] Add a replay shard reader/dataset that reconstructs tensors, sparse legal indices, dense batch-local masks, visit distributions, and outcomes from `standard-gl-self-play-replay-v1`.
-- [ ] Add replay buffer sampling and retention policy.
+- [x] Add supervised-style training over replay samples (`-train`) (#8).
+- [x] Train policy with cross entropy against MCTS visit distributions over legal actions (#8).
+- [x] Train value with mean squared error against final outcomes (#8).
+- [x] Add a replay shard reader/dataset that reconstructs tensors, sparse legal indices, visit distributions, and outcomes from `standard-gl-self-play-replay-v1` (#8).
+- [x] Add in-memory seeded sample shuffling for the v1 replay buffer; streaming and bounded-buffer loading are tracked by #180.
 - [ ] Add optional materialized replay cache for faster repeated training loads (#172).
 - [ ] Add checkpoint promotion/evaluation against previous models.
-- [ ] Add command-line options for epochs, batch size, learning rate, device, checkpoint path, and replay path.
+- [x] Add command-line options for epochs, batch size, learning rate, device, checkpoint path, replay path, max samples, loss weights, weight decay, gradient clipping, and periodic checkpoints (#8).
 
 ## Phase 6: Evaluation And Iteration
 
@@ -101,7 +101,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] #5 Refactor MCTS for action-level self-play and same-player turn sequences.
 - [x] #6 Add self-play replay writer.
 - [x] #7 Add policy/value network scaffold.
-- [ ] #8 Add training command-line entry point.
+- [x] #8 Add training command-line entry point.
 - [ ] #9 Add checkpoint evaluation harness.
 - [ ] #164 Track CO matchup statistics for pregame selection.
 - [ ] #166 Add neural-guided MCTS with PUCT.
@@ -110,6 +110,9 @@ The rules/API completeness target for the initial playable environment is normal
 - [ ] #172 Add optional materialized replay cache for faster training loads.
 - [ ] #173 Add self-play orchestration for map pools, matchups, and side balancing.
 - [ ] #174 Add compressed self-play replay shard support.
+- [ ] #180 Add streaming or bounded replay dataset loading for training.
+- [ ] #181 Persist optimizer state for resumable long training runs.
+- [ ] #182 Harden training checkpoint writes with atomic bundle commits.
 - [x] #65 Define and enforce normal Global League Standard game settings.
 - [x] #66 Add REST game lifecycle and step API contract for self-play.
 - [x] #67 Validate and atomically reject illegal submitted actions.

--- a/docs/TRAINING_COMMAND_DESIGN.md
+++ b/docs/TRAINING_COMMAND_DESIGN.md
@@ -1,0 +1,441 @@
+# Training Command Design
+
+Issue: https://github.com/ryparikh/AdvanceWarsServer/issues/8
+
+This document records the design for the first replay-driven training command in
+AdvanceWarsServer. The goal is a practical v1 path from validated self-play
+replay shards to a saved policy/value checkpoint, while keeping the engine,
+state tensor, action space, and replay schema as the source of truth.
+
+## Goal
+
+Add a command-line entry point that can:
+
+- load `standard-gl-self-play-replay-v1` replay shards,
+- reconstruct model-ready batches from sparse replay samples,
+- optimize `standard-gl-policy-value-v1` with LibTorch,
+- write checkpoint bundles compatible with the existing model scaffold,
+- write training-run provenance beside the model checkpoint, and
+- print enough metrics to know that a smoke training run consumed data and made
+  progress.
+
+This is intentionally the first trainer, not the final distributed AlphaZero
+system. It should be good enough to run a supervised-style training smoke test
+from existing MCTS replay data and produce a checkpoint that later evaluation
+work can compare.
+
+## Repo-Decided Constraints
+
+These branches of the design tree are already answered by code or existing
+docs:
+
+- Training v1 runs inside the C++ executable with LibTorch. A Python
+  environment API is deferred.
+- The model ABI is `standard-gl-policy-value-v1`.
+- The model input is `standard-gl-v1-state`, shaped `[N, 219, 23, 27]`.
+- The policy output is a dense `ActionSpace::ActionCount()` logit vector.
+- The value output is a scalar in `[-1, 1]`, from the current player's
+  perspective.
+- Device names follow the policy/value model scaffold: `cpu`, `auto`, and
+  `cuda`.
+- Replay input is sparse JSONL in `standard-gl-self-play-replay-v1`.
+- Replay shards store sparse legal action indices and sparse positive MCTS
+  visit counts; dense state tensors and dense legal masks are derived at load
+  time.
+- Checkpoints are directory bundles with strict `metadata.json` compatibility
+  and required `model.pt` weights.
+- The existing replay module validates shards but does not expose a reusable
+  replay-dataset reader for training.
+
+## Proposed V1 Shape
+
+The first training command should be a new top-level executable option:
+
+```powershell
+..\x64\Release\AdvanceWarsServer.exe -train `
+  --replay <file-or-directory> `
+  --checkpoint-in <checkpoint-dir> `
+  --checkpoint-out <checkpoint-dir> `
+  --epochs 1 `
+  --batch-size 32 `
+  [--max-samples <n>] `
+  --learning-rate 0.001 `
+  [--weight-decay 0.0001] `
+  [--policy-loss-weight 1.0] `
+  [--value-loss-weight 1.0] `
+  [--max-grad-norm 0] `
+  [--seed 0] `
+  [--log-every-batches <n>] `
+  --device auto `
+  [--force] `
+  [--checkpoint-every-epochs <n> --checkpoint-dir <dir>]
+```
+
+Decision: require an input checkpoint for issue #8. A separate
+`-model-init` command already creates a compatible checkpoint bundle, and
+requiring explicit initialization keeps architecture, seed, and compatibility
+metadata owned by the checkpoint system from issue #7. `-train` preserves the
+architecture and compatibility metadata from `--checkpoint-in`; it does not
+accept architecture overrides.
+
+## Data Flow
+
+1. Resolve `--replay` as either one JSONL file or a directory of `.jsonl`
+   shards. Directory entries are sorted by path before validation and seeded
+   shuffle.
+2. Validate each replay shard before consuming samples. In directory mode, any
+   invalid shard fails the training command.
+3. Load compact replay sample records into memory. Do not eagerly materialize
+   dense state tensors for every sample. If `--max-samples <n>` is provided,
+   keep the first `n` samples after deterministic replay ordering and parsing,
+   before epoch shuffle.
+4. For each training batch, reconstruct each needed state from `initialState`
+   plus the action prefix before the sample. V1 does not cache reconstructed
+   states across batches.
+5. Regenerate legal action indices for the reconstructed state and fail if they
+   differ from the replay sample.
+6. Lazily encode `StateTensor` values for the current batch and compare the
+   computed checksum to the replay sample.
+7. Read sparse legal action indices and sparse visit counts from the sample.
+8. Convert the sparse visits to a target distribution over only legal actions.
+9. Gather model logits at legal action indices or apply a batch-local legal
+   mask before the policy loss.
+10. Train value predictions against sample `outcome`. The final partial batch is
+   included when sample count is not divisible by `--batch-size`.
+11. Save the final checkpoint bundle only after all epochs complete
+   successfully, plus optional periodic checkpoint bundles when configured.
+
+All checkpoint output paths are validated before replay loading or optimization
+starts. `--checkpoint-out` must not already exist unless `--force` is passed.
+With `--force`, v1 may only overwrite known bundle files: `metadata.json`,
+`model.pt`, and `training.json`. Periodic checkpoint directories must also be
+checked up front so a long run does not fail only when the first periodic save
+is due.
+
+`--checkpoint-in` and `--checkpoint-out` must resolve to different paths, even
+when `--force` is passed. V1 does not support in-place checkpoint mutation.
+
+Periodic checkpoints are written under `--checkpoint-dir` as deterministic
+epoch subdirectories such as `epoch-000001`, `epoch-000002`, and so on. The
+trainer only creates a periodic subdirectory when that epoch checkpoint is due,
+but it checks planned periodic paths for conflicts during startup. Periodic
+`training.json` files should record `checkpointRole: "periodic"` and the
+completed epoch.
+
+Final and periodic checkpoints should ideally be written atomically: write the
+complete bundle to a temporary sibling directory, validate the expected files
+exist, and then move it into the final checkpoint path. This hardening is
+tracked by #182 and is an optional stretch for #8.
+
+If an atomic checkpoint write fails, the trainer should try to delete only the
+temporary directory it created. If cleanup fails, leave the temp directory in
+place and print its path in the failure summary.
+
+## Public C++ Surface
+
+The CLI should be a thin wrapper over reusable trainer APIs. Issue #8 should
+introduce focused C++ types such as `TrainingOptions`, `TrainingSummary`,
+`TrainingError`, and `RunTraining(...)`, plus helpers for replay dataset loading
+and lazy batch assembly. `main.cpp` should only dispatch `-train` and
+`-test-train`.
+
+The initial file layout should be:
+
+- `AdvanceWarsServer/inc/Training.h`
+- `AdvanceWarsServer/src/Training.cpp`
+- `AdvanceWarsServer/inc/TrainingCommand.h`
+- `AdvanceWarsServer/src/TrainingCommand.cpp`
+- `AdvanceWarsServer/inc/TrainingTest.h`
+- `AdvanceWarsServer/src/TrainingTest.cpp`
+
+Replay-dataset and batch-assembly helper types can remain private to
+`Training.cpp` until they become large enough to deserve their own module.
+
+## Option Validation
+
+The command should fail early with clear errors for invalid numeric ranges:
+
+- `--epochs` must be greater than `0`.
+- `--batch-size` must be greater than `0`.
+- `--learning-rate` must be finite and greater than `0`.
+- `--weight-decay` must be finite and greater than or equal to `0`.
+- `--policy-loss-weight` and `--value-loss-weight` must be greater than or
+  equal to `0`, finite, with at least one positive.
+- `--max-grad-norm` must be finite and greater than or equal to `0`.
+- `--seed` must be greater than or equal to `0`.
+- `--max-samples`, when present, must be greater than `0`.
+- `--checkpoint-every-epochs` must be greater than or equal to `0`; `0`
+  disables periodic checkpointing.
+- `--log-every-batches` must be greater than or equal to `0`; `0` disables
+  batch progress logging.
+
+## Final Design Closure
+
+The remaining smaller design branches use these adopted defaults:
+
+1. Empty replay inputs fail. A replay file or directory that resolves to zero
+   usable samples is an error, including a directory with no `.jsonl` shards or
+   a `--max-samples` setting that would leave no samples.
+2. Epoch shuffling is deterministic. The same replay input, `--seed`, and
+   options produce the same sample order. Each epoch uses a seed derived from
+   the trainer seed and epoch number so epochs do not repeat the exact same
+   order.
+3. #8 does not add a validation split, holdout metrics, early stopping, or
+   best-checkpoint selection. Those belong with evaluation and promotion work
+   in #9.
+4. #8 is single-process and single-worker. It does not add background prefetch,
+   parallel replay loading, or asynchronous batch assembly. Larger data-loading
+   performance work belongs to #180.
+5. `training.json` is the machine-readable training artifact. Console output is
+   human-readable.
+6. `training.json` should include a `trainingMetadataVersion` field starting at
+   `1`, plus enough resolved options and input/output paths to reproduce the
+   smoke run.
+7. During optimization the model must be in training mode. Checkpoint
+   validation or any inference-only checks should use eval/no-grad mode.
+8. Checkpoint save/load compatibility stays centralized in the policy/value
+   checkpoint layer. The trainer may add `training.json`, but it should not
+   weaken existing `metadata.json` validation.
+9. The trainer should return structured `TrainingError` values with stable
+   codes and context fields rather than relying only on exception text.
+10. #8 does not implement neural-guided self-play or PUCT priors. It consumes
+   replay data generated by the existing MCTS/self-play path.
+
+## Checkpoint Outputs
+
+Training-produced checkpoint bundles should include `training.json` beside
+`metadata.json` and `model.pt`. `metadata.json` remains the strict model
+compatibility manifest owned by the policy/value checkpoint layer.
+`training.json` records run provenance and aggregate metrics, including replay
+paths, resolved sample count, epochs completed, batch size, optimizer settings,
+loss weights, trainer seed, device, elapsed time, checkpoint role, and latest
+aggregate losses. It should also include a compact per-epoch history array with
+epoch number, samples, batches, average policy loss, average value loss, average
+total loss, elapsed seconds, and periodic checkpoint path when one was written.
+
+V1 checkpoint continuation is model-only: any saved checkpoint can be used as a
+future `--checkpoint-in`, but AdamW optimizer state is not persisted or
+restored. Full optimizer-state resume is deferred to #181 and should be treated
+as a prerequisite before spending serious compute on a competitive model.
+
+`--device auto` uses CUDA only when the binary was built with CUDA support and
+CUDA is available; otherwise it uses CPU. `--device cuda` fails when CUDA is not
+available. The resolved device is printed and written to `training.json`.
+
+## Losses
+
+Policy loss should train against the normalized MCTS visit distribution after
+illegal actions are excluded. Run `log_softmax` over all legal actions for the
+sample, including legal actions with zero visits. Assign target probability
+only to positive-visit actions. This penalizes probability mass assigned to
+legal-but-unvisited actions while keeping illegal actions out of the loss.
+
+The implementation can avoid materializing a full dense target vector by
+gathering legal logits, applying `log_softmax` over that legal subset, and
+computing the negative weighted log probability for visited actions.
+`selectedActionIndex` is useful for validation and debugging, but it does not
+add a separate supervised action-pick loss in v1.
+
+Value loss should use mean squared error between the scalar value head and the
+sample outcome. Samples from games that end by the self-play action limit stay
+in the batch with value target `0`, matching the replay writer's v1 outcome
+contract.
+
+V1 total loss should be:
+
+```text
+totalLoss = policyLoss * policyLossWeight + valueLoss * valueLossWeight
+```
+
+Both weights default to `1.0` and are configurable with
+`--policy-loss-weight` and `--value-loss-weight`.
+
+## Optimizer
+
+V1 should use AdamW only. The command exposes `--learning-rate` and
+`--weight-decay`; optimizer family selection is deferred until there is a
+measured reason to add it. The learning rate is constant for issue #8.
+Learning-rate schedules and scheduler checkpoint state are deferred to #181.
+Training uses float32 only; mixed precision and scaler checkpointing are also
+deferred to #181.
+
+V1 may optionally clip gradients by global norm when `--max-grad-norm` is
+greater than `0`. The default is disabled.
+
+## Metrics
+
+V1 `-train` should print:
+
+- sample count,
+- epoch,
+- batch count,
+- average policy loss,
+- average value loss,
+- average total loss,
+- elapsed time,
+- device,
+- input checkpoint, and
+- output checkpoint.
+
+Successful runs print one startup summary and one progress line per epoch by
+default. Batch-level progress is opt-in through `--log-every-batches <n>`.
+
+Win rate, head-to-head results, map/side/CO breakdowns, resignations, game
+length, search throughput during evaluation, promotion decisions, and
+best-checkpoint selection belong to the checkpoint evaluation harness in #9.
+
+On failure, `-train` should print a concise stderr summary with any progress
+known at the failure point: replay shards resolved, samples loaded, epoch and
+batch reached, last completed periodic checkpoint, and the structured error
+context.
+
+## Tests
+
+Issue #8 should add a focused `-test-train` command. It should stay separate
+from `-test-model` and `-test-replay` so trainer failures are easy to isolate.
+The focused gate should cover replay dataset loading, lazy batch assembly, loss
+computation, tiny deterministic training, checkpoint output, overwrite
+failures, and structured error diagnostics.
+
+The core deterministic smoke test should generate a tiny temporary replay shard
+with the current replay writer path where practical, initialize a very small
+model, run one epoch with a batch size that creates a partial final batch,
+assert that the final checkpoint and `training.json` are written, assert sample
+and batch counts, and assert that at least one model parameter changed from the
+input checkpoint. Tiny checked-in malformed fixtures are acceptable for
+error-path tests when generating malformed data would be cumbersome.
+
+## Documentation Updates
+
+When #8 is implemented, update:
+
+- `BUILD_AND_TEST.md` with `-train` and `-test-train` command references.
+- `README.md` with a basic replay-to-checkpoint smoke command sequence.
+- `TRAINING_LOOP_WORK_ITEMS.md` to mark the #8 training-command work complete
+  and point deferred scale/resume/evaluation work to #180, #181, and #9.
+
+The docs should include a minimal end-to-end smoke sequence that initializes a
+small model checkpoint, generates a tiny self-play replay shard, trains for one
+epoch, and writes a new checkpoint.
+
+## Open Decisions
+
+The following decisions should be resolved before implementation:
+
+No unresolved decisions remain from the initial design interview.
+
+## Decision Log
+
+- `-train` requires `--checkpoint-in <checkpoint-dir>` for v1. It does not
+  initialize a fresh model implicitly. Use `-model-init` first to create the
+  starting checkpoint bundle.
+- `-train` validates replay shards by default before training. A future
+  performance option may skip validation only after replay loading becomes a
+  measured bottleneck.
+- V1 loads all reconstructed samples into memory and performs a seeded shuffle
+  each epoch. Streaming, bounded buffers, reservoir sampling, or other
+  large-corpus loading modes are deferred to #180.
+- V1 exposes optional `--max-samples <n>`, default unlimited, for quick smoke
+  runs. It selects the first `n` samples after deterministic replay ordering and
+  parsing, before epoch shuffle.
+- V1 writes the final `--checkpoint-out` bundle and also supports optional
+  periodic checkpointing with `--checkpoint-every-epochs <n>` and
+  `--checkpoint-dir <dir>`. Periodic checkpoints are for interruption recovery
+  and experiment inspection; checkpoint promotion and best-model selection stay
+  with the evaluation harness in #9.
+- `--checkpoint-out` preserves the architecture and compatibility metadata from
+  `--checkpoint-in`. `-train` does not accept architecture overrides.
+- V1 `-train` prints sample count, epoch, batch count, average policy loss,
+  average value loss, average total loss, elapsed time, device, input
+  checkpoint, and output checkpoint. Evaluation metrics and promotion reporting
+  are tracked by #9.
+- V1 uses AdamW only, with `--learning-rate` and `--weight-decay` exposed as
+  trainer options. The learning rate is constant; learning-rate schedules are
+  deferred to #181.
+- V1 trains in float32 only. Mixed precision is deferred to #181 so scaler
+  state can be handled with other resumable trainer state.
+- V1 exposes optional global-norm gradient clipping with `--max-grad-norm`.
+  The default `0` disables clipping.
+- V1 exposes `--policy-loss-weight` and `--value-loss-weight`, both defaulting
+  to `1.0`.
+- V1 trains policy only against the normalized MCTS visit distribution.
+  `selectedActionIndex` is not a separate policy-loss target.
+- Policy `log_softmax` is computed over all legal actions. Positive target mass
+  comes only from positive-visit actions; zero-visit legal actions remain in the
+  denominator; illegal actions are excluded.
+- Samples from games that ended by `action-limit` are included in value
+  training with target `0`.
+- `--replay` accepts either a single JSONL file or a directory. Directory mode
+  consumes `.jsonl` shards sorted by path before sample reconstruction and
+  seeded epoch shuffling.
+- In directory mode, one invalid shard fails the command. V1 does not silently
+  skip bad replay files.
+- V1 stores compact sample records in memory and lazily reconstructs/encodes
+  `StateTensor` batches during training. Full streaming and bounded-buffer
+  loading are deferred to #180.
+- V1 reconstructs sample states from `initialState` plus the action prefix each
+  time the sample is used. It does not cache reconstructed states across
+  batches.
+- During batch assembly, v1 regenerates legal action indices for each
+  reconstructed state and fails if they differ from replay-stored
+  `legalActionIndices`.
+- During batch assembly, v1 recomputes each encoded `StateTensor` checksum and
+  fails with shard/game/ply context if it differs from the replay sample.
+- Any invalid sample fails the whole training command. V1 does not skip or
+  quarantine individual samples.
+- The final `--checkpoint-out` bundle is written only after all epochs complete
+  successfully. Failed runs may leave previously completed periodic checkpoints,
+  but they do not write a final checkpoint that appears complete.
+- Failed runs print a concise stderr summary with resolved replay/progress
+  context and the structured error.
+- Successful runs print a startup summary and one progress line per epoch by
+  default. `--log-every-batches <n>` enables batch-level progress logs.
+- Issue #8 adds a focused `-test-train` command for trainer dataset, loss,
+  checkpoint, and error-path coverage.
+- The core `-test-train` smoke test proves that a tiny deterministic run writes
+  a final checkpoint plus `training.json`, reports correct sample/batch counts,
+  includes a partial final batch, and changes at least one model parameter.
+- Valid trainer smoke-test replay shards should be generated temporarily through
+  the current replay writer path where practical. Checked-in malformed fixtures
+  may be used for focused error-path coverage.
+- Implementation should update `BUILD_AND_TEST.md`, `README.md`, and
+  `TRAINING_LOOP_WORK_ITEMS.md` with the new trainer commands and follow-up
+  issue boundaries.
+- Docs should include a minimal end-to-end smoke sequence chaining
+  `-model-init`, `-self-play`, and `-train`.
+- Trainer internals should be reusable C++ APIs with a thin CLI wrapper, not a
+  large training loop embedded in `main.cpp`.
+- Initial implementation should add `Training`, `TrainingCommand`, and
+  `TrainingTest` files. Replay-dataset and batch helpers can stay private to
+  `Training.cpp` for v1.
+- CLI parsing should validate numeric option ranges up front and fail with
+  clear errors before replay loading or training starts.
+- `--checkpoint-in` and `--checkpoint-out` must resolve to different paths.
+  In-place checkpoint mutation is not supported.
+- Periodic checkpoints are named as epoch subdirectories under
+  `--checkpoint-dir`, for example `epoch-000001`, and planned periodic paths
+  are checked for conflicts during startup.
+- Final and periodic checkpoints are written through a temporary sibling
+  directory and moved into place only after the bundle is complete. This
+  hardening is tracked by #182 and is an optional stretch for #8.
+- Failed atomic checkpoint writes use best-effort cleanup of the trainer-created
+  temp directory; if cleanup fails, the failure summary prints the temp path.
+- `--checkpoint-out` fails early if it already exists unless `--force` is
+  passed. Output and periodic checkpoint path conflicts are checked during
+  command startup before replay loading or optimization begins.
+- Training-produced checkpoint bundles include `training.json` for run
+  provenance and aggregate training metrics. `metadata.json` remains the model
+  compatibility manifest.
+- Final `training.json` includes compact per-epoch history with losses, sample
+  and batch counts, elapsed seconds, and any periodic checkpoint path.
+- V1 supports model-only continuation from checkpoints. It does not persist or
+  restore AdamW optimizer state. Full optimizer-state resume is tracked by #181
+  and should be completed before serious competitive training runs.
+- V1 exposes `--seed`, defaulting to `0`, for training-data order only. Model
+  initialization seed comes from `--checkpoint-in`; replay generation seeds come
+  from the replay shards.
+- V1 trains on the final partial batch instead of dropping it. Metrics report
+  actual batches and samples consumed.
+- `--device auto` falls back to CPU when CUDA is unavailable. `--device cuda`
+  fails if CUDA is unavailable. The resolved device is printed and recorded in
+  `training.json`.

--- a/docs/TRAINING_DESIGN.md
+++ b/docs/TRAINING_DESIGN.md
@@ -36,9 +36,9 @@ Checkpoints are directory bundles containing both `metadata.json` and `model.pt`
 
 Start small enough to fit comfortably on an 8 GB GPU:
 
-- mixed precision when CUDA is available
+- float32 for the v1 `-train` command; mixed precision is deferred until trainer-state checkpointing can persist scaler state (#181)
 - small batches such as 1, 2, 4, or 8
-- gradient accumulation if a larger effective batch helps stability
+- gradient accumulation later if a larger effective batch helps stability
 - modest channel and block counts before scaling up
 
 Longer training with smaller batches is acceptable. The first priority is stable self-play and replay quality, not maximum GPU throughput.
@@ -64,10 +64,12 @@ The v1 C++ replay writer emits sparse JSONL shards using `standard-gl-self-play-
 
 V1 training should run inside the C++ executable with LibTorch. Do not expose a Python environment API yet; the replay shard format is the language-neutral boundary for future tools if Python becomes useful for experimentation, reporting, or distributed training.
 
-Training should sample replay positions, rebuild tensors, expand sparse legal indices for masking, and optimize two losses:
+The v1 `-train` command samples replay positions from validated `standard-gl-self-play-replay-v1` shards, rebuilds tensors lazily, trains only over legal action logits, writes `training.json` provenance, and optimizes two losses:
 
 - policy loss against the MCTS visit distribution
-- value loss against the final outcome
+- value MSE loss against the final outcome
+
+The first trainer uses AdamW, a constant learning rate, float32, and model-only checkpoint continuation. Streaming replay loading, optimizer-state resume, learning-rate schedules, mixed precision, and atomic checkpoint publishing are tracked separately by #180, #181, and #182. See `docs/TRAINING_COMMAND_DESIGN.md` for the concrete command contract.
 
 Checkpoints should be evaluated against the current best checkpoint on fixed maps, fixed seeds, and a held-out map set. Promote a checkpoint only when it improves head-to-head results or clearly improves selected metrics.
 


### PR DESCRIPTION
## Summary
- Add a reusable replay-driven training API plus `-train` CLI entry point for policy/value checkpoint training.
- Add `-test-train` coverage that generates a tiny replay, trains a small model, verifies `training.json`, and checks that parameters change.
- Document the settled v1 trainer design and update training roadmap docs, including deferred follow-ups for streaming replay loading, optimizer-state resume, and atomic checkpoint publishing.

## Why
Issue #8 needs the first practical path from validated self-play replay shards to a saved `standard-gl-policy-value-v1` checkpoint. This keeps training inside the C++/LibTorch executable and preserves the existing checkpoint manifest as the model ABI source of truth.

## Verification
- Built Debug x64 with `LIBTORCH_ROOT=D:\Projects\libtorch-win-shared-with-deps-debug-2.6.0+cu118\libtorch`.
- Ran `..\x64\Debug\AdvanceWarsServer.exe -test-train`.
- Ran invalid-option smoke check: `..\x64\Debug\AdvanceWarsServer.exe -train --learning-rate nan` exits with code 1.
- Earlier in this branch, ran `-test-model`, `-test-replay`, `-test-mcts`, `-test-api-contract`, full `-test test/json`, and a real `-model-init -> -self-play -> -train` smoke flow.
- Ran `git diff --check` and `git diff --cached --check`.

## Deferred Work
- Streaming or bounded replay dataset loading remains in #180.
- Optimizer-state resume, schedules, and mixed precision/scaler persistence remain in #181.
- Atomic checkpoint bundle publishing remains in #182.
- Evaluation, promotion, and map/side/CO metric breakdowns remain in #9.

Closes #8