### PR TITLE
Add known-legal MCTS action apply path

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -211,6 +211,22 @@ public:
 		return actedGameState;
 	}
 
+	GameState applyKnownLegalAction(const Action& action) {
+		GameState actedGameState{ Clone() };
+		if (Result::Failed == actedGameState.ExecuteAction(action)) {
+			json jaction;
+			::to_json(jaction, action);
+			json jstate;
+			to_json(jstate, *this);
+			std::cout << "Failed to execute a known-legal action:" << jaction.dump() << "\n" << jstate.dump() << std::endl;
+			return Clone();
+		}
+		if (actedGameState.FHeuristicAutoResign()) {
+			actedGameState.CheckPlayerResigns();
+		}
+		return actedGameState;
+	}
+
 	double evaluate(int playerPerspective) const {
 		if (!m_fGameOver || m_winningPlayer == 2) {
 			return 0;

--- a/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
+++ b/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <random>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -51,10 +52,34 @@ struct MCTSSearchResult {
 // StateType must provide:
 // - std::vector<ActionType> getLegalActions() const
 // - StateType applyAction(const ActionType&) const
+// - optional StateType applyKnownLegalAction(const ActionType&) for known-legal MCTS actions
 // - bool isTerminal() const
 // - int getCurrentPlayer() const
 // - double-compatible evaluate(int player) const
 // ActionType must be equality-comparable.
+namespace MctsDetail {
+template <typename StateType, typename ActionType, typename = void>
+struct HasKnownLegalApply : std::false_type {
+};
+
+template <typename StateType, typename ActionType>
+struct HasKnownLegalApply<
+	StateType,
+	ActionType,
+	std::void_t<decltype(std::declval<StateType&>().applyKnownLegalAction(std::declval<const ActionType&>()))>> : std::true_type {
+};
+
+template <typename StateType, typename ActionType>
+StateType ApplyKnownLegalAction(StateType& state, const ActionType& action) {
+	if constexpr (HasKnownLegalApply<StateType, ActionType>::value) {
+		return state.applyKnownLegalAction(action);
+	}
+	else {
+		return state.applyAction(action);
+	}
+}
+}
+
 template <typename StateType, typename ActionType>
 class MCTS {
 public:
@@ -192,7 +217,7 @@ private:
 		ActionType action = node.unexpandedActions[static_cast<std::size_t>(actionIndex)];
 		node.unexpandedActions.erase(node.unexpandedActions.begin() + actionIndex);
 
-		StateType newState = node.state.applyAction(action);
+		StateType newState = MctsDetail::ApplyKnownLegalAction(node.state, action);
 		node.children.push_back(std::make_unique<Node>(newState, action, &node));
 		return node.children.back().get();
 	}
@@ -223,7 +248,7 @@ private:
 			if (FindChild(node, node.legalActions[i]) != nullptr) {
 				continue;
 			}
-			StateType newState = node.state.applyAction(node.legalActions[i]);
+			StateType newState = MctsDetail::ApplyKnownLegalAction(node.state, node.legalActions[i]);
 			node.children.push_back(std::make_unique<Node>(newState, node.legalActions[i], &node, node.legalActionPriors[i]));
 			++context.nodesCreated;
 		}
@@ -238,7 +263,7 @@ private:
 			}
 
 			std::uniform_int_distribution<int> distribution(0, static_cast<int>(actions.size() - 1));
-			state = state.applyAction(actions[static_cast<std::size_t>(distribution(rng))]);
+			state = MctsDetail::ApplyKnownLegalAction(state, actions[static_cast<std::size_t>(distribution(rng))]);
 		}
 
 		reachedTerminal = state.isTerminal();

--- a/AdvanceWarsServer/src/MctsTest.cpp
+++ b/AdvanceWarsServer/src/MctsTest.cpp
@@ -29,6 +29,8 @@ struct TestNodeDef {
 
 struct TestGraph {
 	std::vector<TestNodeDef> nodes;
+	mutable int applyActionCalls{ 0 };
+	mutable int applyKnownLegalActionCalls{ 0 };
 };
 
 class TestState {
@@ -48,13 +50,13 @@ public:
 	}
 
 	TestState applyAction(const TestAction& action) const {
-		for (const auto& transition : GetNode().transitions) {
-			if (transition.first == action) {
-				return TestState(m_graph, transition.second);
-			}
-		}
+		++m_graph->applyActionCalls;
+		return ApplyTransition(action);
+	}
 
-		throw std::runtime_error("test action was not legal in scripted state");
+	TestState applyKnownLegalAction(const TestAction& action) const {
+		++m_graph->applyKnownLegalActionCalls;
+		return ApplyTransition(action);
 	}
 
 	bool isTerminal() const {
@@ -74,9 +76,27 @@ public:
 		return *node.winner == player ? 1.0 : -1.0;
 	}
 
+	int getApplyActionCalls() const {
+		return m_graph->applyActionCalls;
+	}
+
+	int getApplyKnownLegalActionCalls() const {
+		return m_graph->applyKnownLegalActionCalls;
+	}
+
 private:
 	const TestNodeDef& GetNode() const {
 		return m_graph->nodes.at(static_cast<std::size_t>(m_nodeId));
+	}
+
+	TestState ApplyTransition(const TestAction& action) const {
+		for (const auto& transition : GetNode().transitions) {
+			if (transition.first == action) {
+				return TestState(m_graph, transition.second);
+			}
+		}
+
+		throw std::runtime_error("test action was not legal in scripted state");
 	}
 
 	std::shared_ptr<const TestGraph> m_graph;
@@ -196,6 +216,24 @@ bool TestOneActionExpansionAndRootStats() {
 		Expect(SumRootVisits(result) == 1, "only one root action should be visited") &&
 		Expect(CountVisitedRootActions(result) == 1, "only one root child should be expanded") &&
 		Expect(result.selectedAction.has_value(), "a selected action should be returned for non-empty root");
+}
+
+bool TestSearchExpansionUsesKnownLegalApplyPath() {
+	TestState root = MakeThreeTerminalActionState();
+
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 1;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 0;
+	options.temperature = 0.0;
+	options.seed = 7;
+
+	MCTSSearchResult<TestAction> result = mcts.search(root, options);
+
+	return Expect(result.nodesCreated == 2, "test setup should create one expanded child") &&
+		Expect(root.getApplyKnownLegalActionCalls() == 1, "MCTS expansion should use the known-legal apply path") &&
+		Expect(root.getApplyActionCalls() == 0, "MCTS expansion should not use the validating apply path for known-legal actions");
 }
 
 bool TestSeededSearchIsReproducible() {
@@ -443,6 +481,7 @@ bool TestNeuralSearchBacksUpLeafValueWithoutRollout() {
 int RunMctsTests() {
 	bool passed = true;
 	passed = TestOneActionExpansionAndRootStats() && passed;
+	passed = TestSearchExpansionUsesKnownLegalApplyPath() && passed;
 	passed = TestSeededSearchIsReproducible() && passed;
 	passed = TestPlayerPerspectiveBackupHandlesSamePlayerAndSwitches() && passed;
 	passed = TestRolloutCutoffBacksUpZero() && passed;


### PR DESCRIPTION
## Summary

- Add an optional `applyKnownLegalAction` hook to the generic MCTS state contract and use it for search-owned actions selected from legal action lists.
- Add `GameState::applyKnownLegalAction` so MCTS can clone once and call `ExecuteAction` directly while leaving `DoAction` as the public validating, atomic API.
- Add a deterministic MCTS regression that proves expansion uses the known-legal path instead of the validating fallback.

## Root Cause

MCTS child expansion already operates on actions produced by `getLegalActions`, but the `GameState` MCTS adapter routed those actions back through `DoAction`. That regenerated legal actions, searched for the action, cloned again, then executed. The new path keeps validation on public submissions and avoids that redundant work for search-internal known-legal actions.

## Tests

- Red test observed before implementation: `..\x64\Debug\AdvanceWarsServer.exe -test-mcts` failed with `MCTS expansion should use the known-legal apply path`.
- `MSBuild AdvanceWarsServer.sln /p:Configuration=Debug /p:Platform=x64 /p:LIBTORCH_ROOT=... /m /v:minimal /clp:ErrorsOnly`
- `..\x64\Debug\AdvanceWarsServer.exe -test-mcts`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test-replay`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `MSBuild AdvanceWarsServer.sln /p:Configuration=Release /p:Platform=x64 /p:LIBTORCH_ROOT=... /p:UseLibtorchCuda=true /p:CUDA_PATH=... /p:CUDNN_LIB_PATH=... /p:NVTOOLSEXT_PATH=... /m /v:minimal /clp:ErrorsOnly`
- `..\x64\Release\AdvanceWarsServer.exe -test-model --device cuda`

## Benchmark

Comparable local CUDA Release command shape:

```powershell
..\x64\Release\AdvanceWarsServer.exe -self-play --out ..\artifacts\replays\issue-194-benchmark-800-total-sims-run-N.jsonl --map lefty --player0-co andy --player1-co adder --mcts-mode neural-puct --policy-value-checkpoint ..\artifacts\checkpoints\issue-194-benchmark --device cuda --games 1 --max-actions 100 --mcts-simulations 8 --quiet
```

Issue baseline: 100 actions, 800 simulations, 8792.4138ms total MCTS search, 45,385 nodes.

Post-change three-run sample: 100 actions, 800 simulations, 48,401 nodes each run.

- Run 1: 8756.2933ms total MCTS search
- Run 2: 8812.0464ms total MCTS search
- Run 3: 8902.3588ms total MCTS search

The run handles about 6.6% more nodes than the issue baseline with roughly flat total search time in this local sample, reducing approximate search time per created node from ~0.194ms to ~0.182ms on the median run.

## Risk

Low behavioral risk: public/API action submission still goes through `DoAction`; the new direct execution path is only selected by MCTS when the state type explicitly exposes `applyKnownLegalAction`.

Closes #194