### PR TITLE
Optimize MCTS legal action generation

### DIFF
--- a/AdvanceWarsServer/inc/GameState.h
+++ b/AdvanceWarsServer/inc/GameState.h
@@ -190,9 +190,14 @@ public:
 		return m_fGameOver;
 	}
 
+	void getLegalActions(std::vector<Action>& vecActions) const noexcept {
+		vecActions.clear();
+		GetValidActions(vecActions);
+	}
+
 	std::vector<Action> getLegalActions() const {
 		std::vector<Action> vecActions;
-		GetValidActions(vecActions);
+		getLegalActions(vecActions);
 		return vecActions;
 	}
 

--- a/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
+++ b/AdvanceWarsServer/inc/MonteCarloTreeSearch.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -47,10 +49,13 @@ struct MCTSSearchResult {
 	std::vector<MCTSActionStats<ActionType>> rootActionStats;
 	int simulationsRun{ 0 };
 	int nodesCreated{ 0 };
+	int legalActionGenerationCalls{ 0 };
+	double legalActionGenerationTimeMs{ 0.0 };
 };
 
 // StateType must provide:
 // - std::vector<ActionType> getLegalActions() const
+// - optional void/result getLegalActions(std::vector<ActionType>&) const for caller-owned action storage
 // - StateType applyAction(const ActionType&) const
 // - optional StateType applyKnownLegalAction(const ActionType&) for known-legal MCTS actions
 // - bool isTerminal() const
@@ -67,6 +72,17 @@ struct HasKnownLegalApply<
 	StateType,
 	ActionType,
 	std::void_t<decltype(std::declval<StateType&>().applyKnownLegalAction(std::declval<const ActionType&>()))>> : std::true_type {
+};
+
+template <typename StateType, typename ActionType, typename = void>
+struct HasFillLegalActions : std::false_type {
+};
+
+template <typename StateType, typename ActionType>
+struct HasFillLegalActions<
+	StateType,
+	ActionType,
+	std::void_t<decltype(std::declval<const StateType&>().getLegalActions(std::declval<std::vector<ActionType>&>()))>> : std::true_type {
 };
 
 template <typename StateType, typename ActionType>
@@ -88,11 +104,12 @@ public:
 		SearchContext context{ std::max(1, options.maxNodes), 1 };
 
 		Node root(rootState, std::nullopt, nullptr);
+		InitializeNode(root, context, true);
 		MCTSSearchResult<ActionType> result;
-		result.nodesCreated = context.nodesCreated;
 
 		if (root.state.isTerminal() || root.legalActions.empty()) {
 			result.rootActionStats = BuildRootActionStats(root);
+			FinalizeSearchResult(result, context);
 			return result;
 		}
 
@@ -102,21 +119,21 @@ public:
 			Node* simulationStart = selected;
 
 			if (!selected->state.isTerminal() &&
-				!selected->unexpandedActions.empty() &&
+				!selected->unexpandedActionIndices.empty() &&
 				context.nodesCreated < context.maxNodes) {
-				simulationStart = ExpandOne(*selected, rng);
+				simulationStart = ExpandOne(*selected, context, rng);
 				++context.nodesCreated;
 			}
 
 			bool reachedTerminal = false;
-			StateType rolloutState = Rollout(simulationStart->state, std::max(0, options.maxRolloutActions), rng, reachedTerminal);
+			StateType rolloutState = Rollout(simulationStart->state, std::max(0, options.maxRolloutActions), context, rng, reachedTerminal);
 			Backpropagate(simulationStart, rolloutState, reachedTerminal);
 			++result.simulationsRun;
 		}
 
-		result.nodesCreated = context.nodesCreated;
 		result.rootActionStats = BuildRootActionStats(root);
 		result.selectedAction = SelectAction(result.rootActionStats, options.temperature, rng);
+		FinalizeSearchResult(result, context);
 		return result;
 	}
 
@@ -126,11 +143,12 @@ public:
 		SearchContext context{ std::max(1, options.maxNodes), 1 };
 
 		Node root(rootState, std::nullopt, nullptr);
+		InitializeNode(root, context, false);
 		MCTSSearchResult<ActionType> result;
-		result.nodesCreated = context.nodesCreated;
 
 		if (root.state.isTerminal() || root.legalActions.empty()) {
 			result.rootActionStats = BuildRootActionStats(root);
+			FinalizeSearchResult(result, context);
 			return result;
 		}
 
@@ -155,13 +173,20 @@ public:
 			++result.simulationsRun;
 		}
 
-		result.nodesCreated = context.nodesCreated;
 		result.rootActionStats = BuildRootActionStats(root);
 		result.selectedAction = SelectAction(result.rootActionStats, options.temperature, rng);
+		FinalizeSearchResult(result, context);
 		return result;
 	}
 
 private:
+	struct SearchContext {
+		int maxNodes{ 1 };
+		int nodesCreated{ 1 };
+		int legalActionGenerationCalls{ 0 };
+		double legalActionGenerationTimeMs{ 0.0 };
+	};
+
 	struct Node {
 		StateType state;
 		std::optional<ActionType> action;
@@ -169,35 +194,69 @@ private:
 		double prior{ 0.0 };
 		std::vector<ActionType> legalActions;
 		std::vector<double> legalActionPriors;
-		std::vector<ActionType> unexpandedActions;
+		std::vector<std::size_t> unexpandedActionIndices;
 		std::vector<std::unique_ptr<Node>> children;
 		int visits{ 0 };
 		double totalValue{ 0.0 };
+		bool legalActionsLoaded{ false };
 		bool neuralExpanded{ false };
 		double evaluatedValue{ 0.0 };
 
-		Node(const StateType& state, std::optional<ActionType> action, Node* parent, double prior = 0.0) :
-			state(state),
+		Node(StateType state, std::optional<ActionType> action, Node* parent, double prior = 0.0) :
+			state(std::move(state)),
 			action(std::move(action)),
 			parent(parent),
 			prior(prior) {
-			if (!this->state.isTerminal()) {
-				legalActions = this->state.getLegalActions();
-				legalActionPriors.assign(legalActions.size(), 0.0);
-				unexpandedActions = legalActions;
-			}
 		}
 	};
 
-	struct SearchContext {
-		int maxNodes{ 1 };
-		int nodesCreated{ 1 };
-	};
+	void LoadLegalActions(const StateType& state, std::vector<ActionType>& legalActions, SearchContext& context) const {
+		const auto start = std::chrono::steady_clock::now();
+		legalActions.clear();
+		if constexpr (MctsDetail::HasFillLegalActions<StateType, ActionType>::value) {
+			state.getLegalActions(legalActions);
+		}
+		else {
+			legalActions = state.getLegalActions();
+		}
+		const auto end = std::chrono::steady_clock::now();
+		++context.legalActionGenerationCalls;
+		context.legalActionGenerationTimeMs += std::chrono::duration<double, std::milli>(end - start).count();
+	}
+
+	void InitializeNode(Node& node, SearchContext& context, bool trackUnexpandedActions) const {
+		if (node.legalActionsLoaded) {
+			return;
+		}
+
+		if (node.state.isTerminal()) {
+			node.legalActionsLoaded = true;
+			return;
+		}
+
+		LoadLegalActions(node.state, node.legalActions, context);
+		node.legalActionsLoaded = true;
+		if (!trackUnexpandedActions) {
+			return;
+		}
+
+		node.unexpandedActionIndices.clear();
+		node.unexpandedActionIndices.reserve(node.legalActions.size());
+		for (std::size_t i = 0; i < node.legalActions.size(); ++i) {
+			node.unexpandedActionIndices.push_back(i);
+		}
+	}
+
+	void FinalizeSearchResult(MCTSSearchResult<ActionType>& result, const SearchContext& context) const {
+		result.nodesCreated = context.nodesCreated;
+		result.legalActionGenerationCalls = context.legalActionGenerationCalls;
+		result.legalActionGenerationTimeMs = context.legalActionGenerationTimeMs;
+	}
 
 	Node* Select(Node& root, double explorationConstant, bool canExpand) {
 		Node* node = &root;
 		while (!node->state.isTerminal()) {
-			if (!node->unexpandedActions.empty() && (canExpand || node->children.empty())) {
+			if (!node->unexpandedActionIndices.empty() && (canExpand || node->children.empty())) {
 				return node;
 			}
 
@@ -211,14 +270,18 @@ private:
 		return node;
 	}
 
-	Node* ExpandOne(Node& node, std::mt19937& rng) {
-		std::uniform_int_distribution<int> distribution(0, static_cast<int>(node.unexpandedActions.size() - 1));
-		const int actionIndex = distribution(rng);
-		ActionType action = node.unexpandedActions[static_cast<std::size_t>(actionIndex)];
-		node.unexpandedActions.erase(node.unexpandedActions.begin() + actionIndex);
+	Node* ExpandOne(Node& node, SearchContext& context, std::mt19937& rng) {
+		std::uniform_int_distribution<int> distribution(0, static_cast<int>(node.unexpandedActionIndices.size() - 1));
+		const std::size_t unexpandedIndex = static_cast<std::size_t>(distribution(rng));
+		const std::size_t actionIndex = node.unexpandedActionIndices[unexpandedIndex];
+		node.unexpandedActionIndices[unexpandedIndex] = node.unexpandedActionIndices.back();
+		node.unexpandedActionIndices.pop_back();
 
+		const ActionType& action = node.legalActions[actionIndex];
 		StateType newState = MctsDetail::ApplyKnownLegalAction(node.state, action);
-		node.children.push_back(std::make_unique<Node>(newState, action, &node));
+		auto child = std::make_unique<Node>(std::move(newState), action, &node);
+		InitializeNode(*child, context, true);
+		node.children.push_back(std::move(child));
 		return node.children.back().get();
 	}
 
@@ -231,6 +294,7 @@ private:
 			return;
 		}
 
+		InitializeNode(node, context, false);
 		if (node.legalActions.empty()) {
 			value = 0.0;
 			node.evaluatedValue = value;
@@ -244,20 +308,25 @@ private:
 		node.legalActionPriors = NormalizePriors(node.legalActions, evaluation.actionPriors);
 		node.neuralExpanded = true;
 
+		const int remainingNodes = context.maxNodes - context.nodesCreated;
+		if (remainingNodes > 0) {
+			const std::size_t childCapacity = std::min(node.legalActions.size(), static_cast<std::size_t>(remainingNodes));
+			node.children.reserve(node.children.size() + childCapacity);
+		}
+
 		for (std::size_t i = 0; i < node.legalActions.size() && context.nodesCreated < context.maxNodes; ++i) {
-			if (FindChild(node, node.legalActions[i]) != nullptr) {
-				continue;
-			}
 			StateType newState = MctsDetail::ApplyKnownLegalAction(node.state, node.legalActions[i]);
-			node.children.push_back(std::make_unique<Node>(newState, node.legalActions[i], &node, node.legalActionPriors[i]));
+			auto child = std::make_unique<Node>(std::move(newState), node.legalActions[i], &node, node.legalActionPriors[i]);
+			node.children.push_back(std::move(child));
 			++context.nodesCreated;
 		}
 	}
 
-	StateType Rollout(const StateType& startState, int maxRolloutActions, std::mt19937& rng, bool& reachedTerminal) {
+	StateType Rollout(const StateType& startState, int maxRolloutActions, SearchContext& context, std::mt19937& rng, bool& reachedTerminal) {
 		StateType state(startState);
+		std::vector<ActionType> actions;
 		for (int i = 0; i < maxRolloutActions && !state.isTerminal(); ++i) {
-			std::vector<ActionType> actions = state.getLegalActions();
+			LoadLegalActions(state, actions, context);
 			if (actions.empty()) {
 				break;
 			}
@@ -348,8 +417,7 @@ private:
 
 		for (std::size_t i = 0; i < root.legalActions.size(); ++i) {
 			const ActionType& action = root.legalActions[i];
-			MCTSActionStats<ActionType> actionStats;
-			actionStats.action = action;
+			MCTSActionStats<ActionType> actionStats{ action };
 			if (i < root.legalActionPriors.size()) {
 				actionStats.prior = root.legalActionPriors[i];
 			}
@@ -365,7 +433,7 @@ private:
 				actionStats.averageValue = actionStats.visits == 0 ? 0.0 : actionStats.totalValue / actionStats.visits;
 			}
 
-			stats.push_back(actionStats);
+			stats.push_back(std::move(actionStats));
 		}
 
 		return stats;

--- a/AdvanceWarsServer/src/MctsTest.cpp
+++ b/AdvanceWarsServer/src/MctsTest.cpp
@@ -29,6 +29,7 @@ struct TestNodeDef {
 
 struct TestGraph {
 	std::vector<TestNodeDef> nodes;
+	mutable int legalActionCalls{ 0 };
 	mutable int applyActionCalls{ 0 };
 	mutable int applyKnownLegalActionCalls{ 0 };
 };
@@ -41,6 +42,7 @@ public:
 	}
 
 	std::vector<TestAction> getLegalActions() const {
+		++m_graph->legalActionCalls;
 		const TestNodeDef& node = GetNode();
 		if (node.winner.has_value()) {
 			return {};
@@ -84,6 +86,10 @@ public:
 		return m_graph->applyKnownLegalActionCalls;
 	}
 
+	int getLegalActionCalls() const {
+		return m_graph->legalActionCalls;
+	}
+
 private:
 	const TestNodeDef& GetNode() const {
 		return m_graph->nodes.at(static_cast<std::size_t>(m_nodeId));
@@ -101,6 +107,75 @@ private:
 
 	std::shared_ptr<const TestGraph> m_graph;
 	int m_nodeId{ 0 };
+};
+
+struct CopyCountingAction {
+	int id{ 0 };
+
+	CopyCountingAction() = default;
+	explicit CopyCountingAction(int id) : id(id) {}
+	CopyCountingAction(const CopyCountingAction& other) : id(other.id) {
+		++s_copies;
+	}
+	CopyCountingAction& operator=(const CopyCountingAction& other) {
+		id = other.id;
+		++s_copies;
+		return *this;
+	}
+	CopyCountingAction(CopyCountingAction&& other) noexcept = default;
+	CopyCountingAction& operator=(CopyCountingAction&& other) noexcept = default;
+
+	bool operator==(const CopyCountingAction& other) const noexcept {
+		return id == other.id;
+	}
+
+	static void ResetCopies() {
+		s_copies = 0;
+	}
+
+	static int Copies() {
+		return s_copies;
+	}
+
+private:
+	static int s_copies;
+};
+
+int CopyCountingAction::s_copies = 0;
+
+class CopyCountingState {
+public:
+	CopyCountingState(std::shared_ptr<const std::vector<CopyCountingAction>> legalActions) :
+		m_legalActions(std::move(legalActions)) {
+	}
+
+	void getLegalActions(std::vector<CopyCountingAction>& legalActions) const {
+		legalActions.clear();
+		legalActions.insert(legalActions.end(), m_legalActions->begin(), m_legalActions->end());
+	}
+
+	std::vector<CopyCountingAction> getLegalActions() const {
+		return *m_legalActions;
+	}
+
+	CopyCountingState applyAction(const CopyCountingAction&) const {
+		return CopyCountingState(std::make_shared<std::vector<CopyCountingAction>>());
+	}
+
+	bool isTerminal() const {
+		return false;
+	}
+
+	int getCurrentPlayer() const {
+		return 0;
+	}
+
+	double evaluate(int) const {
+		return 0.0;
+	}
+
+private:
+	std::shared_ptr<const std::vector<CopyCountingAction>> m_legalActions;
 };
 
 TestState MakeState(std::vector<TestNodeDef> nodes, int nodeId = 0) {
@@ -234,6 +309,41 @@ bool TestSearchExpansionUsesKnownLegalApplyPath() {
 	return Expect(result.nodesCreated == 2, "test setup should create one expanded child") &&
 		Expect(root.getApplyKnownLegalActionCalls() == 1, "MCTS expansion should use the known-legal apply path") &&
 		Expect(root.getApplyActionCalls() == 0, "MCTS expansion should not use the validating apply path for known-legal actions");
+}
+
+bool TestSearchReportsLegalActionGenerationTelemetry() {
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 1;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 0;
+	options.temperature = 0.0;
+	options.seed = 7;
+
+	MCTSSearchResult<TestAction> result = mcts.search(MakeThreeTerminalActionState(), options);
+
+	return Expect(result.legalActionGenerationCalls == 1, "search should count legal-action generation calls") &&
+		Expect(result.legalActionGenerationTimeMs >= 0.0, "search should report nonnegative legal-action generation time");
+}
+
+bool TestSearchDoesNotCopyLegalActionsIntoUnexpandedActions() {
+	std::vector<CopyCountingAction> legalActions;
+	for (int i = 0; i < 8; ++i) {
+		legalActions.emplace_back(i);
+	}
+	CopyCountingState root(std::make_shared<std::vector<CopyCountingAction>>(std::move(legalActions)));
+
+	MCTS<CopyCountingState, CopyCountingAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 0;
+	options.temperature = 0.0;
+
+	CopyCountingAction::ResetCopies();
+	MCTSSearchResult<CopyCountingAction> result = mcts.search(root, options);
+	const int actionCount = static_cast<int>(result.rootActionStats.size());
+
+	return Expect(actionCount == 8, "test setup should expose all root legal actions") &&
+		Expect(CopyCountingAction::Copies() <= actionCount * 2 + 1, "MCTS should not copy each root action into both stats and a separate unexpanded action list");
 }
 
 bool TestSeededSearchIsReproducible() {
@@ -476,12 +586,37 @@ bool TestNeuralSearchBacksUpLeafValueWithoutRollout() {
 		Expect(VisitsFor(result, 2) == 0, "unvisited neural root actions should remain in stats with zero visits") &&
 		Expect(SelectedActionIs(result, 1), "temperature zero should select the visited neural action");
 }
+
+bool TestNeuralSearchLoadsChildLegalActionsLazily() {
+	TestState root = MakeState({
+		{ 0, std::nullopt, { { 1 }, { 2 } }, { { { 1 }, 1 }, { { 2 }, 2 } } },
+		{ 0, std::nullopt, { { 11 } }, { { { 11 }, 3 } } },
+		{ 0, std::nullopt, { { 21 } }, { { { 21 }, 4 } } },
+		{ 0, 1, {}, {} },
+		{ 0, 0, {}, {} },
+	});
+
+	MCTS<TestState, TestAction> mcts;
+	MCTSOptions options;
+	options.maxSimulations = 1;
+	options.maxNodes = 10;
+	options.maxRolloutActions = 0;
+	options.temperature = 0.0;
+
+	LeafValueEvaluator evaluator;
+	MCTSSearchResult<TestAction> result = mcts.searchNeural(root, evaluator, options);
+
+	return Expect(result.legalActionGenerationCalls == 2, "neural search should load legal actions for the root and selected leaf only") &&
+		Expect(root.getLegalActionCalls() == 2, "unvisited neural children should not generate legal actions during node creation");
+}
 }
 
 int RunMctsTests() {
 	bool passed = true;
 	passed = TestOneActionExpansionAndRootStats() && passed;
 	passed = TestSearchExpansionUsesKnownLegalApplyPath() && passed;
+	passed = TestSearchReportsLegalActionGenerationTelemetry() && passed;
+	passed = TestSearchDoesNotCopyLegalActionsIntoUnexpandedActions() && passed;
 	passed = TestSeededSearchIsReproducible() && passed;
 	passed = TestPlayerPerspectiveBackupHandlesSamePlayerAndSwitches() && passed;
 	passed = TestRolloutCutoffBacksUpZero() && passed;
@@ -491,6 +626,7 @@ int RunMctsTests() {
 	passed = TestTemperatureZeroTieAndPositiveTemperatureSampling() && passed;
 	passed = TestNeuralSearchUsesPuctPriorsForRootVisits() && passed;
 	passed = TestNeuralSearchBacksUpLeafValueWithoutRollout() && passed;
+	passed = TestNeuralSearchLoadsChildLegalActionsLazily() && passed;
 
 	if (!passed) {
 		return 1;

--- a/AdvanceWarsServer/src/SelfPlayReplay.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplay.cpp
@@ -237,8 +237,16 @@ bool IsNonnegativeNumber(const json& value) {
 		(value.is_number_float() && value.get<double>() >= 0.0);
 }
 
-Result ValidateMctsBlock(const json& mcts, int& simulationsRun, int& nodesCreated, double& searchTimeMs, SelfPlayError& error, int line, int gameIndex, int ply) {
-	IfFailedReturn(RequireObjectWithFields(mcts, { "mctsSeed", "simulationsRun", "nodesCreated", "searchTimeMs" }, "sample.mcts", error, line, gameIndex, ply));
+Result ValidateMctsBlock(const json& mcts, int& simulationsRun, int& nodesCreated, double& searchTimeMs, int& legalActionGenerationCalls, double& legalActionGenerationTimeMs, SelfPlayError& error, int line, int gameIndex, int ply) {
+	IfFailedReturn(RequireObjectWithRequiredAndOptionalFields(
+		mcts,
+		{ "mctsSeed", "simulationsRun", "nodesCreated", "searchTimeMs" },
+		{ "legalActionGenerationCalls", "legalActionGenerationTimeMs" },
+		"sample.mcts",
+		error,
+		line,
+		gameIndex,
+		ply));
 	if (!mcts.at("mctsSeed").is_number_unsigned() && !mcts.at("mctsSeed").is_number_integer()) {
 		SetError(error, "schema-error", "mctsSeed must be an integer", line, gameIndex, ply);
 		return Result::Failed;
@@ -255,10 +263,21 @@ Result ValidateMctsBlock(const json& mcts, int& simulationsRun, int& nodesCreate
 		SetError(error, "schema-error", "searchTimeMs must be nonnegative", line, gameIndex, ply);
 		return Result::Failed;
 	}
+	if (mcts.contains("legalActionGenerationCalls") &&
+		(!mcts.at("legalActionGenerationCalls").is_number_integer() || mcts.at("legalActionGenerationCalls").get<int>() < 0)) {
+		SetError(error, "schema-error", "legalActionGenerationCalls must be nonnegative", line, gameIndex, ply);
+		return Result::Failed;
+	}
+	if (mcts.contains("legalActionGenerationTimeMs") && !IsNonnegativeNumber(mcts.at("legalActionGenerationTimeMs"))) {
+		SetError(error, "schema-error", "legalActionGenerationTimeMs must be nonnegative", line, gameIndex, ply);
+		return Result::Failed;
+	}
 
 	simulationsRun = mcts.at("simulationsRun").get<int>();
 	nodesCreated = mcts.at("nodesCreated").get<int>();
 	searchTimeMs = mcts.at("searchTimeMs").get<double>();
+	legalActionGenerationCalls = mcts.contains("legalActionGenerationCalls") ? mcts.at("legalActionGenerationCalls").get<int>() : 0;
+	legalActionGenerationTimeMs = mcts.contains("legalActionGenerationTimeMs") ? mcts.at("legalActionGenerationTimeMs").get<double>() : 0.0;
 	return Result::Succeeded;
 }
 
@@ -325,9 +344,16 @@ int ExpectedOutcome(const json& winner, int currentPlayer) {
 	return winningPlayer == currentPlayer ? 1 : -1;
 }
 
-Result ValidateMetrics(const json& game, int actionCount, int sampleCount, int turnCount, double totalSearchTimeMs, double averageBranchingFactor, SelfPlayReplayValidationSummary& summary, SelfPlayError& error, int line, int gameIndex) {
+Result ValidateMetrics(const json& game, int actionCount, int sampleCount, int turnCount, double totalSearchTimeMs, int totalLegalActionGenerationCalls, double totalLegalActionGenerationTimeMs, double averageBranchingFactor, SelfPlayReplayValidationSummary& summary, SelfPlayError& error, int line, int gameIndex) {
 	const json& metrics = game.at("metrics");
-	IfFailedReturn(RequireObjectWithFields(metrics, { "actionCount", "sampleCount", "turnCount", "resignations", "invalidActionCount", "averageBranchingFactor", "totalSearchTimeMs", "averageSearchTimeMs", "totalElapsedMs" }, "metrics", error, line, gameIndex));
+	IfFailedReturn(RequireObjectWithRequiredAndOptionalFields(
+		metrics,
+		{ "actionCount", "sampleCount", "turnCount", "resignations", "invalidActionCount", "averageBranchingFactor", "totalSearchTimeMs", "averageSearchTimeMs", "totalElapsedMs" },
+		{ "totalLegalActionGenerationCalls", "totalLegalActionGenerationTimeMs", "averageLegalActionGenerationTimeMs" },
+		"metrics",
+		error,
+		line,
+		gameIndex));
 
 	if (!metrics.at("actionCount").is_number_integer() || metrics.at("actionCount").get<int>() != actionCount ||
 		!metrics.at("sampleCount").is_number_integer() || metrics.at("sampleCount").get<int>() != sampleCount ||
@@ -357,6 +383,32 @@ Result ValidateMetrics(const json& game, int actionCount, int sampleCount, int t
 	if (std::fabs(metrics.at("totalSearchTimeMs").get<double>() - totalSearchTimeMs) > kMetricTolerance) {
 		SetError(error, "metrics-mismatch", "totalSearchTimeMs does not match samples", line, gameIndex);
 		return Result::Failed;
+	}
+	const bool hasLegalActionMetrics =
+		metrics.contains("totalLegalActionGenerationCalls") ||
+		metrics.contains("totalLegalActionGenerationTimeMs") ||
+		metrics.contains("averageLegalActionGenerationTimeMs");
+	if (hasLegalActionMetrics) {
+		if (!metrics.contains("totalLegalActionGenerationCalls") ||
+			!metrics.contains("totalLegalActionGenerationTimeMs") ||
+			!metrics.contains("averageLegalActionGenerationTimeMs")) {
+			SetError(error, "schema-error", "legal-action generation metrics must be present together", line, gameIndex);
+			return Result::Failed;
+		}
+		if (!metrics.at("totalLegalActionGenerationCalls").is_number_integer() ||
+			metrics.at("totalLegalActionGenerationCalls").get<int>() < 0 ||
+			!IsNonnegativeNumber(metrics.at("totalLegalActionGenerationTimeMs")) ||
+			!IsNonnegativeNumber(metrics.at("averageLegalActionGenerationTimeMs"))) {
+			SetError(error, "schema-error", "legal-action generation metrics must be nonnegative", line, gameIndex);
+			return Result::Failed;
+		}
+		const double expectedAverage = totalLegalActionGenerationCalls == 0 ? 0.0 : totalLegalActionGenerationTimeMs / totalLegalActionGenerationCalls;
+		if (metrics.at("totalLegalActionGenerationCalls").get<int>() != totalLegalActionGenerationCalls ||
+			std::fabs(metrics.at("totalLegalActionGenerationTimeMs").get<double>() - totalLegalActionGenerationTimeMs) > kMetricTolerance ||
+			std::fabs(metrics.at("averageLegalActionGenerationTimeMs").get<double>() - expectedAverage) > kMetricTolerance) {
+			SetError(error, "metrics-mismatch", "legal-action generation metrics do not match samples", line, gameIndex);
+			return Result::Failed;
+		}
 	}
 
 	summary.invalidActions += metrics.at("invalidActionCount").get<int>();
@@ -443,6 +495,8 @@ Result ValidateGameRecord(const json& game, SelfPlayReplayValidationSummary& sum
 
 	int legalActionTotal = 0;
 	double totalSearchTimeMs = 0.0;
+	int totalLegalActionGenerationCalls = 0;
+	double totalLegalActionGenerationTimeMs = 0.0;
 	for (std::size_t i = 0; i < game.at("samples").size(); ++i) {
 		const int ply = static_cast<int>(i);
 		const json& actionEntry = game.at("actions").at(i);
@@ -509,9 +563,13 @@ Result ValidateGameRecord(const json& game, SelfPlayReplayValidationSummary& sum
 		int simulationsRun = 0;
 		int nodesCreated = 0;
 		double searchTimeMs = 0.0;
-		IfFailedReturn(ValidateMctsBlock(sample.at("mcts"), simulationsRun, nodesCreated, searchTimeMs, error, line, gameIndex, ply));
+		int legalActionGenerationCalls = 0;
+		double legalActionGenerationTimeMs = 0.0;
+		IfFailedReturn(ValidateMctsBlock(sample.at("mcts"), simulationsRun, nodesCreated, searchTimeMs, legalActionGenerationCalls, legalActionGenerationTimeMs, error, line, gameIndex, ply));
 		IfFailedReturn(ValidateVisitCounts(sample.at("visitCounts"), legalActionIndices, actionIndex, simulationsRun, error, line, gameIndex, ply));
 		totalSearchTimeMs += searchTimeMs;
+		totalLegalActionGenerationCalls += legalActionGenerationCalls;
+		totalLegalActionGenerationTimeMs += legalActionGenerationTimeMs;
 
 		if (!sample.at("outcome").is_number_integer() || sample.at("outcome").get<int>() != ExpectedOutcome(game.at("winner"), currentPlayer)) {
 			SetError(error, "outcome-mismatch", "sample outcome does not match winner/currentPlayer", line, gameIndex, ply);
@@ -557,7 +615,7 @@ Result ValidateGameRecord(const json& game, SelfPlayReplayValidationSummary& sum
 
 	const int sampleCount = static_cast<int>(game.at("samples").size());
 	const double averageBranchingFactor = sampleCount == 0 ? 0.0 : static_cast<double>(legalActionTotal) / sampleCount;
-	IfFailedReturn(ValidateMetrics(game, static_cast<int>(game.at("actions").size()), sampleCount, replayState.GetTurnCount(), totalSearchTimeMs, averageBranchingFactor, summary, error, line, gameIndex));
+	IfFailedReturn(ValidateMetrics(game, static_cast<int>(game.at("actions").size()), sampleCount, replayState.GetTurnCount(), totalSearchTimeMs, totalLegalActionGenerationCalls, totalLegalActionGenerationTimeMs, averageBranchingFactor, summary, error, line, gameIndex));
 
 	++summary.games;
 	summary.samples += sampleCount;

--- a/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
@@ -153,6 +153,15 @@ bool GeneratedReplayValidatesAndUsesSparseSamples() {
 	if (!Expect(!game.at("samples")[0].contains("legalActionMask"), "sample should not store a dense legal action mask")) {
 		return false;
 	}
+	if (!Expect(game.at("samples")[0].at("mcts").at("legalActionGenerationCalls").get<int>() > 0, "sample should report MCTS legal-action generation calls")) {
+		return false;
+	}
+	if (!Expect(game.at("samples")[0].at("mcts").at("legalActionGenerationTimeMs").get<double>() >= 0.0, "sample should report nonnegative MCTS legal-action generation time")) {
+		return false;
+	}
+	if (!Expect(game.at("metrics").at("totalLegalActionGenerationCalls").get<int>() > 0, "metrics should aggregate legal-action generation calls")) {
+		return false;
+	}
 
 	std::filesystem::remove(replayPath);
 	return true;
@@ -227,10 +236,13 @@ bool GeneratedNeuralReplayUsesPolicyValueEvaluator() {
 
 	const json header = ReadJsonLine(replayPath, 1);
 	const json game = ReadJsonLine(replayPath, 2);
+	const json& mcts = game.at("samples")[0].at("mcts");
 	const bool passed =
 		Expect(header.at("config").at("mctsMode") == "neural-puct", "header should record neural MCTS mode") &&
 		Expect(game.at("config").at("mctsMode") == "neural-puct", "game config should record neural MCTS mode") &&
-		Expect(game.at("samples")[0].at("mcts").at("simulationsRun") == 2, "neural sample should record requested simulations") &&
+		Expect(mcts.at("simulationsRun") == 2, "neural sample should record requested simulations") &&
+		Expect(mcts.at("legalActionGenerationCalls").get<int>() > 0, "neural sample should report MCTS legal-action generation calls") &&
+		Expect(mcts.at("legalActionGenerationTimeMs").get<double>() >= 0.0, "neural sample should report MCTS legal-action generation time") &&
 		Expect(runSummary.samplesWritten == 1, "neural smoke run should write one sample");
 
 	std::filesystem::remove(replayPath);

--- a/AdvanceWarsServer/src/SelfPlayRunner.cpp
+++ b/AdvanceWarsServer/src/SelfPlayRunner.cpp
@@ -377,6 +377,8 @@ Result BuildGameRecord(const SelfPlayRunnerOptions& options, SelfPlayRuntime& ru
 	int invalidActionCount = 0;
 	int legalActionTotal = 0;
 	double totalSearchTimeMs = 0.0;
+	int totalLegalActionGenerationCalls = 0;
+	double totalLegalActionGenerationTimeMs = 0.0;
 
 	const auto gameStart = std::chrono::steady_clock::now();
 	for (int ply = 0; ply < options.maxActions && !gameState.FGameOver(); ++ply) {
@@ -421,6 +423,8 @@ Result BuildGameRecord(const SelfPlayRunnerOptions& options, SelfPlayRuntime& ru
 		const auto searchEnd = std::chrono::steady_clock::now();
 		const double searchTimeMs = std::chrono::duration<double, std::milli>(searchEnd - searchStart).count();
 		totalSearchTimeMs += searchTimeMs;
+		totalLegalActionGenerationCalls += searchResult.legalActionGenerationCalls;
+		totalLegalActionGenerationTimeMs += searchResult.legalActionGenerationTimeMs;
 
 		if (!searchResult.selectedAction.has_value()) {
 			SetError(error, "mcts-no-action", "MCTS did not select an action", gameIndex, ply);
@@ -466,6 +470,8 @@ Result BuildGameRecord(const SelfPlayRunnerOptions& options, SelfPlayRuntime& ru
 				{ "simulationsRun", searchResult.simulationsRun },
 				{ "nodesCreated", searchResult.nodesCreated },
 				{ "searchTimeMs", searchTimeMs },
+				{ "legalActionGenerationCalls", searchResult.legalActionGenerationCalls },
+				{ "legalActionGenerationTimeMs", searchResult.legalActionGenerationTimeMs },
 			} },
 		});
 
@@ -499,6 +505,7 @@ Result BuildGameRecord(const SelfPlayRunnerOptions& options, SelfPlayRuntime& ru
 	const int sampleCount = static_cast<int>(samples.size());
 	const double averageBranchingFactor = sampleCount == 0 ? 0.0 : static_cast<double>(legalActionTotal) / sampleCount;
 	const double averageSearchTimeMs = sampleCount == 0 ? 0.0 : totalSearchTimeMs / sampleCount;
+	const double averageLegalActionGenerationTimeMs = totalLegalActionGenerationCalls == 0 ? 0.0 : totalLegalActionGenerationTimeMs / totalLegalActionGenerationCalls;
 	const int resignations = terminalReason.is_string() && terminalReason.get<std::string>() == "heuristic-resign" ? 1 : 0;
 
 	gameRecord = {
@@ -524,6 +531,9 @@ Result BuildGameRecord(const SelfPlayRunnerOptions& options, SelfPlayRuntime& ru
 			{ "averageBranchingFactor", averageBranchingFactor },
 			{ "totalSearchTimeMs", totalSearchTimeMs },
 			{ "averageSearchTimeMs", averageSearchTimeMs },
+			{ "totalLegalActionGenerationCalls", totalLegalActionGenerationCalls },
+			{ "totalLegalActionGenerationTimeMs", totalLegalActionGenerationTimeMs },
+			{ "averageLegalActionGenerationTimeMs", averageLegalActionGenerationTimeMs },
 			{ "totalElapsedMs", totalElapsedMs },
 		} },
 	};
@@ -719,6 +729,8 @@ Result RunSelfPlay(const SelfPlayRunnerOptions& options, SelfPlayRunSummary& sum
 				" winner=" << gameRecord.at("winner").dump() <<
 				" actions=" << gameRecord.at("metrics").at("actionCount") <<
 				" samples=" << gameRecord.at("metrics").at("sampleCount") <<
+				" searchMs=" << gameRecord.at("metrics").at("totalSearchTimeMs") <<
+				" legalActionMs=" << gameRecord.at("metrics").at("totalLegalActionGenerationTimeMs") <<
 				" elapsedMs=" << gameRecord.at("metrics").at("totalElapsedMs") <<
 				" out=" << options.outputPath.string() << std::endl;
 		}

--- a/docs/SELF_PLAY_REPLAYS.md
+++ b/docs/SELF_PLAY_REPLAYS.md
@@ -194,7 +194,9 @@ Samples contain compact training targets:
     "mctsSeed": 3992670690,
     "simulationsRun": 128,
     "nodesCreated": 128,
-    "searchTimeMs": 14.7
+    "searchTimeMs": 14.7,
+    "legalActionGenerationCalls": 129,
+    "legalActionGenerationTimeMs": 4.2
   }
 }
 ```
@@ -202,6 +204,8 @@ Samples contain compact training targets:
 Replay v1 does not store dense state tensors or dense legal action masks. Validation rebuilds the state from `initialState` plus `actions[0..ply)`, regenerates the tensor checksum and sparse legal action indices, and compares them exactly.
 
 `visitCounts` stores positive visits only, sorted by `actionIndex`. Legal actions with zero visits are implied by `legalActionIndices`.
+
+Each sample's `mcts` block records total search wall time plus legal-action generation calls/time observed inside MCTS. The game-level `metrics` block also aggregates `totalLegalActionGenerationCalls`, `totalLegalActionGenerationTimeMs`, and `averageLegalActionGenerationTimeMs` so self-play runs can be used as focused legal-action generation perf reports.
 
 In `neural-puct` mode, the runner gathers model policy logits only at the sparse legal action indices, normalizes those legal logits into priors, uses PUCT for tree selection, and backs up the value head at expanded leaves. The replay target format is unchanged: training still consumes sparse positive visit counts over legal action indices.
 


### PR DESCRIPTION
## Summary

- Add MCTS legal-action generation telemetry to `MCTSSearchResult` and self-play replay records.
- Let states fill MCTS-owned legal-action vectors directly, with `GameState` exposing a caller-owned `getLegalActions` overload.
- Replace copied `unexpandedActions` with unexpanded action indices, avoid rollout vector reallocation, and lazy-load neural child legal actions only when a child is evaluated.
- Document the new replay perf metrics and keep replay validation backward-compatible for older shards without these fields.

## Root Cause

MCTS node construction eagerly generated and copied legal-action vectors for every non-terminal node. Neural PUCT also loaded legal actions for all newly expanded children immediately, including children that might never be selected/evaluated.

## Tests

Red checks observed before implementation:

- `MSBuild ...` failed on the new `MCTSSearchResult::legalActionGeneration*` assertions before telemetry existed.
- `-test-mcts` failed on `neural search should load legal actions for the root and selected leaf only` before lazy neural child loading.

Passing verification:

- `MSBuild.exe AdvanceWarsServer.sln /m /p:Configuration=Debug /p:Platform=x64 /v:minimal` with `LIBTORCH_ROOT=D:\Projects\libtorch-win-shared-with-deps-2.6.0+cu118\libtorch`
- `..\x64\Debug\AdvanceWarsServer.exe -test-mcts`
- `..\x64\Debug\AdvanceWarsServer.exe -test-replay`
- `..\x64\Debug\AdvanceWarsServer.exe -test test/json`
- `..\x64\Debug\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Debug\AdvanceWarsServer.exe -test-train`
- `..\x64\Debug\AdvanceWarsServer.exe -self-play --out $env:TEMP\advance-wars-issue193-smoke-final.jsonl --map mcts --player0-co andy --player1-co adder --games 1 --max-actions 2 --seed 17 --mcts-simulations 1 --mcts-max-nodes 16 --mcts-max-rollout-actions 4 --temperature 0`
  - Reported: `searchMs=1.7797 legalActionMs=0.9849`, then replay validation passed.
- `git diff --check`

## Residual Risk

This intentionally avoids the broader unit-cache refactor from #51. It reduces MCTS-side allocation/copying and unnecessary neural child legal-action generation, while leaving `GameState::GetValidActions`' full-board scan semantics unchanged.

Closes #193