### PR TITLE
Add neural-guided PUCT MCTS

### DIFF
--- a/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
+++ b/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
@@ -25,6 +25,19 @@ struct MCTSActionStats {
 	int visits{ 0 };
 	double totalValue{ 0.0 };
 	double averageValue{ 0.0 };
+	double prior{ 0.0 };
+};
+
+template <typename ActionType>
+struct MCTSActionPrior {
+	ActionType action;
+	double prior{ 0.0 };
+};
+
+template <typename ActionType>
+struct MCTSNeuralEvaluation {
+	double value{ 0.0 };
+	std::vector<MCTSActionPrior<ActionType>> actionPriors;
 };
 
 template <typename ActionType>
@@ -82,23 +95,70 @@ public:
 		return result;
 	}
 
+	template <typename EvaluatorType>
+	MCTSSearchResult<ActionType> searchNeural(const StateType& rootState, EvaluatorType& evaluator, const MCTSOptions& options = MCTSOptions()) {
+		std::mt19937 rng(options.seed);
+		SearchContext context{ std::max(1, options.maxNodes), 1 };
+
+		Node root(rootState, std::nullopt, nullptr);
+		MCTSSearchResult<ActionType> result;
+		result.nodesCreated = context.nodesCreated;
+
+		if (root.state.isTerminal() || root.legalActions.empty()) {
+			result.rootActionStats = BuildRootActionStats(root);
+			return result;
+		}
+
+		double rootValue = 0.0;
+		EvaluateAndExpand(root, evaluator, context, rootValue);
+
+		const int maxSimulations = std::max(0, options.maxSimulations);
+		for (int i = 0; i < maxSimulations; ++i) {
+			Node* leaf = SelectNeural(root, options.explorationConstant);
+			double value = 0.0;
+			if (leaf->state.isTerminal()) {
+				value = static_cast<double>(leaf->state.evaluate(leaf->state.getCurrentPlayer()));
+			}
+			else if (!leaf->neuralExpanded) {
+				EvaluateAndExpand(*leaf, evaluator, context, value);
+			}
+			else {
+				value = leaf->evaluatedValue;
+			}
+
+			BackpropagateNeural(leaf, value);
+			++result.simulationsRun;
+		}
+
+		result.nodesCreated = context.nodesCreated;
+		result.rootActionStats = BuildRootActionStats(root);
+		result.selectedAction = SelectAction(result.rootActionStats, options.temperature, rng);
+		return result;
+	}
+
 private:
 	struct Node {
 		StateType state;
 		std::optional<ActionType> action;
 		Node* parent{ nullptr };
+		double prior{ 0.0 };
 		std::vector<ActionType> legalActions;
+		std::vector<double> legalActionPriors;
 		std::vector<ActionType> unexpandedActions;
 		std::vector<std::unique_ptr<Node>> children;
 		int visits{ 0 };
 		double totalValue{ 0.0 };
+		bool neuralExpanded{ false };
+		double evaluatedValue{ 0.0 };
 
-		Node(const StateType& state, std::optional<ActionType> action, Node* parent) :
+		Node(const StateType& state, std::optional<ActionType> action, Node* parent, double prior = 0.0) :
 			state(state),
 			action(std::move(action)),
-			parent(parent) {
+			parent(parent),
+			prior(prior) {
 			if (!this->state.isTerminal()) {
 				legalActions = this->state.getLegalActions();
+				legalActionPriors.assign(legalActions.size(), 0.0);
 				unexpandedActions = legalActions;
 			}
 		}
@@ -137,6 +197,38 @@ private:
 		return node.children.back().get();
 	}
 
+	template <typename EvaluatorType>
+	void EvaluateAndExpand(Node& node, EvaluatorType& evaluator, SearchContext& context, double& value) {
+		if (node.state.isTerminal()) {
+			value = static_cast<double>(node.state.evaluate(node.state.getCurrentPlayer()));
+			node.evaluatedValue = value;
+			node.neuralExpanded = true;
+			return;
+		}
+
+		if (node.legalActions.empty()) {
+			value = 0.0;
+			node.evaluatedValue = value;
+			node.neuralExpanded = true;
+			return;
+		}
+
+		MCTSNeuralEvaluation<ActionType> evaluation = evaluator.evaluate(node.state, node.legalActions);
+		value = std::isfinite(evaluation.value) ? evaluation.value : 0.0;
+		node.evaluatedValue = value;
+		node.legalActionPriors = NormalizePriors(node.legalActions, evaluation.actionPriors);
+		node.neuralExpanded = true;
+
+		for (std::size_t i = 0; i < node.legalActions.size() && context.nodesCreated < context.maxNodes; ++i) {
+			if (FindChild(node, node.legalActions[i]) != nullptr) {
+				continue;
+			}
+			StateType newState = node.state.applyAction(node.legalActions[i]);
+			node.children.push_back(std::make_unique<Node>(newState, node.legalActions[i], &node, node.legalActionPriors[i]));
+			++context.nodesCreated;
+		}
+	}
+
 	StateType Rollout(const StateType& startState, int maxRolloutActions, std::mt19937& rng, bool& reachedTerminal) {
 		StateType state(startState);
 		for (int i = 0; i < maxRolloutActions && !state.isTerminal(); ++i) {
@@ -162,9 +254,26 @@ private:
 		}
 	}
 
+	Node* SelectNeural(Node& root, double explorationConstant) {
+		Node* node = &root;
+		while (!node->state.isTerminal() && node->neuralExpanded && !node->children.empty()) {
+			node = BestPuctChild(*node, explorationConstant);
+			if (!node->neuralExpanded) {
+				break;
+			}
+		}
+		return node;
+	}
+
 	Node* BestChild(Node& node, double explorationConstant) {
 		return std::max_element(node.children.begin(), node.children.end(), [&](const std::unique_ptr<Node>& left, const std::unique_ptr<Node>& right) {
 			return UctValue(node, *left, explorationConstant) < UctValue(node, *right, explorationConstant);
+		})->get();
+	}
+
+	Node* BestPuctChild(Node& node, double explorationConstant) {
+		return std::max_element(node.children.begin(), node.children.end(), [&](const std::unique_ptr<Node>& left, const std::unique_ptr<Node>& right) {
+			return PuctValue(node, *left, explorationConstant) < PuctValue(node, *right, explorationConstant);
 		})->get();
 	}
 
@@ -182,16 +291,47 @@ private:
 		return averageValue + exploration;
 	}
 
+	double PuctValue(const Node& parent, const Node& child, double explorationConstant) const {
+		double averageValue = 0.0;
+		if (child.visits > 0) {
+			averageValue = child.totalValue / child.visits;
+			if (child.state.getCurrentPlayer() != parent.state.getCurrentPlayer()) {
+				averageValue *= -1.0;
+			}
+		}
+
+		const double exploration = explorationConstant * child.prior * std::sqrt(parent.visits + 1.0) / (1.0 + child.visits);
+		return averageValue + exploration;
+	}
+
+	void BackpropagateNeural(Node* node, double leafValue) {
+		const int leafPlayer = node->state.getCurrentPlayer();
+		while (node != nullptr) {
+			++node->visits;
+			double value = leafValue;
+			if (node->state.getCurrentPlayer() != leafPlayer) {
+				value *= -1.0;
+			}
+			node->totalValue += value;
+			node = node->parent;
+		}
+	}
+
 	std::vector<MCTSActionStats<ActionType>> BuildRootActionStats(const Node& root) const {
 		std::vector<MCTSActionStats<ActionType>> stats;
 		stats.reserve(root.legalActions.size());
 
-		for (const ActionType& action : root.legalActions) {
+		for (std::size_t i = 0; i < root.legalActions.size(); ++i) {
+			const ActionType& action = root.legalActions[i];
 			MCTSActionStats<ActionType> actionStats;
 			actionStats.action = action;
+			if (i < root.legalActionPriors.size()) {
+				actionStats.prior = root.legalActionPriors[i];
+			}
 
 			const Node* child = FindChild(root, action);
 			if (child != nullptr) {
+				actionStats.prior = child->prior;
 				actionStats.visits = child->visits;
 				actionStats.totalValue = child->totalValue;
 				if (child->state.getCurrentPlayer() != root.state.getCurrentPlayer()) {
@@ -214,6 +354,30 @@ private:
 		}
 
 		return nullptr;
+	}
+
+	std::vector<double> NormalizePriors(const std::vector<ActionType>& legalActions, const std::vector<MCTSActionPrior<ActionType>>& actionPriors) const {
+		std::vector<double> priors(legalActions.size(), 0.0);
+		double total = 0.0;
+		for (std::size_t i = 0; i < legalActions.size(); ++i) {
+			for (const MCTSActionPrior<ActionType>& actionPrior : actionPriors) {
+				if (actionPrior.action == legalActions[i] && std::isfinite(actionPrior.prior) && actionPrior.prior > 0.0) {
+					priors[i] += actionPrior.prior;
+				}
+			}
+			total += priors[i];
+		}
+
+		if (total <= 0.0) {
+			const double uniform = legalActions.empty() ? 0.0 : 1.0 / static_cast<double>(legalActions.size());
+			std::fill(priors.begin(), priors.end(), uniform);
+			return priors;
+		}
+
+		for (double& prior : priors) {
+			prior /= total;
+		}
+		return priors;
 	}
 
 	std::optional<ActionType> SelectAction(const std::vector<MCTSActionStats<ActionType>>& stats, double temperature, std::mt19937& rng) const {

--- a/AdvanceWarsServer/inc/SelfPlayRunner.h
+++ b/AdvanceWarsServer/inc/SelfPlayRunner.h
@@ -8,10 +8,18 @@
 #include "Result.h"
 #include "SelfPlayReplay.h"
 
+enum class SelfPlayMctsMode {
+	Rollout,
+	NeuralPuct,
+};
+
 struct SelfPlayRunnerOptions {
 	std::filesystem::path outputPath;
 	bool append{ false };
 	bool quiet{ false };
+	SelfPlayMctsMode mctsMode{ SelfPlayMctsMode::Rollout };
+	std::filesystem::path policyValueCheckpointPath;
+	std::string deviceName{ "auto" };
 	std::string mapId;
 	std::string player0CoId;
 	std::string player1CoId;

--- a/AdvanceWarsServer/src/MctsTest.cpp
+++ b/AdvanceWarsServer/src/MctsTest.cpp
@@ -345,6 +345,99 @@ bool TestTemperatureZeroTieAndPositiveTemperatureSampling() {
 		Expect(sampledResult.selectedAction.has_value(), "positive temperature should select an action") &&
 		Expect(sampledResult.selectedAction->id == positiveVisitAction, "positive temperature should sample only positive-visit actions when any exist");
 }
+
+class TestPolicyValueEvaluator {
+public:
+	MCTSNeuralEvaluation<TestAction> evaluate(const TestState&, const std::vector<TestAction>& legalActions) {
+		++calls;
+		MCTSNeuralEvaluation<TestAction> evaluation;
+		evaluation.value = 0.0;
+		for (const TestAction& action : legalActions) {
+			double prior = 1.0;
+			if (action.id == 1) {
+				prior = 0.05;
+			}
+			else if (action.id == 2) {
+				prior = 0.15;
+			}
+			else if (action.id == 3) {
+				prior = 0.80;
+			}
+			evaluation.actionPriors.push_back({ action, prior });
+		}
+		return evaluation;
+	}
+
+	int calls{ 0 };
+};
+
+class LeafValueEvaluator {
+public:
+	MCTSNeuralEvaluation<TestAction> evaluate(const TestState&, const std::vector<TestAction>& legalActions) {
+		++calls;
+		MCTSNeuralEvaluation<TestAction> evaluation;
+		evaluation.value = 0.0;
+		if (!legalActions.empty() && legalActions.front().id == 11) {
+			evaluation.value = 0.9;
+		}
+		for (const TestAction& action : legalActions) {
+			evaluation.actionPriors.push_back({ action, 1.0 });
+		}
+		return evaluation;
+	}
+
+	int calls{ 0 };
+};
+
+bool TestNeuralSearchUsesPuctPriorsForRootVisits() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 24;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 0;
+	options.explorationConstant = 2.0;
+	options.temperature = 0.0;
+
+	TestPolicyValueEvaluator evaluator;
+	MCTSSearchResult<TestAction> result = mcts.searchNeural(MakeThreeTerminalActionState(), evaluator, options);
+
+	return Expect(evaluator.calls == 1, "terminal children should only require root neural evaluation") &&
+		Expect(result.simulationsRun == 24, "neural search should run requested simulations") &&
+		Expect(result.nodesCreated == 4, "neural search should create root plus all root children") &&
+		Expect(SumRootVisits(result) == 24, "neural root visits should sum to simulations") &&
+		Expect(NearlyEqual(FindStats(result, 1)->prior, 0.05), "root stats should expose normalized prior for action 1") &&
+		Expect(NearlyEqual(FindStats(result, 2)->prior, 0.15), "root stats should expose normalized prior for action 2") &&
+		Expect(NearlyEqual(FindStats(result, 3)->prior, 0.80), "root stats should expose normalized prior for action 3") &&
+		Expect(VisitsFor(result, 3) > VisitsFor(result, 2), "PUCT should visit the highest-prior root action most") &&
+		Expect(VisitsFor(result, 2) > VisitsFor(result, 1), "PUCT should reflect lower prior actions in visit counts") &&
+		Expect(SelectedActionIs(result, 3), "temperature zero should select the highest-visit neural action");
+}
+
+bool TestNeuralSearchBacksUpLeafValueWithoutRollout() {
+	TestState root = MakeState({
+		{ 0, std::nullopt, { { 1 }, { 2 } }, { { { 1 }, 1 }, { { 2 }, 2 } } },
+		{ 0, std::nullopt, { { 11 } }, { { { 11 }, 3 } } },
+		{ 0, std::nullopt, { { 21 } }, { { { 21 }, 4 } } },
+		{ 0, 1, {}, {} },
+		{ 0, 0, {}, {} },
+	});
+
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 1;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 100;
+	options.temperature = 0.0;
+
+	LeafValueEvaluator evaluator;
+	MCTSSearchResult<TestAction> result = mcts.searchNeural(root, evaluator, options);
+
+	return Expect(evaluator.calls == 2, "neural search should evaluate the root and selected leaf") &&
+		Expect(VisitsFor(result, 1) == 1, "first legal action should receive the single PUCT visit") &&
+		Expect(NearlyEqual(AverageFor(result, 1), 0.9), "leaf value should back up without rolling out to the scripted loss") &&
+		Expect(VisitsFor(result, 2) == 0, "unvisited neural root actions should remain in stats with zero visits") &&
+		Expect(SelectedActionIs(result, 1), "temperature zero should select the visited neural action");
+}
 }
 
 int RunMctsTests() {
@@ -357,6 +450,8 @@ int RunMctsTests() {
 	passed = TestNodeLimitReusesExistingChildrenWhenExpansionIsBlocked() && passed;
 	passed = TestTerminalAndActionlessRootsReturnNoSelection() && passed;
 	passed = TestTemperatureZeroTieAndPositiveTemperatureSampling() && passed;
+	passed = TestNeuralSearchUsesPuctPriorsForRootVisits() && passed;
+	passed = TestNeuralSearchBacksUpLeafValueWithoutRollout() && passed;
 
 	if (!passed) {
 		return 1;

--- a/AdvanceWarsServer/src/SelfPlayReplay.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplay.cpp
@@ -61,6 +61,38 @@ Result RequireObjectWithFields(const json& value, const std::vector<std::string>
 	return Result::Succeeded;
 }
 
+Result RequireObjectWithRequiredAndOptionalFields(
+	const json& value,
+	const std::vector<std::string>& requiredFields,
+	const std::vector<std::string>& optionalFields,
+	const std::string& label,
+	SelfPlayError& error,
+	int line,
+	int gameIndex = -1,
+	int ply = -1) {
+	if (!value.is_object()) {
+		SetError(error, "schema-error", label + " must be an object", line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	std::vector<std::string> allowedFields = requiredFields;
+	allowedFields.insert(allowedFields.end(), optionalFields.begin(), optionalFields.end());
+	std::string invalidField;
+	if (!ContainsOnlyFields(value, allowedFields, invalidField)) {
+		SetError(error, "schema-error", label + " has unknown or invalid field: " + invalidField, line, gameIndex, ply);
+		return Result::Failed;
+	}
+
+	for (const std::string& requiredField : requiredFields) {
+		if (!value.contains(requiredField)) {
+			SetError(error, "schema-error", label + " is missing required field: " + requiredField, line, gameIndex, ply);
+			return Result::Failed;
+		}
+	}
+
+	return Result::Succeeded;
+}
+
 std::string ChecksumToHex(std::uint64_t checksum) {
 	std::ostringstream stream;
 	stream << std::hex << std::setw(16) << std::setfill('0') << checksum;
@@ -144,6 +176,23 @@ bool IsSortedUniqueInts(const json& value) {
 	return true;
 }
 
+void NormalizeHeaderConfigDefaults(json& header) {
+	if (!header.contains("config") || !header.at("config").is_object()) {
+		return;
+	}
+
+	json& config = header["config"];
+	if (!config.contains("mctsMode")) {
+		config["mctsMode"] = "rollout";
+	}
+	if (!config.contains("policyValueCheckpoint")) {
+		config["policyValueCheckpoint"] = nullptr;
+	}
+	if (!config.contains("device")) {
+		config["device"] = "auto";
+	}
+}
+
 Result ValidateHeader(const json& header, const json* expectedHeader, SelfPlayError& error, int line) {
 	IfFailedReturn(RequireObjectWithFields(header, { "recordType", "replayFormatVersion", "createdAt", "versions", "config" }, "header", error, line));
 	if (header.at("recordType") != "header") {
@@ -172,6 +221,8 @@ Result ValidateHeader(const json& header, const json* expectedHeader, SelfPlayEr
 		json expectedComparable = *expectedHeader;
 		actualComparable.erase("createdAt");
 		expectedComparable.erase("createdAt");
+		NormalizeHeaderConfigDefaults(actualComparable);
+		NormalizeHeaderConfigDefaults(expectedComparable);
 		if (actualComparable != expectedComparable) {
 			SetError(error, "append-header-mismatch", "existing replay header is not compatible with requested append", line);
 			return Result::Failed;
@@ -328,8 +379,33 @@ Result ValidateGameRecord(const json& game, SelfPlayReplayValidationSummary& sum
 	}
 
 	const int gameIndex = game.at("gameIndex").get<int>();
-	IfFailedReturn(RequireObjectWithFields(game.at("config"), { "mapId", "baseSeed", "combatSeed", "mctsSeed", "maxActions", "mctsOptions" }, "game.config", error, line, gameIndex));
+	IfFailedReturn(RequireObjectWithRequiredAndOptionalFields(
+		game.at("config"),
+		{ "mapId", "baseSeed", "combatSeed", "mctsSeed", "maxActions", "mctsOptions" },
+		{ "mctsMode", "policyValueCheckpoint", "device" },
+		"game.config",
+		error,
+		line,
+		gameIndex));
 	IfFailedReturn(RequireObjectWithFields(game.at("config").at("mctsOptions"), { "maxSimulations", "maxNodes", "maxRolloutActions", "explorationConstant", "temperature" }, "game.config.mctsOptions", error, line, gameIndex));
+	if (game.at("config").contains("mctsMode")) {
+		const json& mode = game.at("config").at("mctsMode");
+		if (!mode.is_string() || (mode != "rollout" && mode != "neural-puct")) {
+			SetError(error, "schema-error", "game.config.mctsMode must be rollout or neural-puct", line, gameIndex);
+			return Result::Failed;
+		}
+	}
+	if (game.at("config").contains("policyValueCheckpoint") &&
+		!game.at("config").at("policyValueCheckpoint").is_null() &&
+		!game.at("config").at("policyValueCheckpoint").is_string()) {
+		SetError(error, "schema-error", "game.config.policyValueCheckpoint must be a string or null", line, gameIndex);
+		return Result::Failed;
+	}
+	if (game.at("config").contains("device") &&
+		!game.at("config").at("device").is_string()) {
+		SetError(error, "schema-error", "game.config.device must be a string", line, gameIndex);
+		return Result::Failed;
+	}
 	if (!game.at("players").is_array() || game.at("players").size() != 2) {
 		SetError(error, "schema-error", "players must contain two entries", line, gameIndex);
 		return Result::Failed;

--- a/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 
+#include "PolicyValueModel.h"
 #include "SelfPlayReplay.h"
 #include "SelfPlayRunner.h"
 
@@ -157,6 +158,86 @@ bool GeneratedReplayValidatesAndUsesSparseSamples() {
 	return true;
 }
 
+bool WriteLegacyReplayWithoutSearchMetadata(const std::filesystem::path& source, const std::filesystem::path& target) {
+	std::ifstream input(source);
+	std::ofstream output(target, std::ios::trunc);
+	if (!input.is_open() || !output.is_open()) {
+		return false;
+	}
+
+	std::string line;
+	int lineNumber = 0;
+	while (std::getline(input, line)) {
+		++lineNumber;
+		json record = json::parse(line);
+		if (lineNumber == 1) {
+			record["config"].erase("mctsMode");
+			record["config"].erase("policyValueCheckpoint");
+			record["config"].erase("device");
+		}
+		else if (record.contains("config")) {
+			record["config"].erase("mctsMode");
+			record["config"].erase("policyValueCheckpoint");
+			record["config"].erase("device");
+		}
+		output << record.dump() << "\n";
+	}
+
+	return true;
+}
+
+bool GeneratedNeuralReplayUsesPolicyValueEvaluator() {
+	const std::filesystem::path replayPath = MakeTempReplayPath("self-play-neural-replay-test");
+	const std::filesystem::path checkpointPath = std::filesystem::temp_directory_path() / "advance-wars-self-play-neural-checkpoint";
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove_all(checkpointPath);
+
+	PolicyValueModelConfig config;
+	PolicyValueNetwork model = CreatePolicyValueNetwork(config, 31);
+	PolicyValueModelError modelError;
+	if (!Expect(SavePolicyValueCheckpoint(checkpointPath, model, config, 31, "cpu", false, modelError) == Result::Succeeded, "neural checkpoint should save: " + modelError.message)) {
+		std::filesystem::remove_all(checkpointPath);
+		return false;
+	}
+
+	SelfPlayRunnerOptions options;
+	options.outputPath = replayPath;
+	options.mapId = "mcts";
+	options.player0CoId = "andy";
+	options.player1CoId = "adder";
+	options.games = 1;
+	options.maxActions = 1;
+	options.baseSeed = 37;
+	options.mctsMode = SelfPlayMctsMode::NeuralPuct;
+	options.policyValueCheckpointPath = checkpointPath;
+	options.deviceName = "cpu";
+	options.mctsOptions.maxSimulations = 2;
+	options.mctsOptions.maxNodes = 10000;
+	options.mctsOptions.maxRolloutActions = 0;
+	options.mctsOptions.temperature = 0.0;
+	options.quiet = true;
+
+	SelfPlayRunSummary runSummary;
+	SelfPlayError error;
+	if (!Expect(RunSelfPlay(options, runSummary, error) == Result::Succeeded, "neural self-play run should write and validate a replay: " + error.message)) {
+		std::filesystem::remove(replayPath);
+		std::filesystem::remove_all(checkpointPath);
+		return false;
+	}
+
+	const json header = ReadJsonLine(replayPath, 1);
+	const json game = ReadJsonLine(replayPath, 2);
+	const bool passed =
+		Expect(header.at("config").at("mctsMode") == "neural-puct", "header should record neural MCTS mode") &&
+		Expect(game.at("config").at("mctsMode") == "neural-puct", "game config should record neural MCTS mode") &&
+		Expect(game.at("samples")[0].at("mcts").at("simulationsRun") == 2, "neural sample should record requested simulations") &&
+		Expect(runSummary.samplesWritten == 1, "neural smoke run should write one sample");
+
+	std::filesystem::remove(replayPath);
+	std::filesystem::remove_all(checkpointPath);
+	return passed;
+}
+
 bool CorruptedReplayIsRejected() {
 	const std::filesystem::path replayPath = MakeTempReplayPath("self-play-replay-corrupt-source");
 	const std::filesystem::path corruptPath = MakeTempReplayPath("self-play-replay-corrupt");
@@ -234,6 +315,53 @@ bool MissingRequiredReplayFieldIsRejected() {
 	return Expect(error.code == "schema-error", "missing field rejection should report a schema error");
 }
 
+bool LegacyReplayHeaderCanAppendRolloutDefaults() {
+	const std::filesystem::path sourcePath = MakeTempReplayPath("self-play-replay-legacy-source");
+	const std::filesystem::path legacyPath = MakeTempReplayPath("self-play-replay-legacy-append");
+	std::filesystem::remove(sourcePath);
+	std::filesystem::remove(legacyPath);
+
+	SelfPlayRunnerOptions options;
+	options.outputPath = sourcePath;
+	options.mapId = "mcts";
+	options.player0CoId = "andy";
+	options.player1CoId = "adder";
+	options.games = 1;
+	options.maxActions = 1;
+	options.baseSeed = 41;
+	options.mctsOptions.maxSimulations = 1;
+	options.mctsOptions.maxNodes = 16;
+	options.mctsOptions.maxRolloutActions = 4;
+	options.mctsOptions.temperature = 0.0;
+	options.quiet = true;
+
+	SelfPlayRunSummary runSummary;
+	SelfPlayError error;
+	if (!Expect(RunSelfPlay(options, runSummary, error) == Result::Succeeded, "self-play run should create legacy source replay: " + error.message)) {
+		std::filesystem::remove(sourcePath);
+		return false;
+	}
+	if (!Expect(WriteLegacyReplayWithoutSearchMetadata(sourcePath, legacyPath), "test should write a legacy-shaped replay")) {
+		std::filesystem::remove(sourcePath);
+		std::filesystem::remove(legacyPath);
+		return false;
+	}
+
+	options.outputPath = legacyPath;
+	options.append = true;
+	options.baseSeed = 41;
+	const Result appendResult = RunSelfPlay(options, runSummary, error);
+
+	SelfPlayReplayValidationSummary validationSummary;
+	const Result validationResult = ValidateSelfPlayReplay(legacyPath, validationSummary, error);
+	std::filesystem::remove(sourcePath);
+	std::filesystem::remove(legacyPath);
+
+	return Expect(appendResult == Result::Succeeded, "append should accept legacy rollout header defaults: " + error.message) &&
+		Expect(validationResult == Result::Succeeded, "legacy-plus-new replay should validate after append: " + error.message) &&
+		Expect(validationSummary.games == 2, "legacy append test should contain two games");
+}
+
 bool InvalidSelfPlaySetupReportsError() {
 	SelfPlayRunnerOptions options;
 	options.outputPath = MakeTempReplayPath("self-play-invalid-setup");
@@ -265,11 +393,19 @@ int RunSelfPlayReplayTests() {
 		return 1;
 	}
 
+	if (!GeneratedNeuralReplayUsesPolicyValueEvaluator()) {
+		return 1;
+	}
+
 	if (!CorruptedReplayIsRejected()) {
 		return 1;
 	}
 
 	if (!MissingRequiredReplayFieldIsRejected()) {
+		return 1;
+	}
+
+	if (!LegacyReplayHeaderCanAppendRolloutDefaults()) {
 		return 1;
 	}
 

--- a/AdvanceWarsServer/src/SelfPlayRunner.cpp
+++ b/AdvanceWarsServer/src/SelfPlayRunner.cpp
@@ -7,23 +7,147 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ActionSpace.h"
+#include "PolicyValueModel.h"
 #include "StandardGameSetup.h"
 #include "StateTensor.h"
 
 namespace {
+class NeuralMctsEvaluationException : public std::runtime_error {
+public:
+	NeuralMctsEvaluationException(std::string code, const std::string& message) :
+		std::runtime_error(message),
+		m_code(std::move(code)) {
+	}
+
+	const std::string& code() const noexcept {
+		return m_code;
+	}
+
+private:
+	std::string m_code;
+};
+
+struct SelfPlayRuntime {
+	PolicyValueNetwork model{ nullptr };
+	torch::Device device{ torch::kCPU };
+	std::string resolvedDevice{ "cpu" };
+};
+
 void SetError(SelfPlayError& error, const std::string& code, const std::string& message, int gameIndex = -1, int ply = -1) {
 	error.code = code;
 	error.message = message;
 	error.gameIndex = gameIndex;
 	error.ply = ply;
 }
+
+const char* MctsModeName(SelfPlayMctsMode mode) noexcept {
+	switch (mode) {
+	case SelfPlayMctsMode::Rollout:
+		return "rollout";
+	case SelfPlayMctsMode::NeuralPuct:
+		return "neural-puct";
+	default:
+		return "unknown";
+	}
+}
+
+bool ParseMctsMode(const std::string& value, SelfPlayMctsMode& mode) {
+	if (value == "rollout") {
+		mode = SelfPlayMctsMode::Rollout;
+		return true;
+	}
+	if (value == "neural-puct" || value == "neural") {
+		mode = SelfPlayMctsMode::NeuralPuct;
+		return true;
+	}
+	return false;
+}
+
+json OptionalPathJson(const std::filesystem::path& path) {
+	return path.empty() ? json(nullptr) : json(path.string());
+}
+
+class PolicyValueMctsEvaluator {
+public:
+	PolicyValueMctsEvaluator(PolicyValueNetwork& model, const torch::Device& device) :
+		m_model(model),
+		m_device(device) {
+	}
+
+	MCTSNeuralEvaluation<Action> evaluate(const GameState& gameState, const std::vector<Action>& legalActions) {
+		if (legalActions.empty()) {
+			return {};
+		}
+
+		std::vector<float> values;
+		if (StateTensor::Encode(gameState, values) == Result::Failed) {
+			throw NeuralMctsEvaluationException("state-tensor-failed", "state tensor encoding failed during neural MCTS evaluation");
+		}
+
+		torch::Tensor input = torch::from_blob(
+			values.data(),
+			{ 1, StateTensor::ChannelCount(), StateTensor::BoardHeight(), StateTensor::BoardWidth() },
+			torch::TensorOptions().dtype(torch::kFloat32)).clone().contiguous().to(m_device);
+
+		PolicyValueNetworkOutput output;
+		PolicyValueModelError modelError;
+		if (RunPolicyValueInference(m_model, input, output, modelError) == Result::Failed) {
+			throw NeuralMctsEvaluationException(modelError.code, modelError.message);
+		}
+
+		const torch::Tensor policyLogits = output.policyLogits.index({ 0 }).to(torch::kCPU);
+		MCTSNeuralEvaluation<Action> evaluation;
+		evaluation.value = output.value.view({ -1 }).index({ 0 }).to(torch::kCPU).item<double>();
+
+		std::vector<double> logits;
+		logits.reserve(legalActions.size());
+		double maxLogit = -std::numeric_limits<double>::infinity();
+		for (const Action& action : legalActions) {
+			int actionIndex = -1;
+			if (ActionSpace::EncodeAction(action, actionIndex) == Result::Failed) {
+				throw NeuralMctsEvaluationException("action-encoding-failed", "legal action failed to encode during neural MCTS evaluation");
+			}
+
+			const double logit = policyLogits.index({ actionIndex }).item<double>();
+			if (!std::isfinite(logit)) {
+				throw NeuralMctsEvaluationException("invalid-policy-logit", "model produced a non-finite legal action logit");
+			}
+			logits.push_back(logit);
+			maxLogit = std::max(maxLogit, logit);
+		}
+
+		double denominator = 0.0;
+		for (double logit : logits) {
+			denominator += std::exp(logit - maxLogit);
+		}
+		if (!std::isfinite(denominator) || denominator <= 0.0) {
+			throw NeuralMctsEvaluationException("invalid-policy-priors", "legal action logits could not be normalized");
+		}
+
+		evaluation.actionPriors.reserve(legalActions.size());
+		for (std::size_t i = 0; i < legalActions.size(); ++i) {
+			evaluation.actionPriors.push_back({
+				legalActions[i],
+				std::exp(logits[i] - maxLogit) / denominator,
+			});
+		}
+		return evaluation;
+	}
+
+private:
+	PolicyValueNetwork& m_model;
+	torch::Device m_device;
+};
 
 std::string ChecksumToHex(std::uint64_t checksum) {
 	std::ostringstream stream;
@@ -84,6 +208,9 @@ json BuildHeader(const SelfPlayRunnerOptions& options) {
 			{ "player1Co", options.player1CoId },
 			{ "baseSeed", options.baseSeed },
 			{ "maxActions", options.maxActions },
+			{ "mctsMode", MctsModeName(options.mctsMode) },
+			{ "policyValueCheckpoint", OptionalPathJson(options.policyValueCheckpointPath) },
+			{ "device", options.deviceName },
 			{ "settings", SettingsJsonFromOptions(options) },
 			{ "mctsOptions", MctsOptionsJson(options.mctsOptions) },
 		} },
@@ -213,6 +340,9 @@ json GameConfigJson(const SelfPlayRunnerOptions& options, int gameIndex, std::ui
 		{ "combatSeed", combatSeed },
 		{ "mctsSeed", mctsSeed },
 		{ "maxActions", options.maxActions },
+		{ "mctsMode", MctsModeName(options.mctsMode) },
+		{ "policyValueCheckpoint", OptionalPathJson(options.policyValueCheckpointPath) },
+		{ "device", options.deviceName },
 		{ "mctsOptions", MctsOptionsJson(options.mctsOptions) },
 	};
 }
@@ -232,7 +362,7 @@ Result CreateGame(const SelfPlayRunnerOptions& options, int gameIndex, std::uint
 	return Result::Succeeded;
 }
 
-Result BuildGameRecord(const SelfPlayRunnerOptions& options, int gameIndex, int outputGameIndex, json& gameRecord, SelfPlayRunSummary& summary, SelfPlayError& error) {
+Result BuildGameRecord(const SelfPlayRunnerOptions& options, SelfPlayRuntime& runtime, int gameIndex, int outputGameIndex, json& gameRecord, SelfPlayRunSummary& summary, SelfPlayError& error) {
 	const std::uint32_t combatSeed = AddSeed(options.baseSeed, static_cast<std::uint32_t>(gameIndex));
 	const std::uint32_t mctsGameSeed = AddSeed(options.baseSeed, static_cast<std::uint32_t>(1000003u * (static_cast<std::uint32_t>(gameIndex) + 1u)));
 
@@ -270,7 +400,24 @@ Result BuildGameRecord(const SelfPlayRunnerOptions& options, int gameIndex, int 
 		searchOptions.seed = actionMctsSeed;
 
 		const auto searchStart = std::chrono::steady_clock::now();
-		MCTSSearchResult<Action> searchResult = mcts.search(gameState, searchOptions);
+		MCTSSearchResult<Action> searchResult;
+		if (options.mctsMode == SelfPlayMctsMode::NeuralPuct) {
+			if (runtime.model.is_empty()) {
+				SetError(error, "model-not-loaded", "neural MCTS requested without a loaded policy/value model", gameIndex, ply);
+				return Result::Failed;
+			}
+			PolicyValueMctsEvaluator evaluator(runtime.model, runtime.device);
+			try {
+				searchResult = mcts.searchNeural(gameState, evaluator, searchOptions);
+			}
+			catch (const NeuralMctsEvaluationException& err) {
+				SetError(error, err.code(), err.what(), gameIndex, ply);
+				return Result::Failed;
+			}
+		}
+		else {
+			searchResult = mcts.search(gameState, searchOptions);
+		}
 		const auto searchEnd = std::chrono::steady_clock::now();
 		const double searchTimeMs = std::chrono::duration<double, std::milli>(searchEnd - searchStart).count();
 		totalSearchTimeMs += searchTimeMs;
@@ -435,6 +582,14 @@ Result ValidateOptions(const SelfPlayRunnerOptions& options, SelfPlayError& erro
 		SetError(error, "missing-co", "--player0-co and --player1-co are required");
 		return Result::Failed;
 	}
+	if (options.mctsMode == SelfPlayMctsMode::NeuralPuct && options.policyValueCheckpointPath.empty()) {
+		SetError(error, "missing-policy-value-checkpoint", "--policy-value-checkpoint is required when --mcts-mode neural-puct");
+		return Result::Failed;
+	}
+	if (options.mctsMode == SelfPlayMctsMode::Rollout && !options.policyValueCheckpointPath.empty()) {
+		SetError(error, "unexpected-policy-value-checkpoint", "--policy-value-checkpoint requires --mcts-mode neural-puct");
+		return Result::Failed;
+	}
 	if (options.games < 1) {
 		SetError(error, "invalid-games", "--games must be at least 1");
 		return Result::Failed;
@@ -505,11 +660,39 @@ int PrintError(const SelfPlayError& error) {
 	std::cerr << std::endl;
 	return 1;
 }
+
+Result LoadSelfPlayRuntime(const SelfPlayRunnerOptions& options, SelfPlayRuntime& runtime, SelfPlayError& error) {
+	runtime = SelfPlayRuntime{};
+	if (options.mctsMode == SelfPlayMctsMode::Rollout) {
+		return Result::Succeeded;
+	}
+
+	PolicyValueModelError modelError;
+	runtime.device = ResolvePolicyValueDevice(options.deviceName, modelError);
+	if (!modelError.code.empty()) {
+		SetError(error, modelError.code, modelError.message);
+		return Result::Failed;
+	}
+	runtime.resolvedDevice = PolicyValueDeviceName(runtime.device);
+
+	PolicyValueModelConfig config;
+	std::int64_t seed = -1;
+	if (LoadPolicyValueCheckpoint(options.policyValueCheckpointPath, runtime.model, config, seed, modelError) == Result::Failed) {
+		SetError(error, modelError.code, modelError.message);
+		return Result::Failed;
+	}
+
+	runtime.model->to(runtime.device);
+	runtime.model->eval();
+	return Result::Succeeded;
+}
 }
 
 Result RunSelfPlay(const SelfPlayRunnerOptions& options, SelfPlayRunSummary& summary, SelfPlayError& error) {
 	summary = SelfPlayRunSummary{};
 	IfFailedReturn(ValidateOptions(options, error));
+	SelfPlayRuntime runtime;
+	IfFailedReturn(LoadSelfPlayRuntime(options, runtime, error));
 
 	const json header = BuildHeader(options);
 	int existingGames = 0;
@@ -528,7 +711,7 @@ Result RunSelfPlay(const SelfPlayRunnerOptions& options, SelfPlayRunSummary& sum
 
 	for (int gameIndex = 0; gameIndex < options.games; ++gameIndex) {
 		json gameRecord;
-		IfFailedReturn(BuildGameRecord(options, existingGames + gameIndex, existingGames + gameIndex, gameRecord, summary, error));
+		IfFailedReturn(BuildGameRecord(options, runtime, existingGames + gameIndex, existingGames + gameIndex, gameRecord, summary, error));
 		output << gameRecord.dump() << "\n";
 		if (!options.quiet) {
 			std::cout << "self-play game " << (existingGames + gameIndex) <<
@@ -582,6 +765,13 @@ int RunSelfPlayCommand(int argc, char* argv[]) noexcept {
 		else if (arg == "--capture-limit" && requireValue(value) && ParseInt(value, options.captureLimit)) {}
 		else if (arg == "--day-limit" && requireValue(value) && ParseInt(value, options.dayLimit)) {
 			options.hasDayLimit = true;
+		}
+		else if (arg == "--mcts-mode" && requireValue(value) && ParseMctsMode(value, options.mctsMode)) {}
+		else if (arg == "--policy-value-checkpoint" && requireValue(value)) {
+			options.policyValueCheckpointPath = value;
+		}
+		else if (arg == "--device" && requireValue(value)) {
+			options.deviceName = value;
 		}
 		else if (arg == "--mcts-simulations" && requireValue(value) && ParseInt(value, options.mctsOptions.maxSimulations)) {}
 		else if (arg == "--mcts-max-nodes" && requireValue(value) && ParseInt(value, options.mctsOptions.maxNodes)) {}

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -41,10 +41,10 @@ The rules/API completeness target for the initial playable environment is normal
 
 ## Phase 2: MCTS Improvements
 
-- [x] Separate pure rollout MCTS from neural-network-guided MCTS. Neural-guided PUCT is tracked by #166.
+- [x] Separate pure rollout MCTS from neural-network-guided MCTS; `-self-play` defaults to rollout and can opt into neural PUCT with a checkpoint (#166).
 - [x] Expand one child at a time or track unexpanded actions to avoid expanding every legal action immediately.
 - [x] Replace `rand()` rollout action selection with a seeded RNG object.
-- [ ] Add PUCT selection using policy priors once a policy head exists (#166).
+- [x] Add PUCT selection using policy/value priors and leaf values from the LibTorch model path (#166).
 - [x] Store visit counts per legal action for training targets.
 - [x] Handle same-player action sequences explicitly in value backup.
 - [x] Add temperature controls for early-game exploration and late-game exploitation.
@@ -104,7 +104,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] #8 Add training command-line entry point.
 - [x] #9 Add checkpoint evaluation harness.
 - [ ] #164 Track CO matchup statistics for pregame selection.
-- [ ] #166 Add neural-guided MCTS with PUCT.
+- [x] #166 Add neural-guided MCTS with PUCT.
 - [ ] #167 Add reusable MCTS search tree re-rooting.
 - [ ] #168 Add wall-clock MCTS search limits.
 - [ ] #172 Add optional materialized replay cache for faster training loads.

--- a/docs/SELF_PLAY_REPLAYS.md
+++ b/docs/SELF_PLAY_REPLAYS.md
@@ -27,6 +27,22 @@ Validate an existing shard:
 ..\x64\Debug\AdvanceWarsServer.exe -validate-replay ..\artifacts\replays\smoke.jsonl
 ```
 
+Generate one neural-guided PUCT replay from an initialized checkpoint:
+
+```powershell
+..\x64\Debug\AdvanceWarsServer.exe -self-play `
+  --out ..\artifacts\replays\neural-smoke.jsonl `
+  --map mcts `
+  --player0-co andy `
+  --player1-co adder `
+  --mcts-mode neural-puct `
+  --policy-value-checkpoint ..\artifacts\models\candidate `
+  --device auto `
+  --games 1 `
+  --max-actions 100 `
+  --mcts-simulations 64
+```
+
 `-self-play` writes the replay and then validates the whole file. If validation fails, the file is left in place for debugging and the process returns nonzero.
 
 By default, `-self-play` fails when `--out` already exists. Pass `--append` to append to an existing compatible shard. Appends validate the whole existing file first. An empty existing file is treated as a new shard and receives a fresh header.
@@ -60,6 +76,9 @@ MCTS options:
 
 | Option | Default | Meaning |
 | --- | ---: | --- |
+| `--mcts-mode <mode>` | `rollout` | Search mode. Use `rollout` for pure rollout MCTS or `neural-puct` for policy/value-guided PUCT. |
+| `--policy-value-checkpoint <dir>` | unset | Required with `--mcts-mode neural-puct`; points at a strict policy/value checkpoint bundle. |
+| `--device <name>` | `auto` | Model device for neural PUCT: `cpu`, `auto`, or `cuda`. |
 | `--mcts-simulations <n>` | `128` | Root simulations per action. Must be at least `1`. |
 | `--mcts-max-nodes <n>` | `10000` | Search node cap. |
 | `--mcts-max-rollout-actions <n>` | `512` | Rollout action cap. |
@@ -87,6 +106,9 @@ The first line is a header:
     "player1Co": "adder",
     "baseSeed": 123,
     "maxActions": 1000,
+    "mctsMode": "rollout",
+    "policyValueCheckpoint": null,
+    "device": "auto",
     "settings": {},
     "mctsOptions": {}
   }
@@ -110,6 +132,9 @@ Every following line is a game record. Game records are self-contained enough to
     "combatSeed": 123,
     "mctsSeed": 1000126,
     "maxActions": 1000,
+    "mctsMode": "rollout",
+    "policyValueCheckpoint": null,
+    "device": "auto",
     "mctsOptions": {}
   },
   "players": [
@@ -177,6 +202,8 @@ Samples contain compact training targets:
 Replay v1 does not store dense state tensors or dense legal action masks. Validation rebuilds the state from `initialState` plus `actions[0..ply)`, regenerates the tensor checksum and sparse legal action indices, and compares them exactly.
 
 `visitCounts` stores positive visits only, sorted by `actionIndex`. Legal actions with zero visits are implied by `legalActionIndices`.
+
+In `neural-puct` mode, the runner gathers model policy logits only at the sparse legal action indices, normalizes those legal logits into priors, uses PUCT for tree selection, and backs up the value head at expanded leaves. The replay target format is unchanged: training still consumes sparse positive visit counts over legal action indices.
 
 `outcome` is from the sample's `currentPlayer` perspective:
 

--- a/docs/TRAINING_DESIGN.md
+++ b/docs/TRAINING_DESIGN.md
@@ -71,7 +71,7 @@ The v1 `-train` command samples replay positions from validated `standard-gl-sel
 
 The first trainer uses AdamW, a constant learning rate, float32, and model-only checkpoint continuation. Streaming replay loading, optimizer-state resume, learning-rate schedules, mixed precision, and atomic checkpoint publishing are tracked separately by #180, #181, and #182. See `docs/TRAINING_COMMAND_DESIGN.md` for the concrete command contract.
 
-Checkpoints should be evaluated against the current best checkpoint on fixed maps, fixed seeds, and a held-out map set. The v1 `-evaluate` command is report-only: it writes an `evaluation.json` style artifact with compact per-game outcomes and a promotion recommendation, but it does not mutate checkpoint bundles. The first checkpoint agent uses legal-policy argmax and is intentionally labeled `checkpoint-policy`; neural-guided PUCT remains tracked by #166.
+Checkpoints should be evaluated against the current best checkpoint on fixed maps, fixed seeds, and a held-out map set. The v1 `-evaluate` command is report-only: it writes an `evaluation.json` style artifact with compact per-game outcomes and a promotion recommendation, but it does not mutate checkpoint bundles. The first checkpoint agent uses legal-policy argmax and is intentionally labeled `checkpoint-policy`; self-play can opt into neural-guided PUCT via `-self-play --mcts-mode neural-puct`.
 
 ## Metrics
 


### PR DESCRIPTION
## Summary
- Add a neural-guided `searchNeural` MCTS path with PUCT priors, value-head leaf backup, and unchanged sparse root visit-count output.
- Wire `-self-play` to opt into `--mcts-mode neural-puct` with a policy/value checkpoint and model device, while keeping rollout MCTS as the default baseline.
- Preserve replay validation compatibility for older rollout shards and document the neural self-play command path.

## Why
Issue #166 tracks the handoff from pure rollout MCTS to AlphaZero-style self-play search. The self-play runner now gathers policy logits only at legal encoded actions, normalizes those legal logits into priors, uses PUCT for selection, and records visit counts in the same replay format the trainer already consumes.

## Tests
- Red phase: added MCTS tests first; initial build failed on missing `MCTSNeuralEvaluation`, `searchNeural`, and `prior` surface as expected.
- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /p:LIBTORCH_ROOT=D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch /v:minimal /clp:ErrorsOnly`
- `AdvanceWarsServer.exe -test-model --device cpu`
- `AdvanceWarsServer.exe -test-mcts`
- `AdvanceWarsServer.exe -test-replay`
- `AdvanceWarsServer.exe -test-train`
- CLI smoke: `-model-init` a temporary CPU checkpoint, `-self-play --mcts-mode neural-puct`, then `-validate-replay`
- `git diff --check`

## Residual Risk
- Neural MCTS currently performs one model inference per expanded leaf in the single-worker path. Multi-leaf/batched inference remains throughput work tracked separately in the roadmap.

Closes #166