### PR TITLE
[codex] Add curriculum maps and replay file picker

### DIFF
--- a/AdvanceWarsServer/res/AWBW/MapSources/SmallCapture7x7.json
+++ b/AdvanceWarsServer/res/AWBW/MapSources/SmallCapture7x7.json
@@ -1,0 +1,220 @@
+{
+  "activePlayer": 0,
+  "cap-limit": 21,
+  "game-over": false,
+  "gameId": "small-capture-7x7",
+  "map": [
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 42,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "orange-star",
+          "type": "infantry"
+        }
+      },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 38
+      },
+      { "terrain": 1 },
+      { "terrain": 3 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 1 }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      { "terrain": 3 },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 1 }
+    ],
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 38
+      },
+      {
+        "terrain": 1,
+        "unit": {
+          "ammo": 3,
+          "fuel": 70,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "orange-star",
+          "type": "mech"
+        }
+      },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 2 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 1 },
+      { "terrain": 3 }
+    ],
+    [
+      { "terrain": 3 },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      { "terrain": 3 }
+    ],
+    [
+      { "terrain": 3 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 2 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      {
+        "terrain": 1,
+        "unit": {
+          "ammo": 3,
+          "fuel": 70,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "blue-moon",
+          "type": "mech"
+        }
+      },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 43
+      }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      { "terrain": 3 },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 1 }
+    ],
+    [
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 3 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 43
+      },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 47,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "blue-moon",
+          "type": "infantry"
+        }
+      }
+    ]
+  ],
+  "players": [
+    {
+      "armyType": "orange-star",
+      "co": "Andy",
+      "funds": 0,
+      "luck-policy": 1,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 3,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    },
+    {
+      "armyType": "blue-moon",
+      "co": "Adder",
+      "funds": 0,
+      "luck-policy": 2,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 2,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    }
+  ],
+  "turn-count": 1,
+  "unit-cap": 50,
+  "winner": -1
+}

--- a/AdvanceWarsServer/res/AWBW/MapSources/SmallProduction7x7.json
+++ b/AdvanceWarsServer/res/AWBW/MapSources/SmallProduction7x7.json
@@ -1,0 +1,220 @@
+{
+  "activePlayer": 0,
+  "cap-limit": 21,
+  "game-over": false,
+  "gameId": "small-production-7x7",
+  "map": [
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 42
+      },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 38
+      },
+      { "terrain": 1 },
+      { "terrain": 3 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 1 }
+    ],
+    [
+      { "terrain": 16 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 39
+      },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 15 },
+      { "terrain": 1 }
+    ],
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 38
+      },
+      {
+        "terrain": 1,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "orange-star",
+          "type": "infantry"
+        }
+      },
+      { "terrain": 3 },
+      { "terrain": 15 },
+      { "terrain": 3 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 15 },
+      { "terrain": 1 }
+    ],
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 1 },
+      { "terrain": 3 },
+      { "terrain": 15 },
+      { "terrain": 3 },
+      {
+        "terrain": 1,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "blue-moon",
+          "type": "infantry"
+        }
+      },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 43
+      }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 44
+      },
+      { "terrain": 16 }
+    ],
+    [
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 3 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 43
+      },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 47
+      }
+    ]
+  ],
+  "players": [
+    {
+      "armyType": "orange-star",
+      "co": "Andy",
+      "funds": 0,
+      "luck-policy": 1,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 3,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    },
+    {
+      "armyType": "blue-moon",
+      "co": "Adder",
+      "funds": 0,
+      "luck-policy": 2,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 2,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    }
+  ],
+  "turn-count": 1,
+  "unit-cap": 50,
+  "winner": -1
+}

--- a/AdvanceWarsServer/res/AWBW/MapSources/TinyCapture5x5.json
+++ b/AdvanceWarsServer/res/AWBW/MapSources/TinyCapture5x5.json
@@ -1,0 +1,134 @@
+{
+  "activePlayer": 0,
+  "cap-limit": 21,
+  "game-over": false,
+  "gameId": "tiny-capture-5x5",
+  "map": [
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 42,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "orange-star",
+          "type": "infantry"
+        }
+      },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 3 }
+    ],
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 38
+      },
+      { "terrain": 1 },
+      { "terrain": 3 },
+      { "terrain": 15 },
+      { "terrain": 1 }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 3 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 3 },
+      { "terrain": 1 }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 3 },
+      { "terrain": 1 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 43
+      }
+    ],
+    [
+      { "terrain": 3 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 47,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "blue-moon",
+          "type": "infantry"
+        }
+      }
+    ]
+  ],
+  "players": [
+    {
+      "armyType": "orange-star",
+      "co": "Andy",
+      "funds": 0,
+      "luck-policy": 1,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 3,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    },
+    {
+      "armyType": "blue-moon",
+      "co": "Adder",
+      "funds": 0,
+      "luck-policy": 2,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 2,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    }
+  ],
+  "turn-count": 1,
+  "unit-cap": 50,
+  "winner": -1
+}

--- a/AdvanceWarsServer/res/AWBW/MapSources/TinySkirmish5x5.json
+++ b/AdvanceWarsServer/res/AWBW/MapSources/TinySkirmish5x5.json
@@ -1,0 +1,150 @@
+{
+  "activePlayer": 0,
+  "cap-limit": 21,
+  "game-over": false,
+  "gameId": "tiny-skirmish-5x5",
+  "map": [
+    [
+      { "terrain": 1 },
+      { "terrain": 3 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 3 },
+      { "terrain": 1 }
+    ],
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 38,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "orange-star",
+          "type": "infantry"
+        }
+      },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 1 }
+    ],
+    [
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "orange-star"
+        },
+        "terrain": 42
+      },
+      {
+        "terrain": 15,
+        "unit": {
+          "ammo": 9,
+          "fuel": 70,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "orange-star",
+          "type": "tank"
+        }
+      },
+      { "terrain": 1 },
+      {
+        "terrain": 15,
+        "unit": {
+          "ammo": 9,
+          "fuel": 70,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "blue-moon",
+          "type": "tank"
+        }
+      },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 47
+      }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 15 },
+      { "terrain": 1 },
+      { "terrain": 15 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "blue-moon"
+        },
+        "terrain": 43,
+        "unit": {
+          "ammo": 0,
+          "fuel": 99,
+          "health": 100,
+          "hidden": false,
+          "moved": false,
+          "owner": "blue-moon",
+          "type": "infantry"
+        }
+      }
+    ],
+    [
+      { "terrain": 1 },
+      { "terrain": 3 },
+      {
+        "property": {
+          "capture-points": 20,
+          "owner": "neutral"
+        },
+        "terrain": 34
+      },
+      { "terrain": 3 },
+      { "terrain": 1 }
+    ]
+  ],
+  "players": [
+    {
+      "armyType": "orange-star",
+      "co": "Andy",
+      "funds": 0,
+      "luck-policy": 1,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 3,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    },
+    {
+      "armyType": "blue-moon",
+      "co": "Adder",
+      "funds": 0,
+      "luck-policy": 2,
+      "power-meter": {
+        "charge": 0,
+        "cop-stars": 2,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0
+    }
+  ],
+  "turn-count": 1,
+  "unit-cap": 50,
+  "winner": -1
+}

--- a/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
+++ b/AdvanceWarsServer/src/SelfPlayReplayTest.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "PolicyValueModel.h"
 #include "SelfPlayReplay.h"
@@ -374,6 +376,66 @@ bool LegacyReplayHeaderCanAppendRolloutDefaults() {
 		Expect(validationSummary.games == 2, "legacy append test should contain two games");
 }
 
+bool CurriculumMapsCanGenerateValidatedReplays() {
+	const std::vector<std::pair<std::string, int>> mapCases{
+		{ "tiny-capture-5x5", 5 },
+		{ "tiny-skirmish-5x5", 5 },
+		{ "small-capture-7x7", 7 },
+		{ "small-production-7x7", 7 },
+	};
+
+	for (std::size_t i = 0; i < mapCases.size(); ++i) {
+		const std::string& mapId = mapCases[i].first;
+		const int expectedSize = mapCases[i].second;
+		const std::filesystem::path replayPath = MakeTempReplayPath("self-play-" + mapId);
+		std::filesystem::remove(replayPath);
+
+		SelfPlayRunnerOptions options;
+		options.outputPath = replayPath;
+		options.mapId = mapId;
+		options.player0CoId = "andy";
+		options.player1CoId = "adder";
+		options.games = 1;
+		options.maxActions = 2;
+		options.baseSeed = static_cast<std::uint32_t>(101 + i);
+		options.mctsOptions.maxSimulations = 1;
+		options.mctsOptions.maxNodes = 32;
+		options.mctsOptions.maxRolloutActions = 4;
+		options.mctsOptions.temperature = 0.0;
+		options.quiet = true;
+
+		SelfPlayRunSummary runSummary;
+		SelfPlayError error;
+		if (!Expect(RunSelfPlay(options, runSummary, error) == Result::Succeeded, "curriculum map should generate replay: " + mapId + " " + error.message)) {
+			std::filesystem::remove(replayPath);
+			return false;
+		}
+
+		SelfPlayReplayValidationSummary validationSummary;
+		if (!Expect(ValidateSelfPlayReplay(replayPath, validationSummary, error) == Result::Succeeded, "curriculum map replay should validate: " + mapId + " " + error.message)) {
+			std::filesystem::remove(replayPath);
+			return false;
+		}
+
+		const json header = ReadJsonLine(replayPath, 1);
+		const json game = ReadJsonLine(replayPath, 2);
+		const json& map = game.at("initialState").at("map");
+		const bool passed =
+			Expect(header.at("config").at("mapId") == mapId, "header should record curriculum map id: " + mapId) &&
+			Expect(game.at("config").at("mapId") == mapId, "game should record curriculum map id: " + mapId) &&
+			Expect(static_cast<int>(map.size()) == expectedSize, "curriculum map should have expected row count: " + mapId) &&
+			Expect(static_cast<int>(map.at(0).size()) == expectedSize, "curriculum map should have expected column count: " + mapId) &&
+			Expect(validationSummary.games == 1, "curriculum map validation should see one game: " + mapId);
+
+		std::filesystem::remove(replayPath);
+		if (!passed) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 bool InvalidSelfPlaySetupReportsError() {
 	SelfPlayRunnerOptions options;
 	options.outputPath = MakeTempReplayPath("self-play-invalid-setup");
@@ -418,6 +480,10 @@ int RunSelfPlayReplayTests() {
 	}
 
 	if (!LegacyReplayHeaderCanAppendRolloutDefaults()) {
+		return 1;
+	}
+
+	if (!CurriculumMapsCanGenerateValidatedReplays()) {
 		return 1;
 	}
 

--- a/AdvanceWarsServer/src/StandardGameSetup.cpp
+++ b/AdvanceWarsServer/src/StandardGameSetup.cpp
@@ -16,9 +16,13 @@ struct MapTemplate {
 	const char* path;
 };
 
-constexpr std::array<MapTemplate, 2> MapTemplates{ {
+constexpr std::array<MapTemplate, 6> MapTemplates{ {
 	{ "lefty", "res/AWBW/MapSources/Lefty.json" },
 	{ "mcts", "res/AWBW/MapSources/MCTS.json" },
+	{ "tiny-capture-5x5", "res/AWBW/MapSources/TinyCapture5x5.json" },
+	{ "tiny-skirmish-5x5", "res/AWBW/MapSources/TinySkirmish5x5.json" },
+	{ "small-capture-7x7", "res/AWBW/MapSources/SmallCapture7x7.json" },
+	{ "small-production-7x7", "res/AWBW/MapSources/SmallProduction7x7.json" },
 } };
 
 void SetError(StandardGameSetupError& error, StandardGameSetupErrorType type, const std::string& code, const std::string& message, json details = json::object()) {

--- a/TRAINING_LOOP_WORK_ITEMS.md
+++ b/TRAINING_LOOP_WORK_ITEMS.md
@@ -16,7 +16,7 @@ The rules/API completeness target for the initial playable environment is normal
 - [x] Decide whether v1 targets full AWBW fidelity or a simplified deterministic subset. V1 targets normal Global League Standard play, with other modes explicitly deferred in `STANDARD_ENGINE_COMPLETENESS.md`.
 - [x] Decide how combat luck should work during self-play. V1 uses seeded deterministic combat RNG derived from the self-play setup seed; averaged or disabled luck can remain a later experiment if training quality needs it.
 - [x] Decide whether v1 includes fog, hidden units, CO powers, transports, naval units, and all unit types. V1 targets normal Global League Standard: fog disabled, CO powers enabled, transports/naval units in scope, and Standard unit bans/settings enforced through setup.
-- [x] Decide the first map set for self-play. The bootstrap runner/API map catalog currently supports `lefty` and `mcts`; broader map pools and side balancing are tracked by #173.
+- [x] Decide the first map set for self-play. The bootstrap runner/API map catalog currently supports `tiny-capture-5x5`, `tiny-skirmish-5x5`, `small-capture-7x7`, `small-production-7x7`, `mcts`, and `lefty`; broader map pools and side balancing are tracked by #173.
 - [x] Decide whether training should run inside the C++ executable only, or whether C++ should expose an environment API for a Python training process. V1 training stays inside the C++ executable with LibTorch; a Python environment API is deferred unless replay-driven C++ training becomes the bottleneck.
 
 ## Phase 0: Stabilize The Simulator

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,7 +54,7 @@ Resolved default settings:
 }
 ```
 
-Supported v1 map ids are `lefty` and `mcts`.
+Supported v1 map ids are `tiny-capture-5x5`, `tiny-skirmish-5x5`, `small-capture-7x7`, `small-production-7x7`, `mcts`, and `lefty`.
 
 ## Responses
 

--- a/docs/SELF_PLAY_REPLAYS.md
+++ b/docs/SELF_PLAY_REPLAYS.md
@@ -54,9 +54,20 @@ Required:
 | Option | Meaning |
 | --- | --- |
 | `--out <path>` | Output JSONL shard. Missing parent directories are created. |
-| `--map <id>` | Supported Standard map id, currently `lefty` or `mcts`. |
+| `--map <id>` | Supported Standard map id. |
 | `--player0-co <id>` | Player 0 CO id in API style, such as `andy` or `von-bolt`. |
 | `--player1-co <id>` | Player 1 CO id in API style. |
+
+Supported map ids:
+
+| Map id | Size | Training intent |
+| --- | ---: | --- |
+| `tiny-capture-5x5` | 5x5 | Stage 1 infantry capture and HQ race. |
+| `tiny-skirmish-5x5` | 5x5 | Stage 1 direct combat, rout pressure, and HQ threats. |
+| `small-capture-7x7` | 7x7 | Stage 1/2 capture expansion with more neutral properties. |
+| `small-production-7x7` | 7x7 | Stage 2 base production plus nearby capture choices. |
+| `mcts` | 5x5 | Legacy deterministic MCTS smoke map. |
+| `lefty` | full | Full Standard GL target map. |
 
 Common optional settings:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,7 +24,9 @@ yarn dev
 
 Open <http://127.0.0.1:5173/>. The Vite dev server is bound to `127.0.0.1` by default for local-only access.
 
-The app opens on a board viewer, not a landing page. It can load the bundled Lefty board sample, a small legal-action sample, pasted JSON, or a state created by the current C++ server.
+The app opens on a board viewer, not a landing page. It can load the bundled Lefty board sample, a small legal-action sample, pasted JSON, a local `.json`/`.jsonl` file, or a state created by the current C++ server.
+
+Use **Open file** to inspect a local serialized `GameState`, a JSON fixture with `initial-game-state`, map templates such as `AdvanceWarsServer/res/AWBW/MapSources/TinyCapture5x5.json`, or the initial state from a self-play replay `.jsonl` shard.
 
 ## Server Source
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { BoardCanvas } from "./components/BoardCanvas";
 import { actionHighlightsForSource } from "./rendering/actions";
 import { actionToSubmitFromBoardTarget, actionsVisibleInInspector, buyMenuItems, globalActionsFromLegalActions, labelForAction } from "./gameState/actionDisplay";
 import { coordinateKey, parseGameStatePayload, type Action, legalActionEnvelopeSchema, type Coordinate, type GameState, type ValidActionGroup } from "./gameState/schema";
+import { parseGameStateFileText } from "./gameState/filePayload";
 import { normalizeServerBaseUrl, serverApiUrl } from "./api/url";
 import { terrainDisplayName } from "./rendering/terrain";
 import { unitAssetPath, unitFallbackLabel } from "./rendering/unitAssets";
@@ -12,7 +13,7 @@ const defaultServerBaseUrl = "http://localhost:80";
 const storageKey = "advance-wars-server-base-url";
 const maxPastedJsonCharacters = 2_000_000;
 
-type LoadSource = "sample" | "server" | "pasted";
+type LoadSource = "sample" | "server" | "pasted" | "file";
 
 type LoadedState = {
   gameState: GameState;
@@ -101,6 +102,7 @@ export default function App() {
   const [zoom, setZoom] = useState(2.4);
   const [inspectedCoordinate, setInspectedCoordinate] = useState<Coordinate | undefined>();
   const [inspectedActions, setInspectedActions] = useState<Action[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const loadRequestId = useRef(0);
   const actionRequestId = useRef(0);
   const [toggles, setToggles] = useState<Toggles>({
@@ -213,6 +215,41 @@ export default function App() {
       setInspectedActions([]);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to parse pasted JSON");
+    }
+  }
+
+  async function loadLocalFile(event: ChangeEvent<HTMLInputElement>) {
+    const input = event.currentTarget;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const requestId = loadRequestId.current + 1;
+    loadRequestId.current = requestId;
+    setIsLoading(true);
+    setError(undefined);
+    try {
+      const parsed = parseGameStateFileText(await file.text(), file.name);
+      if (loadRequestId.current !== requestId) {
+        return;
+      }
+
+      actionRequestId.current += 1;
+      setLoaded({ ...parsed, globalActions: [], source: "file", label: file.name });
+      setSelected(undefined);
+      setInspectedCoordinate(undefined);
+      setSelectedActions([]);
+      setInspectedActions([]);
+    } catch (err) {
+      if (loadRequestId.current === requestId) {
+        setError(err instanceof Error ? err.message : "Unable to load selected file");
+      }
+    } finally {
+      input.value = "";
+      if (loadRequestId.current === requestId) {
+        setIsLoading(false);
+      }
     }
   }
 
@@ -358,6 +395,18 @@ export default function App() {
         <button type="button" onClick={() => loadPayload("/samples/grit-indirect-range-valid-actions.json", "Grit action sample")}>
           Action sample
         </button>
+        <button type="button" onClick={() => fileInputRef.current?.click()}>
+          Open file
+        </button>
+        <input
+          ref={fileInputRef}
+          className="file-input"
+          type="file"
+          accept=".json,.jsonl,application/json,application/x-ndjson"
+          tabIndex={-1}
+          aria-hidden="true"
+          onChange={loadLocalFile}
+        />
         <button type="button" onClick={createServerGame}>
           Server game
         </button>

--- a/frontend/src/gameState/filePayload.test.ts
+++ b/frontend/src/gameState/filePayload.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { parseGameStateFileText } from "./filePayload";
+
+const gameState = {
+  activePlayer: 0,
+  "cap-limit": 21,
+  "game-over": false,
+  gameId: "sample",
+  map: [
+    [
+      {
+        terrain: 15,
+        property: {
+          "capture-points": 20,
+          owner: "orange-star"
+        }
+      }
+    ]
+  ],
+  players: [
+    {
+      armyType: "orange-star",
+      co: "Andy",
+      funds: 1000,
+      "power-meter": {
+        charge: 0,
+        "cop-stars": 3,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0,
+      "luck-policy": 1
+    },
+    {
+      armyType: "blue-moon",
+      co: "Adder",
+      funds: 0,
+      "power-meter": {
+        charge: 0,
+        "cop-stars": 2,
+        "scop-stars": 3,
+        "star-value": 9000
+      },
+      "power-status": 0,
+      "luck-policy": 2
+    }
+  ],
+  "turn-count": 1,
+  "unit-cap": 50,
+  winner: -1
+};
+
+describe("parseGameStateFileText", () => {
+  it("parses a local GameState JSON file", () => {
+    const parsed = parseGameStateFileText(JSON.stringify(gameState), "TinyCapture5x5.json");
+
+    expect(parsed.gameState.gameId).toBe("sample");
+    expect(parsed.legalActionGroups).toEqual([]);
+  });
+
+  it("parses a fixture JSON file and preserves legal action groups", () => {
+    const parsed = parseGameStateFileText(
+      JSON.stringify({
+        "initial-game-state": gameState,
+        validActions: [
+          {
+            source: [0, 0],
+            expected: [{ type: "wait", source: [0, 0], target: [0, 0] }]
+          }
+        ]
+      }),
+      "fixture.json"
+    );
+
+    expect(parsed.gameState.gameId).toBe("sample");
+    expect(parsed.legalActionGroups).toHaveLength(1);
+  });
+
+  it("parses the first game record from a replay JSONL file", () => {
+    const replayText = [
+      JSON.stringify({ recordType: "header", replayFormatVersion: 1 }),
+      JSON.stringify({ recordType: "game", initialState: gameState, finalState: { ...gameState, gameId: "final" } })
+    ].join("\n");
+
+    const parsed = parseGameStateFileText(replayText, "shard.jsonl");
+
+    expect(parsed.gameState.gameId).toBe("sample");
+  });
+
+  it("reports invalid JSON with the selected file name", () => {
+    expect(() => parseGameStateFileText("{", "bad.json")).toThrow(/bad\.json/);
+  });
+
+  it("rejects replay JSONL files without a game record", () => {
+    expect(() => parseGameStateFileText(JSON.stringify({ recordType: "header" }), "empty.jsonl")).toThrow(/game record/);
+  });
+});

--- a/frontend/src/gameState/filePayload.ts
+++ b/frontend/src/gameState/filePayload.ts
@@ -1,0 +1,68 @@
+import { parseGameStatePayload, type ParsedGameStatePayload } from "./schema";
+
+function selectedFileLabel(fileName: string): string {
+  return fileName.trim() || "selected file";
+}
+
+function parseJson(text: string, fileName: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : "invalid JSON";
+    throw new Error(`Unable to parse ${selectedFileLabel(fileName)}: ${detail}`);
+  }
+}
+
+function parseJsonLine(line: string, lineNumber: number, fileName: string): unknown {
+  try {
+    return JSON.parse(line);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : "invalid JSON";
+    throw new Error(`Unable to parse ${selectedFileLabel(fileName)} line ${lineNumber}: ${detail}`);
+  }
+}
+
+function isReplayGameRecord(payload: unknown): payload is { initialState: unknown } {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "recordType" in payload &&
+    payload.recordType === "game" &&
+    "initialState" in payload
+  );
+}
+
+function parseReplayJsonl(text: string, fileName: string): ParsedGameStatePayload {
+  const lines = text.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (line.length === 0) {
+      continue;
+    }
+
+    const payload = parseJsonLine(line, index + 1, fileName);
+    if (isReplayGameRecord(payload)) {
+      return parseGameStatePayload(payload.initialState);
+    }
+  }
+
+  throw new Error(`${selectedFileLabel(fileName)} does not contain a replay game record`);
+}
+
+export function parseGameStateFileText(text: string, fileName = "selected file"): ParsedGameStatePayload {
+  if (text.trim().length === 0) {
+    throw new Error(`${selectedFileLabel(fileName)} is empty`);
+  }
+
+  if (fileName.toLowerCase().endsWith(".jsonl")) {
+    return parseReplayJsonl(text, fileName);
+  }
+
+  const payload = parseJson(text, fileName);
+  if (isReplayGameRecord(payload)) {
+    return parseGameStatePayload(payload.initialState);
+  }
+
+  return parseGameStatePayload(payload);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -92,6 +92,15 @@ input {
   font-weight: 700;
 }
 
+.file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
 .server-url input {
   width: min(280px, 50vw);
 }


### PR DESCRIPTION
## Summary

- Add four small AWBW map templates for staged self-play curriculum work: two 5x5 tactical maps and two 7x7 capture/production maps.
- Register the new map ids in the Standard game setup catalog and document them for API/self-play use.
- Add replay-writer coverage proving the curriculum maps can generate validated replay shards.
- Add an `Open file` control to the React board viewer for local `.json` game states/fixtures and `.jsonl` replay shards.

## Validation

- `yarn test`
- `yarn typecheck`
- `git diff --check`
- `..\x64\Release\AdvanceWarsServer.exe -test-replay`
- `..\x64\Release\AdvanceWarsServer.exe -test-api-contract`
- `..\x64\Release\AdvanceWarsServer.exe -test-model --device cuda`

Note: the Release C++ checks were run from `AdvanceWarsServer\` so map resource paths resolve correctly.